### PR TITLE
Dockerfiles: Remove Unneeded mkdir

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -127,8 +127,7 @@ EXPOSE 80
 # Map the source files into /var/www/cms
 # Create library and cache, because they might not exist
 # Create /var/www/backup so that we have somewhere for entrypoint to log errors.
-RUN mkdir -p /var/www/cms && \
-    mkdir -p /var/www/cms/library/temp && \
+RUN mkdir -p /var/www/cms/library/temp && \
     mkdir -p /var/www/cms/cache && \
     mkdir -p /var/www/backup
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -98,8 +98,7 @@ EXPOSE 80
 # Map the source files into /var/www/cms
 # Create library and cache, because they might not exist
 # Create /var/www/backup so that we have somewhere for entrypoint to log errors.
-RUN mkdir -p /var/www/cms && \
-    mkdir -p /var/www/cms/library/temp && \
+RUN mkdir -p /var/www/cms/library/temp && \
     mkdir -p /var/www/cms/cache && \
     mkdir -p /var/www/backup
 


### PR DESCRIPTION
The directory will be created when any of the other `mkdir` commands are called since  `-p` flag is used.