### PR TITLE
Allow use of internal CA signed certificates for msmtp

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -289,6 +289,11 @@ then
       /bin/sed -i "s/tls_starttls .*$/tls_starttls off/" /etc/msmtprc
     fi
 
+    if [ "$CMS_SMTP_CHECK_TLS_CERTIFICATE" == "NO" ]
+    then
+      /bin/sed -i "s/tls .*$/tls_nocertcheck/" /etc/msmtprc
+    fi
+
     /bin/sed -i "s/maildomain .*$/maildomain $CMS_SMTP_REWRITE_DOMAIN/" /etc/msmtprc
     /bin/sed -i "s/domain .*$/domain $CMS_SMTP_HOSTNAME/" /etc/msmtprc
 


### PR DESCRIPTION
By default, msmtp checks the validity of the certificate chain of the mail server. The new option "CMS_SMTP_CHECK_TLS_CERTIFICATE" allows use of TLS certificates signed by internal Certificate Authority that do not pass the default check. If the user sets "CMS_SMTP_CHECK_TLS_CERTIFICATE" to "NO" then the line "tls_nocertcheck" will be added to /etc/msmtprc (see  dagonix/ xibo-docker/config.env.template  commit).