### PR TITLE
Fix problem that API DataSetDelete and DataSetDataDelete always result i...

### DIFF
--- a/lib/service/rest.class.php
+++ b/lib/service/rest.class.php
@@ -1308,7 +1308,7 @@ class Rest
         $dataSetId = $this->GetParam('dataSetId', _INT);
 
         $auth = $this->user->DataSetAuth($dataSetId, true);
-        if (!$auth->delete)
+        if (!$auth->del)
             return $this->Error(1, 'Access Denied');
 
         Kit::ClassLoader('dataset');
@@ -1523,7 +1523,7 @@ class Rest
         $dataSetId = $this->GetParam('dataSetId', _INT);
 
         $auth = $this->user->DataSetAuth($dataSetId, true);
-        if (!$auth->delete)
+        if (!$auth->del)
             return $this->Error(1, 'Access Denied');
 
         // Parameters


### PR DESCRIPTION
...n failure.

These two API calls fails like this log.
`<errormsg>Undefined property: PermissionManager::$delete</errormsg>`
`<errornum>8</errornum>`
`<errortype>Notice</errortype>`
`<scriptname>/home/tkimuranet/xibo-cms/lib/service/rest.class.php</scriptname>`
`<scriptlinenum>1526</scriptlinenum>`

API module referes PermissionManager's undefined property 'delete'.
Change 'delete' to 'del'.