### PR TITLE
Grid Folder feature: Fix double click and table horizontal resizing

### DIFF
--- a/ui/src/core/xibo-cms.js
+++ b/ui/src/core/xibo-cms.js
@@ -836,12 +836,10 @@ function dataTableDraw(e, settings) {
         };
 
         // Bind a click event to our table
-        if (target.data().initialised == undefined) {
-            target.find("tbody").on("click", "tr", function () {
-                $(this).toggleClass("selected");
-                target.data().initialised = true;
-            });
-        }
+        target.find("tbody").off("click", "tr").on("click", "tr", function () {
+            $(this).toggleClass("selected");
+            target.data().initialised = true;
+        });
 
         // Add a button set to the table
         var template = Handlebars.compile($("#multiselect-button-template").html());
@@ -857,7 +855,7 @@ function dataTableDraw(e, settings) {
         if($tagsElement.length > 0 && userRoutePermissions.tags == 1) {
             buttons.push({id: $tagsElement.attr("id"), gridId: e.target.id, text: translations.editTags, contentType: target.data('contentType'), contentIdName: target.data('contentIdName'), customHandler: "XiboMultiSelectTagFormRender", sortGroup: 0});
         }
-
+        
         // Sort buttons by groups/importance
         buttons = buttons.sort(function(a, b) {
             return ((a.sortGroup > b.sortGroup) ? 1 : -1);

--- a/views/campaign-page.twig
+++ b/views/campaign-page.twig
@@ -89,7 +89,7 @@
                     </div>
                     <div id="datatable-container" class="col-sm-10">
                         <div class="XiboData">
-                            <table id="campaigns" class="table table-striped" data-content-type="campaign" data-content-id-name="campaignId" data-state-preference-name="campaignGrid">
+                            <table id="campaigns" class="table table-striped" data-content-type="campaign" data-content-id-name="campaignId" data-state-preference-name="campaignGrid" style="width: 100%;">
                                 <thead>
                                     <tr>
                                         <th>{% trans "Name" %}</th>

--- a/views/dataset-page.twig
+++ b/views/dataset-page.twig
@@ -86,7 +86,7 @@
                     </div>
                     <div id="datatable-container" class="col-sm-10">
                         <div class="XiboData">
-                            <table id="datasets" class="table table-striped" data-state-preference-name="dataSetGrid">
+                            <table id="datasets" class="table table-striped" data-state-preference-name="dataSetGrid" style="width: 100%;">
                                 <thead>
                                     <tr>
                                         <th>{% trans "ID" %}</th>

--- a/views/display-page.twig
+++ b/views/display-page.twig
@@ -202,7 +202,7 @@
                     </div>
                     <div id="datatable-container" class="col-sm-10">
                         <div class="XiboData">
-                            <table id="displays" class="table table-striped" data-content-type="display" data-content-id-name="displayId" data-state-preference-name="displayGrid">
+                            <table id="displays" class="table table-striped" data-content-type="display" data-content-id-name="displayId" data-state-preference-name="displayGrid" style="width: 100%;">
                                 <thead>
                                     <tr>
                                         <th>{% trans "ID" %}</th>
@@ -486,6 +486,7 @@
                     },
                     {
                         "name": "remote",
+                        "data": null,
                         responsivePriority: 4,
                         "render": function (data, type, row) {
                             if (type !== "display")

--- a/views/displaygroup-page.twig
+++ b/views/displaygroup-page.twig
@@ -107,7 +107,7 @@
                     </div>
                     <div id="datatable-container" class="col-sm-10">
                         <div class="XiboData">
-                            <table id="displaygroups" class="table table-striped" data-content-type="displayGroup" data-content-id-name="displayGroupId" data-state-preference-name="displayGroupGrid">
+                            <table id="displaygroups" class="table table-striped" data-content-type="displayGroup" data-content-id-name="displayGroupId" data-state-preference-name="displayGroupGrid" style="width: 100%;">
                                 <thead>
                                     <tr>
                                         <th>{% trans "ID" %}</th>

--- a/views/layout-page.twig
+++ b/views/layout-page.twig
@@ -120,7 +120,7 @@
                     </div>
                     <div id="datatable-container" class="col-sm-10">
                         <div class="XiboData">
-                            <table id="layouts" class="table table-striped responsive nowrap" data-content-type="layout" data-content-id-name="layoutId" data-state-preference-name="layoutGrid">
+                            <table id="layouts" class="table table-striped responsive nowrap" data-content-type="layout" data-content-id-name="layoutId" data-state-preference-name="layoutGrid" style="width: 100%;">
                                 <thead>
                                     <tr>
                                         <th>{% trans "ID" %}</th>

--- a/views/library-page.twig
+++ b/views/library-page.twig
@@ -115,7 +115,7 @@
 
                     <div id="datatable-container" class="col-sm-10">
                         <div class="XiboData">
-                            <table id="libraryItems" class="table table-striped responsive nowrap" data-content-type="media" data-content-id-name="mediaId" data-state-preference-name="libraryGrid">
+                            <table id="libraryItems" class="table table-striped responsive nowrap" data-content-type="media" data-content-id-name="mediaId" data-state-preference-name="libraryGrid" style="width: 100%;">
                                 <thead>
                                 <tr>
                                     <th>{% trans "ID" %}</th>

--- a/views/playlist-page.twig
+++ b/views/playlist-page.twig
@@ -119,7 +119,7 @@
                     <div id="datatable-container" class="col-sm-10">
                         <div class="XiboData">
                             <table id="playlists" class="table table-striped" data-content-type="playlist"
-                                   data-content-id-name="playlistId" data-state-preference-name="playlistGrid">
+                                   data-content-id-name="playlistId" data-state-preference-name="playlistGrid" style="width: 100%;">
                                 <thead>
                                 <tr>
                                     <th>{% trans "ID" %}</th>


### PR DESCRIPTION
fixes xibosignage/xibo#2347

 - Table inline style with at 100%
 - Row select fix
 - Display grid "remote" field warning fix