### PR TITLE
Update MySQL from 5.6 to 5.7

### DIFF
--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: 1
       - name: Pull
         run: |
-          docker pull mysql:5.6
+          docker pull mysql:5.7
           docker pull xibosignage/xibo-xmr:latest
       - name: Get Diff
         run: |
@@ -26,7 +26,7 @@ jobs:
           docker build . -f Dockerfile.cypress -t cms-cypress
       - name: Run
         run: |
-          docker run --name cms-db -e MYSQL_RANDOM_ROOT_PASSWORD=yes -e MYSQL_DATABASE=cms -e MYSQL_USER=cms -e MYSQL_PASSWORD=jenkins -d mysql:5.6
+          docker run --name cms-db -e MYSQL_RANDOM_ROOT_PASSWORD=yes -e MYSQL_DATABASE=cms -e MYSQL_USER=cms -e MYSQL_PASSWORD=jenkins -d mysql:5.7
           docker run --name cms-xmr -d xibosignage/xibo-xmr:latest
           docker run --name cms-web -e MYSQL_USER=cms -e MYSQL_PASSWORD=jenkins -e XIBO_DEV_MODE=true -e XMR_HOST=cms-xmr --link cms-db:db --link cms-xmr:50001 -d cms-web
       - name: Wait for CMS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   db:
-    image: mysql:5.6
+    image: mysql:5.7
     ports:
     - 3315:3306
     volumes:


### PR DESCRIPTION
Updates MySQL from **5.6** to **5.7**, as support for **5.6** ended on Feb 2021, see [here](https://en.wikipedia.org/wiki/MySQL#Release_history).

Relates https://github.com/xibosignage/xibo/issues/2469, https://github.com/xibosignage/xibo-docker/pull/136.