### PR TITLE
Fix object.zIndex is not a function error

### DIFF
--- a/web/theme/default/js/xibo-layout-designer.js
+++ b/web/theme/default/js/xibo-layout-designer.js
@@ -60,7 +60,8 @@ $(document).ready(function(){
         .hover(function() {
             var $region = $(this);
 
-            $region.zIndex(900);
+            //This brings the region forward if it's hovered over
+            $region.css("zIndex", 900);
 
             if (!hideControls) {
                 layout.find(".regionInfo").show();
@@ -72,7 +73,7 @@ $(document).ready(function(){
                 var $resetRegion = $(this);
 
                 // Reset to the original z-index
-                $resetRegion.zIndex($resetRegion.attr("zindex"));
+                $resetRegion.css("zIndex", $resetRegion.attr("zindex"));
             });
 
             layout.find(".regionInfo").hide();


### PR DESCRIPTION
zIndex is not actually a function in newer versions of jQuery UI
https://jqueryui.com/upgrade-guide/1.12/#removed-zindex