### PR TITLE
Take advantage of "php-saml" toolkit

### DIFF
--- a/lib/Helper/Install.php
+++ b/lib/Helper/Install.php
@@ -264,6 +264,10 @@ define('SECRET_KEY', '$secretKey');
 // \$middleware = [];
 // \$authentication = ;
 
+// \$authentication = new \Xibo\Middleware\SAMLAuthentication();
+// \$samlFile = realpath(dirname(__FILE__) . '/samlSettings.php');
+// require_once $samlFile;
+
 END;
 
         if (!fwrite($fh, $settings))

--- a/web/_toolkit_loader.php
+++ b/web/_toolkit_loader.php
@@ -1,0 +1,23 @@
+<?php
+
+// Create an __autoload function 
+// (can conflicts other autoloaders)
+// http://php.net/manual/en/language.oop5.autoload.php
+$libDir = realpath(dirname(__FILE__) . '/../vendor/onelogin/php-saml/lib/Saml2/'). '/';
+$extlibDir = realpath(dirname(__FILE__) . '/../vendor/onelogin/php-saml/extlib/'). '/';
+
+// Load composer
+if (file_exists('vendor/autoload.php')) {
+    require 'vendor/autoload.php';
+}
+
+// Load now external libs
+require_once $extlibDir . 'xmlseclibs/xmlseclibs.php';
+
+$folderInfo = scandir($libDir);
+
+foreach ($folderInfo as $element) {
+    if (is_file($libDir.$element) && (substr($element, -4) === '.php')) {
+        include_once $libDir.$element;
+    }
+}

--- a/web/samlSettings.php
+++ b/web/samlSettings.php
@@ -1,0 +1,73 @@
+<?php
+// Example file for use SAML
+//
+// Make sure to add those lines into settings.php:
+// $authentication = new \Xibo\Middleware\SAMLAuthentication();
+// $samlFile = realpath(dirname(__FILE__) . '/samlSettings.php');
+// require_once $samlFile;
+
+$samlSettings = array (
+   'workflow' => array(
+        // Enable/Disable Just-In-Time provisioning
+        'jit' => true,
+        // Attribute to identify the user 
+        'field_to_identify' => 'UserName',   // Alternatives: UserID, UserName or email
+        // Default libraryQuota assigned to the created user by JIT
+        'libraryQuota' => 1000,
+        // Initial User Group
+        'group' => 'Users',
+        // Home Page
+        'homePage' => 'dashboard',
+        // Enable/Disable Single Logout
+        'slo' => true,
+        // Attribute mapping between XIBO-CMS and the IdP
+        'mapping' => array (
+            'UserID' => '',
+            'usertypeid' => '',
+            'UserName' => 'uid',
+            'email' => 'mail',
+            'ref1' => '',
+            'ref2' => '',
+            'ref3' => '',
+            'ref4' => '',
+            'ref5' => ''
+        )
+    ),
+   // Settings for the PHP-SAML toolkit. 
+   // See documentation: https://github.com/onelogin/php-saml#settings 
+   'strict' => false,
+   'debug' => true,
+   'idp' => array (
+            'entityId' => 'https://idp.example.com/simplesaml/saml2/idp/metadata.php',
+            'singleSignOnService' => array (
+                'url' => 'http://idp.example.com/simplesaml/saml2/idp/SSOService.php',
+            ),
+            'singleLogoutService' => array (
+                'url' => 'http://idp.example.com/simplesaml/saml2/idp/SingleLogoutService.php',
+            ),
+            'x509cert' => 'MIICbDCCAdWgAwIBAgIBADANBgkqhkiG9w0BAQ0FADBTMQswCQYDVQQGEwJ1czETMBEGA1UECAwKQ2FsaWZvcm5pYTEVMBMGA1UECgwMT25lbG9naW4gSW5jMRgwFgYDVQQDDA9pZHAuZXhhbXBsZS5jb20wHhcNMTQwOTIzMTIyNDA4WhcNNDIwMjA4MTIyNDA4WjBTMQswCQYDVQQGEwJ1czETMBEGA1UECAwKQ2FsaWZvcm5pYTEVMBMGA1UECgwMT25lbG9naW4gSW5jMRgwFgYDVQQDDA9pZHAuZXhhbXBsZS5jb20wgZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAOWA+YHU7cvPOrBOfxCscsYTJB+kH3MaA9BFrSHFS+KcR6cw7oPSktIJxUgvDpQbtfNcOkE/tuOPBDoech7AXfvH6d7Bw7xtW8PPJ2mB5Hn/HGW2roYhxmfh3tR5SdwN6i4ERVF8eLkvwCHsNQyK2Ref0DAJvpBNZMHCpS24916/AgMBAAGjUDBOMB0GA1UdDgQWBBQ77/qVeiigfhYDITplCNtJKZTM8DAfBgNVHSMEGDAWgBQ77/qVeiigfhYDITplCNtJKZTM8DAMBgNVHRMEBTADAQH/MA0GCSqGSIb3DQEBDQUAA4GBAJO2j/1uO80E5C2PM6Fk9mzerrbkxl7AZ/mvlbOn+sNZE+VZ1AntYuG8ekbJpJtG1YfRfc7EA9mEtqvv4dhv7zBy4nK49OR+KpIBjItWB5kYvrqMLKBa32sMbgqqUqeF1ENXKjpvLSuPdfGJZA3dNa/+Dyb8GGqWe707zLyc5F8m',
+        ),
+   'sp' => array (
+        'entityId' => 'http://xibo-cms.example.com/saml/metadata',
+        'assertionConsumerService' => array (
+            'url' => 'http://xibo-cms.example.com/saml/acs',
+        ),
+        'singleLogoutService' => array (
+            'url' => 'http://xibo-cms.example.com/saml/sls',
+        ),
+        'NameIDFormat' => 'urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress',
+        'x509cert' => '',
+        'privateKey' > '',
+    ),
+    'security' => array (
+        'nameIdEncrypted' => false,
+        'authnRequestsSigned' => false,
+        'logoutRequestSigned' => false,
+        'logoutResponseSigned' => false,
+        'signMetadata' => false,
+        'wantMessagesSigned' => false,
+        'wantAssertionsSigned' => false,
+        'wantAssertionsEncrypted' => false,
+        'wantNameIdEncrypted' => false,
+    )
+);

--- a/web/samltools/metadata.php
+++ b/web/samltools/metadata.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ *  SAML Metadata view
+ */
+require_once dirname(__DIR__).'/_toolkit_loader.php';
+require_once dirname(__DIR__).'/samlSettings.php';
+try {
+    #$auth = new OneLogin_Saml2_Auth($settingsInfo);
+    #$settings = $auth->getSettings();
+    // Now we only validate SP settings
+    $settings = new OneLogin_Saml2_Settings($samlSettings, true);
+    $metadata = $settings->getSPMetadata();
+    $errors = $settings->validateMetadata($metadata);
+    if (empty($errors)) {
+        header('Content-Type: text/xml');
+        echo $metadata;
+    } else {
+        throw new OneLogin_Saml2_Error(
+            'Invalid SP metadata: '.implode(', ', $errors),
+            OneLogin_Saml2_Error::METADATA_SP_INVALID
+        );
+    }
+} catch (Exception $e) {
+    echo $e->getMessage();
+}


### PR DESCRIPTION
php-saml provide metadata.php to extract and validate the SP and IDP data provided by the array. To make this cleaner I recommend to not use the current settings.php file to add SAML data. I've created a samlSettings.php to hold the array. Also created the folder samltools to host SAML tools useful for the integration. 

metadata.php takes the array parse it and display a xml that you can sent to your 3:rd party federation (IDP).

I have not tested the full work-flow using SAML because I needed to get hold of the metadata first and then I have ~3weeks for approval.

 