### PR TITLE
Session.php fix remoteaddr from Proxy

### DIFF
--- a/lib/Helper/Session.php
+++ b/lib/Helper/Session.php
@@ -421,7 +421,7 @@ class Session implements \SessionHandlerInterface
             'userId' => $this->userId,
             'expired' => ($this->expired) ? 1 : 0,
             'useragent' => substr($_SERVER['HTTP_USER_AGENT'], 0, 253),
-            'remoteaddr' => $_SERVER['REMOTE_ADDR']
+            'remoteaddr' => $this->getIp()
         ];
 
         $this->getDb()->update($sql, $params);
@@ -458,5 +458,22 @@ class Session implements \SessionHandlerInterface
         ];
 
         $this->getDb()->update($sql, $params);
+    }
+    
+    /**
+     * Get the Client IP Address
+     * @return string
+     */
+    private function getIp()
+    {
+        $clientIp = '';
+        $keys = array('X_FORWARDED_FOR', 'HTTP_X_FORWARDED_FOR', 'CLIENT_IP', 'REMOTE_ADDR');
+        foreach ($keys as $key) {
+            if (isset($_SERVER[$key])) {
+                $clientIp = $_SERVER[$key];
+                break;
+            }
+        }
+        return $clientIp;
     }
 }


### PR DESCRIPTION
Session information was displaying the proxy server's IP address instead of client address. I found this issue - https://github.com/xibosignage/xibo/issues/606 - and it seems like it was fixed when referencing display IP addresses but not session, so I added the same function found in https://github.com/xibosignage/xibo-cms/blob/500f3e16fa525c7428a3bc1f98383a0bde6697d0/lib/Xmds/Soap.php#L1735-L1748