### PR TITLE
New feature: Allow using CAS for the authentication of users.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,8 @@
     "ralouphie/mimey": "^1.0",
     "robmorgan/phinx": "^0.9.2",
     "johngrogg/ics-parser": "^2.1",
-    "phpseclib/mcrypt_compat": "^1.0"
+    "phpseclib/mcrypt_compat": "^1.0",
+    "apereo/phpcas": "^1.3"
   },
   "require-dev": {
     "phpunit/phpunit": "^5",

--- a/composer.lock
+++ b/composer.lock
@@ -104,6 +104,61 @@
             "time": "2015-01-07T09:54:54+00:00"
         },
         {
+            "name": "apereo/phpcas",
+            "version": "1.3.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/apereo/phpCAS.git",
+                "reference": "7972833e84f6ee5fa41f1479eab5d855109627f5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/apereo/phpCAS/zipball/7972833e84f6ee5fa41f1479eab5d855109627f5",
+                "reference": "7972833e84f6ee5fa41f1479eab5d855109627f5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~3.7.10"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "source/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Joachim Fritschi",
+                    "homepage": "https://wiki.jasig.org/display/~fritschi"
+                },
+                {
+                    "name": "Adam Franco",
+                    "homepage": "https://wiki.jasig.org/display/~adamfranco"
+                }
+            ],
+            "description": "Provides a simple API for authenticating users against a CAS server",
+            "homepage": "https://wiki.jasig.org/display/CASC/phpCAS",
+            "keywords": [
+                "apereo",
+                "cas",
+                "jasig"
+            ],
+            "time": "2018-10-25T20:22:09+00:00"
+        },
+        {
             "name": "doctrine/inflector",
             "version": "v1.2.0",
             "source": {

--- a/lib/Controller/Login.php
+++ b/lib/Controller/Login.php
@@ -150,11 +150,13 @@ class Login extends Base
         // Check to see if the password reminder functionality is enabled.
         $passwordReminderEnabled = $this->getConfig()->getSetting('PASSWORD_REMINDER_ENABLED');
         $mailFrom = $this->getConfig()->getSetting('mail_from');
+        $authCASEnabled = isset($this->app->configService->casSettings);
 
         // Template
         $this->getState()->template = 'login';
         $this->getState()->setData([
             'passwordReminderEnabled' => (($passwordReminderEnabled === 'On' || $passwordReminderEnabled === 'On except Admin') && $mailFrom != ''),
+            'authCASEnabled' => $authCASEnabled,
             'version' => Environment::$WEBSITE_VERSION_NAME
         ]);
     }

--- a/lib/Middleware/CASAuthentication.php
+++ b/lib/Middleware/CASAuthentication.php
@@ -1,0 +1,194 @@
+<?php
+/*
+ * Xibo - Digital Signage - http://www.xibo.org.uk
+ * Copyright (C) 2019 Spring Signage Ltd
+ * Author: Emmanuel Blindauer
+ * Based on SAMLAuthentication.php
+ *
+ * This file (CASAuthentication.php) is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+namespace Xibo\Middleware;
+
+
+use Slim\Middleware;
+use Xibo\Entity\User;
+use Xibo\Exception\AccessDeniedException;
+use Xibo\Exception\NotFoundException;
+use Xibo\Helper\ApplicationState;
+use Xibo\Helper\Random;
+
+/**
+ * Class CASAuthentication
+ * @package Xibo\Middleware
+ *
+ * Provide CAS authentication to Xibo configured via settings.php.
+ */
+class CASAuthentication extends Middleware
+{
+    public static function casRoutes()
+    {
+        return array(
+            '/cas/login',
+            '/cas/logout',
+        );
+    }
+
+
+    /**
+     * Uses a Hook to check every call for authorization
+     * Will redirect to the login route if the user is unauthorized
+     *
+     * @throws \RuntimeException if there isn't a login route
+     */
+    public function call()
+    {
+        $app = $this->app;
+
+        // Create a user
+        $app->user = $app->userFactory->create();
+
+        // Register CAS routes.
+        $app->excludedCsrfRoutes = CASAuthentication::casRoutes();
+        $app->logoutRoute = 'cas.logout';
+
+        $app->map('/cas/login', function () use ($app) {
+
+            // Initiate CAS SSO
+            $sso_host = $app->configService->casSettings['config']['server'];
+            $sso_port = $app->configService->casSettings['config']['port'];
+            $sso_uri = $app->configService->casSettings['config']['uri'];
+            \phpCAS::client(CAS_VERSION_2_0, $sso_host, intval($sso_port), $sso_uri, true, null);
+            \phpCAS::setNoCasServerValidation();
+
+            //Login happens here
+            \phpCAS::forceAuthentication();
+
+            $username = \phpCAS::getUser();
+
+            try {
+                $user = $app->userFactory->getByName($username);
+            } catch (NotFoundException $e) {
+                throw new AccessDeniedException("Unknown user");
+            }
+            if (isset($user) && $user->userId > 0) {
+                // Load User
+                $user->setChildAclDependencies($app->userGroupFactory, $app->pageFactory);
+                $user->load();
+
+                // Overwrite our stored user with this new object.
+                $this->app->user = $user;
+
+                // Set the user factory ACL dependencies (used for working out intra-user permissions)
+                $app->userFactory->setAclDependencies($user, $app->userFactory);
+
+                // Switch Session ID's
+                $this->app->session->setIsExpired(0);
+                $this->app->session->regenerateSessionId();
+                $this->app->session->setUser($user->userId);
+
+                // Audit Log
+                // Set the userId on the log object
+                $this->app->logService->setUserId($user->userId);
+                $this->app->logService->audit('User', $user->userId, 'Login Granted via CAS', [
+                    'IPAddress' => $this->app->request()->getIp(),
+                    'UserAgent' => $this->app->request()->getUserAgent()
+                ]);
+            }
+            $app->redirect($app->urlFor('home'));
+        })->via('GET','POST')->setName('cas.login');;
+
+        // Service for the logout of the user.
+        // End the CAS session and the application session
+        $app->get('/cas/logout', function () use ($app) {
+            // The order is first: local session to destroy, second the cas session
+            // because phpCAS::logout() redirects to CAS server
+            $loginController = $app->container->get('\Xibo\Controller\Login');
+            $loginController->logout(false);
+            $sso_host = $app->configService->casSettings['config']['server'];
+            $sso_port = $app->configService->casSettings['config']['port'];
+            $sso_uri = $app->configService->casSettings['config']['uri'];
+            \phpCAS::client(CAS_VERSION_2_0, $sso_host, intval($sso_port), $sso_uri, true, null);
+            \phpCAS::logout();
+
+        })->setName('cas.logout');
+
+        // Create a function which we will call should the request be for a protected page
+        // and the user not yet be logged in.
+        $redirectToLogin = function () use ($app) {
+            if ($app->request->isAjax()) {
+                $state = $app->state;
+                /* @var ApplicationState $state */
+                // Return a JSON response which tells the App to redirect to the login page
+                $app->response()->header('Content-Type', 'application/json');
+                $state->Login();
+                echo $state->asJson();
+                $app->stop();
+            }
+            else {
+                // We redirect to login and not cas.login to let the user choose
+                // the source of authentication
+                $app->redirect($app->urlFor('login'));
+            }
+        };
+
+        // Define a callable to check the route requested in before.dispatch
+        $isAuthorised = function () use ($app, $redirectToLogin) {
+            /** @var \Xibo\Entity\User $user */
+            $user = $app->user;
+
+            // Get the current route pattern
+            $resource = $app->router->getCurrentRoute()->getPattern();
+
+            // Pass the page factory into the user object, so that it can check its page permissions
+            $user->setChildAclDependencies($app->userGroupFactory, $app->pageFactory);
+
+            // Check to see if this is a public resource (there are only a few, so we have them in an array)
+            if (!in_array($resource, $app->publicRoutes) && !in_array($resource, CASAuthentication::casRoutes())) {
+                $app->public = false;
+                // Need to check
+                if ($user->hasIdentity() && !$app->session->isExpired()) {
+                    // Replace our user with a fully loaded one
+                    $user = $app->userFactory->getById($user->userId);
+                    $user->setChildAclDependencies($app->userGroupFactory, $app->pageFactory);
+                    $user->load();
+                    $app->logService->setUserId($user->userId);
+                    $user->routeAuthentication($resource);
+
+                    // We are authenticated, override with the populated user object
+                    $app->user = $user;
+                }
+                else {
+                    // Store the current route so we can come back to it after login
+                    $app->flash('priorRoute', $app->request()->getRootUri() . $app->request()->getResourceUri());
+                    $redirectToLogin();
+                }
+            }
+            else {
+                $app->public = true;
+                // If we are expired and come from ping/clock, then we redirect
+                if ($app->session->isExpired() && ($resource == '/login/ping' || $resource == 'clock')) {
+                    $redirectToLogin();
+                }
+            }
+        };
+
+        $app->hook('slim.before.dispatch', $isAuthorised);
+
+        $this->next->call();
+    }
+}

--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -73,6 +73,7 @@ class ConfigService implements ConfigServiceInterface
     public $logProcessors = null;
     public $authentication = null;
     public $samlSettings = null;
+    public $casSettings = null;
     public $cacheDrivers = null;
     public $cacheNamespace = 'Xibo';
 
@@ -206,6 +207,10 @@ class ConfigService implements ConfigServiceInterface
         // Saml settings
         if (isset($samlSettings))
             $config->samlSettings = $samlSettings;
+
+        // CAS settings
+        if (isset($casSettings))
+            $config->casSettings = $casSettings;
 
         // Cache drivers
         if (isset($cacheDrivers))

--- a/views/login.twig
+++ b/views/login.twig
@@ -69,6 +69,22 @@
 
             {% if passwordReminderEnabled %}<p><a href="#" id="reminder-form-toggle">{% trans "Forgotten your password?" %}</a></p>{% endif %}
         </form>
+        {% if authCASEnabled %}
+        <form id="cas-login-form" class="form-signin text-center" action="{{ urlFor("cas.login") }}" method="post">
+            <input name="priorRoute" type="hidden" value="{{ flash.priorRoute }}" />
+            <input type="hidden" name="{{ csrfKey }}" value="{{ csrfToken }}" />
+            <p><img class="login-logo" src="{{ theme.uri("img/cas.png") }}"></p>
+
+            <p>{% trans "Click here to login with your Central Authentication Server" %}</p>
+
+            {% if flash.cas_login_message %}
+            <div class="alert alert-danger">{{ flash.cas_login_message }}</div>
+            {% endif %}
+
+            <p><button class="btn btn-large btn-primary" type="submit" name="logincas">{% trans "CAS Login" %}</button></p>
+        </form>
+        {% endif %}
+
 
         {% if passwordReminderEnabled %}
         <form id="reminder-form" class="form-signin text-center hidden" action="{{ urlFor("login.forgotten") }}" method="post">


### PR DESCRIPTION
Local accounts are still available
Code is based on the SAMLAuthentication
The needed settings are:
```
$authentication = new \Xibo\Middleware\CASAuthentication();
$casSettings = array(
    'config' => array (
        'server' => 'your.cas.server',
        'port' => '443',
        'uri' => '/cas'
    )
);
```