### PR TITLE
Feature: Can search layouts filtered by ParentId

### DIFF
--- a/lib/Controller/Layout.php
+++ b/lib/Controller/Layout.php
@@ -913,6 +913,7 @@ class Layout extends Base
             'exactTags' => $this->getSanitizer()->getCheckbox('exactTags'),
             'filterLayoutStatusId' => $this->getSanitizer()->getInt('layoutStatusId'),
             'layoutId' => $this->getSanitizer()->getInt('layoutId'),
+            'parentId' => $this->getSanitizer()->getInt('parentId'),
             'ownerUserGroupId' => $this->getSanitizer()->getInt('ownerUserGroupId'),
             'mediaLike' => $this->getSanitizer()->getString('mediaLike'),
             'publishedStateId' => $this->getSanitizer()->getInt('publishedStateId'),


### PR DESCRIPTION
Hello,

One of our needs was to be able to find, through the API, the "draft" Layout given the original "published" Layout's id.

This change allows a user to pass a `parentId` parameter to the `api/layout` endpoint to filter Layouts whose parent Layout has the given id.