### PR TITLE
Detect image format, convert to preferred format if necessary and pos…

### DIFF
--- a/lib/Xmds/Soap4.php
+++ b/lib/Xmds/Soap4.php
@@ -432,6 +432,11 @@ class Soap4 extends Soap
         $serverKey = Sanitize::string($serverKey);
         $hardwareKey = Sanitize::string($hardwareKey);
 
+        $screenShotFmt = "jpg";
+        $screenShotMime = "image/jpeg";
+        $converted = false;
+        $needConversion = false;
+
         // Check the serverKey matches
         if ($serverKey != Config::GetSetting('SERVER_KEY'))
             throw new \SoapFault('Sender', 'The Server key you entered does not match with the server key at this address');
@@ -449,7 +454,45 @@ class Soap4 extends Soap
 
         // Open this displays screen shot file and save this.
         Library::ensureLibraryExists();
-        $location = Config::GetSetting('LIBRARY_LOCATION') . 'screenshots/' . $this->display->displayId . '_screenshot.jpg';
+        $location = Config::GetSetting('LIBRARY_LOCATION') . 'screenshots/' . $this->display->displayId . '_screenshot.' . $screenShotFmt;
+
+        // Try gd first, check image format against $screenShotMime.
+        // TODO: consider using exif extension, if it's more/equals common to gd, eg. available for most PHP installation.
+        if (extension_loaded('gd')) {
+            $fmtSupported = getimagesizefromstring($screenShot);
+            if($fmtSupported !== FALSE) {
+                if($screenShotMime != $fmtSupported['mime']) {
+                    $needConversion = true;
+                }
+            } else {
+                $needConversion = true;
+            }
+        }
+
+        // Try imagick for conversion to $screenShotFmt
+        if (extension_loaded('imagick')) {
+            $shotImg = new \Imagick();
+            $shotImg->readImageBlob($screenShot);
+            if($screenShotFmt != strtolower($shotImg->getImageFormat())) {
+                $needConversion = true;
+                try {
+                    if($shotImg->setImageFormat($screenShotFmt)) {
+                        $screenShot = $shotImg->getImageBlob();
+                        $converted = true;
+                    }
+                } catch (\Exception $ex) {}
+            }
+        }
+
+        // return early with false, keep screenShotRequested intact, let the Player retry.
+        if($needConversion && !$converted) {
+            $this->LogBandwidth($this->display->displayId, Bandwidth::$SCREENSHOT, filesize($location));
+
+            return false;
+        }
+
+
+
         $fp = fopen($location, 'wb');
         fwrite($fp, $screenShot);
         fclose($fp);


### PR DESCRIPTION
Detect image format, convert to preferred format if necessary and possible.

Check the image format from data submitted by a Player and do conversion if
the incoming format is different with preferred format, provided that the php
extension, imagick in this case, is available and enabled, and supports conversion
from the detected format to preferred one.

On successful conversion, the `$screenShot` variable will contain the converted
binary data.
On failure conversion and when the incoming format != preferred format,
the method returns `false`.

On detection failure and conversion failure, the method flow doesn't change.
