### PR TITLE
Fix this function on a page without table

### DIFF
--- a/web/theme/default/js/xibo-forms.js
+++ b/web/theme/default/js/xibo-forms.js
@@ -476,8 +476,9 @@ var backGroundFormSetup = function(dialog) {
                         if (backgroundChanged)
                             window.location.reload();
                     } else {
-                        // On the layout page - call render
-                        if (backgroundChanged && table != undefined)
+                        // We assume we're on the layout page - call render
+                        // If we're not, table is a Chrome/Safari/FireBug global function
+                        if (backgroundChanged && typeof(table) !== 'undefined' && table.hasOwnProperty('ajax'))
                             table.ajax.reload(null, false);
                     }
                 }


### PR DESCRIPTION
If we use this function on a page that does not have a global variable named table a bug happens. We cannot test simply to see if the table variable exists because table exists as a built-in function in modern browsers (console.table is aliased to table).

I've tested the "if (backgroundChanges && table)" construction which due to it existing causes weirdness. This is the only way to test if table actually exists.