### PR TITLE
Detect image format, convert to preferred format if necessary and possible.

### DIFF
--- a/lib/Xmds/Soap4.php
+++ b/lib/Xmds/Soap4.php
@@ -466,10 +466,12 @@ class Soap4 extends Soap
                 $screenShotImg = Img::make($screenShot);
             } catch (\Exception $e) {
                 if ($this->display->isAuditing == 1)
-                    Log::debug($e->getMessage());
+                    Log::debug($imgDriver . " - " . $e->getMessage());
             }
-            if($screenShotImg !== false)
+            if($screenShotImg !== false) {
+                Log::debug("Use " . $imgDriver);
                 break;
+            }
         }
 
         if($screenShotImg !== false) {

--- a/lib/Xmds/Soap4.php
+++ b/lib/Xmds/Soap4.php
@@ -459,13 +459,17 @@ class Soap4 extends Soap
         Library::ensureLibraryExists();
         $location = Config::GetSetting('LIBRARY_LOCATION') . 'screenshots/' . $this->display->displayId . '_screenshot.' . $screenShotFmt;
 
-        Img::configure(array('driver' => array('gd', 'imagick')));
-
-        try {
-            $screenShotImg = Img::make($screenShot);
-        } catch (\Exception $e) {
-            if ($this->display->isAuditing == 1)
-                Log::debug($e->getMessage());
+        //Img::configure(array('driver' => array('gd', 'imagick')));
+        foreach(array('gd', 'imagick') as $imgDriver) {
+            Img::configure(array('driver' => $imgDriver));
+            try {
+                $screenShotImg = Img::make($screenShot);
+            } catch (\Exception $e) {
+                if ($this->display->isAuditing == 1)
+                    Log::debug($e->getMessage());
+            }
+            if($screenShotImg !== false)
+                break;
         }
 
         if($screenShotImg !== false) {

--- a/lib/Xmds/Soap4.php
+++ b/lib/Xmds/Soap4.php
@@ -459,8 +459,7 @@ class Soap4 extends Soap
         Library::ensureLibraryExists();
         $location = Config::GetSetting('LIBRARY_LOCATION') . 'screenshots/' . $this->display->displayId . '_screenshot.' . $screenShotFmt;
 
-        //Img::configure(array('driver' => array('gd', 'imagick')));
-        foreach(array('gd', 'imagick') as $imgDriver) {
+        foreach(array('imagick', 'gd') as $imgDriver) {
             Img::configure(array('driver' => $imgDriver));
             try {
                 $screenShotImg = Img::make($screenShot);
@@ -469,15 +468,20 @@ class Soap4 extends Soap
                     Log::debug($imgDriver . " - " . $e->getMessage());
             }
             if($screenShotImg !== false) {
-                Log::debug("Use " . $imgDriver);
+                if ($this->display->isAuditing == 1)
+                    Log::debug("Use " . $imgDriver);
                 break;
             }
         }
 
         if($screenShotImg !== false) {
-            if($screenShotImg->mime() != $screenShotMime) {
+            $imgMime = $screenShotImg->mime(); 
+
+            if($imgMime != $screenShotMime) {
                 $needConversion = true;
                 try {
+                    if ($this->display->isAuditing == 1)
+                        Log::debug("converting: '" . $imgMime . "' to '" . $screenShotMime . "'");
                     $screenShot = (string) $screenShotImg->encode($screenShotFmt);
                     $converted = true;
                 } catch (\Exception $e) {


### PR DESCRIPTION
Please ignore the [previous](https://github.com/xibosignage/xibo-cms/pull/131) PR.

Detect image format, convert to preferred format if necessary and possible.

Check the image format from data submitted by a Player and do conversion if
the incoming format is different with preferred format, provided that the php
extension, imagick in this case, is available and enabled, and supports conversion
from the detected format to preferred one.

On successful conversion, the `$screenShot` variable will contain the converted
binary data.
On failure conversion and when the incoming format != preferred format,
the method returns `false`.

On detection failure and conversion failure, the method flow doesn't change.

xibosignage/xibo#689