### PR TITLE
Sprint/2.1.1

### DIFF
--- a/ui/src/css/designer.less
+++ b/ui/src/css/designer.less
@@ -979,11 +979,11 @@
 #layout-editor #layout-timeline .designer-region .designer-region-overlay {
     display: none;
     z-index: 2;
-    width: calc(100% + 6px);
-    height: calc(100% + 6px);
-    left: -3px;
-    top: -3px;
-    position: relative;
+    width: 100%;
+    height: 100%;
+    left: 0;
+    top: 0;
+    position: absolute;
     .border-radius(4px);
 
     .info {

--- a/ui/src/css/designer.less
+++ b/ui/src/css/designer.less
@@ -273,7 +273,6 @@
     color: white;
     font-weight: bold;
     padding: 10px;
-    position: absolute;
 }
 
 #layout-editor #layout-timeline #timeline-container {


### PR DESCRIPTION
OSX-824 ( xibosignage/xibo#1943 ): Widgets cannot be added to the Region Timeline using the + method.
OSX-824 ( xibosignage/xibo#1944 ): Widget add to region css fix