### PR TITLE
RemoteDatasets always truncates

### DIFF
--- a/lib/Entity/DataSet.php
+++ b/lib/Entity/DataSet.php
@@ -573,7 +573,7 @@ class DataSet implements \JsonSerializable
      */
     public function isTruncateEnabled()
     {
-        return $this->clearRate !== 0;
+        return intval($this->clearRate) !== 0;
     }
 
     /**


### PR DESCRIPTION
RemoteDatasets has been cleared all the time because the clearRate Property is a string and not an int