### PR TITLE
Fix hidden region add button

### DIFF
--- a/views/layout-designer-page.twig
+++ b/views/layout-designer-page.twig
@@ -64,7 +64,7 @@
                                         <a class="XiboFormButton btn btn-default btn-sm" role="button" href="{{ urlFor("layout.edit.form", {id: layout.layoutId}) }}" title="{% trans "Edit the Layout Properties" %}"><span><i class="fa fa-picture-o" aria-hidden="true"></i> {% trans "Background" %}</span></a>
                                     </div>
                                     <div class="btn-group" role="group">
-                                        <a class="btn btn-info btn-sm hidden-md" id="regionAddButton" role="button" href="{{ urlFor("region.add", {id: layout.layoutId}) }}"><span><i class="fa fa-plus" aria-hidden="true"></i> {% trans "Region" %}</span></a>
+                                        <a class="btn btn-info btn-sm" id="regionAddButton" role="button" href="{{ urlFor("region.add", {id: layout.layoutId}) }}"><span><i class="fa fa-plus" aria-hidden="true"></i> {% trans "Region" %}</span></a>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
I don't know why this button had a hidden-md class added, but it makes it impossible (even as a superuser) to add more regions to a layout.