### PR TITLE
Share: With Selected Share requires repeated attempts to apply desired settings

### DIFF
--- a/ui/src/core/xibo-forms.js
+++ b/ui/src/core/xibo-forms.js
@@ -597,15 +597,11 @@ function permissionsMultiFormOpen(dialog) {
                     }
                 }
 
-                // initialise the permission and start permissions arrays
-                if ($grid.data().permissions == undefined) {
-                    $grid.data().permissions = newData;
-                }
+                // merge the permission and start permissions arrays
+                $grid.data().permissions = Object.assign({}, $grid.data().permissions, newData);
+                $grid.data().startPermissions = Object.assign({}, $grid.data().startPermissions, JSON.parse(JSON.stringify(newData)));
 
-                if ($grid.data().startPermissions == undefined) {
-                    $grid.data().startPermissions = JSON.parse(JSON.stringify(newData));
-                }
-
+                // init save permissions if undefined
                 if ($grid.data().savePermissions == undefined) {
                     $grid.data().savePermissions = {};
                 }


### PR DESCRIPTION
Basically the stored data in table was only addressing the first set of results, changing to a different page or searching for an element not contained in that set would break that data.

By merging the permissions objects we get all needed data, and it seems to be fixed