### PR TITLE
Fix SQL query

### DIFF
--- a/modules/module_user_general.php
+++ b/modules/module_user_general.php
@@ -583,7 +583,8 @@ class User {
         $SQL .= "         menuitem.Text , ";
         $SQL .= "         menuitem.Class, ";
         $SQL .= "         menuitem.Img, ";
-        $SQL .= "         menuitem.External ";
+        $SQL .= "         menuitem.External, ";
+        $SQL .= "         menuitem.Sequence ";
         $SQL .= "FROM     menuitem ";
         $SQL .= "         INNER JOIN menu ";
         $SQL .= "         ON       menuitem.MenuID = menu.MenuID ";


### PR DESCRIPTION
The menuitem.Sequence was missing in the Select statement, while being used in the Order By statement.
See problem and solution log here:
https://community.xibo.org.uk/t/admin-panel-does-not-show-navigation-bar/4601/9