### PR TITLE
Removed recursive chown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -151,7 +151,7 @@ COPY --from=composer /app /var/www/cms
 COPY --from=webpack /app/web/dist /var/www/cms/web/dist
 
 # All other files (.dockerignore excludes many things, but we tidy up the rest below)
-COPY . /var/www/cms
+COPY --chown=apache:apache . /var/www/cms
 
 # Tidy up
 RUN rm /var/www/cms/composer.* && \

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -203,7 +203,11 @@ then
     /bin/chmod g+s /usr/sbin/ssmtp
 
     mkdir -p /var/www/cms/library/temp
-    chown apache.apache -R /var/www/cms
+    chown apache.apache /var/www/cms/library
+    chown apache.apache /var/www/cms/library/temp
+    chown apache.apache /var/www/cms/custom
+    chown apache.apache /var/www/cms/custom/settings-custom.php
+    chown apache.apache /var/www/cms/ca-certs
 
     # If we have a CMS ALIAS environment variable, then configure that in our Apache conf.
     # this must not be done in DEV mode, as it modifies the .htaccess file, which might then be committed by accident

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -203,11 +203,11 @@ then
     /bin/chmod g+s /usr/sbin/ssmtp
 
     mkdir -p /var/www/cms/library/temp
-    chown apache.apache /var/www/cms/library
-    chown apache.apache /var/www/cms/library/temp
-    chown apache.apache /var/www/cms/custom
-    chown apache.apache /var/www/cms/custom/settings-custom.php
-    chown apache.apache /var/www/cms/ca-certs
+    chown apache.apache -R /var/www/cms/library
+    chown apache.apache -R /var/www/cms/custom
+    chown apache.apache -R /var/www/cms/web/theme/custom
+    chown apache.apache -R /var/www/cms/web/userscripts
+    chown apache.apache -R /var/www/cms/ca-certs
 
     # If we have a CMS ALIAS environment variable, then configure that in our Apache conf.
     # this must not be done in DEV mode, as it modifies the .htaccess file, which might then be committed by accident


### PR DESCRIPTION
This commit replaces the recursive chown in the entrypoint.sh for the cms folder to a non-recursive chown on some files and set the correct permissions when copying the files to the docker container.
See issue's https://github.com/xibosignage/xibo/issues/2010 and https://github.com/docker/for-linux/issues/388