### PR TITLE
Widgets: DataSet data provider for DataSet Ticker/View widgets.

### DIFF
--- a/lib/Controller/Widget.php
+++ b/lib/Controller/Widget.php
@@ -1,8 +1,8 @@
 <?php
 /*
- * Copyright (C) 2022 Xibo Signage Ltd
+ * Copyright (c) 2023  Xibo Signage Ltd
  *
- * Xibo - Digital Signage - http://www.xibo.org.uk
+ * Xibo - Digital Signage - https://xibosignage.com
  *
  * This file is part of Xibo.
  *
@@ -18,6 +18,7 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 
 namespace Xibo\Controller;
@@ -1065,7 +1066,10 @@ class Widget extends Base
             ])
         );
 
-        return $response->withJson($data);
+        return $response->withJson([
+            'data' => $data,
+            'meta' => $dataProvider->getMetaData(),
+        ]);
     }
 
     /**

--- a/lib/Controller/Widget.php
+++ b/lib/Controller/Widget.php
@@ -1,8 +1,8 @@
 <?php
 /*
- * Copyright (c) 2023  Xibo Signage Ltd
+ * Copyright (C) 2023 Xibo Signage Ltd
  *
- * Xibo - Digital Signage - https://xibosignage.com
+ * Xibo - Digital Signage - http://www.xibo.org.uk
  *
  * This file is part of Xibo.
  *
@@ -18,7 +18,6 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
- *
  */
 
 namespace Xibo\Controller;
@@ -110,7 +109,7 @@ class Widget extends Base
         $this->regionFactory = $regionFactory;
         $this->widgetAudioFactory = $widgetAudioFactory;
     }
-    
+
     /**
      * Add Widget
      *
@@ -415,7 +414,7 @@ class Widget extends Base
             }
             $widget->applyProperties($template->properties);
         }
-        
+
         // Check to see if the media we've assigned exists.
         foreach ($widget->mediaIds as $mediaId) {
             try {
@@ -988,10 +987,10 @@ class Widget extends Base
         $module = $this->moduleFactory->getByType($widget->type);
 
         // This is always a preview
-        if (!$module->isDataProviderExpected()) {
+        if (!$module->isDataProviderExpected() && !$module->isWidgetProviderAvailable()) {
             return $response->withJson([]);
         }
-        
+
         // Populate the widget with its properties.
         $widget->load();
         $module->decorateProperties($widget, true);

--- a/lib/Controller/Widget.php
+++ b/lib/Controller/Widget.php
@@ -1041,6 +1041,7 @@ class Widget extends Base
                         // Success
                         // We don't need to do anything else, references to mediaId will be built when we decorate
                         // the HTML.
+                        // Nothing is linked to a display when in preview mode.
                         $this->getLog()->debug('Successfully downloaded ' . $media->mediaId);
                     });
                 }
@@ -1068,7 +1069,7 @@ class Widget extends Base
 
         return $response->withJson([
             'data' => $data,
-            'meta' => $dataProvider->getMetaData(),
+            'meta' => $dataProvider->getMeta(),
         ]);
     }
 

--- a/lib/Entity/DataSet.php
+++ b/lib/Entity/DataSet.php
@@ -1,8 +1,8 @@
 <?php
 /*
- * Copyright (c) 2022 Xibo Signage Ltd
+ * Copyright (c) 2022-2023  Xibo Signage Ltd
  *
- * Xibo - Digital Signage - http://www.xibo.org.uk
+ * Xibo - Digital Signage - https://xibosignage.com
  *
  * This file is part of Xibo.
  *
@@ -18,6 +18,7 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 
 
@@ -471,7 +472,6 @@ class DataSet implements \JsonSerializable
      */
     public function getData($filterBy = [], $options = [])
     {
-
         $sanitizer = $this->getSanitizer($filterBy);
 
         $start = $sanitizer->getInt('start', ['default' => 0]);
@@ -482,7 +482,8 @@ class DataSet implements \JsonSerializable
 
         $options = array_merge([
             'includeFormulaColumns' => true,
-            'requireTotal' => true
+            'requireTotal' => true,
+            'connection' => 'default'
         ], $options);
 
         // Params
@@ -623,11 +624,15 @@ class DataSet implements \JsonSerializable
 
         $sql = $select . $body . $order . $limit;
 
-        $data = $this->getStore()->select($sql, $params);
+        $data = $this->getStore()->select($sql, $params, $options['connection']);
 
         // If there are limits run some SQL to work out the full payload of rows
         if ($options['requireTotal']) {
-            $results = $this->getStore()->select('SELECT COUNT(*) AS total FROM (' . $body, $params);
+            $results = $this->getStore()->select(
+                'SELECT COUNT(*) AS total FROM (' . $body,
+                $params,
+                $options['connection']
+            );
             $this->countLast = intval($results[0]['total']);
         }
 

--- a/lib/Entity/Module.php
+++ b/lib/Entity/Module.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2022 Xibo Signage Ltd
+ * Copyright (C) 2023 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - http://www.xibo.org.uk
  *
@@ -252,6 +252,15 @@ class Module implements \JsonSerializable
     }
 
     /**
+     * Is a widget provider available
+     * @return bool
+     */
+    public function isWidgetProviderAvailable(): bool
+    {
+        return $this->widgetProvider !== null;
+    }
+
+    /**
      * Get this module's widget provider, or null if there isn't one
      * @return \Xibo\Widget\Provider\WidgetProviderInterface|null
      */
@@ -303,7 +312,9 @@ class Module implements \JsonSerializable
     public function setWidgetProvider(WidgetProviderInterface $widgetProvider): Module
     {
         $this->widgetProvider = $widgetProvider;
-        $this->widgetProvider->setLog($this->getLog()->getLoggerInterface());
+        $this->widgetProvider
+            ->setLog($this->getLog()->getLoggerInterface())
+            ->setDispatcher($this->getDispatcher());
         return $this;
     }
 

--- a/lib/Entity/ModulePropertyTrait.php
+++ b/lib/Entity/ModulePropertyTrait.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2022 Xibo Signage Ltd
+ * Copyright (C) 2023 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - http://www.xibo.org.uk
  *
@@ -44,6 +44,12 @@ trait ModulePropertyTrait
                 $property->value = $property->default;
             }
 
+            if ($property->type === 'integer' && $property->value !== null) {
+                $property->value = intval($property->value);
+            } else if ($property->type === 'double' && $property->value !== null) {
+                $property->value = intval($property->value);
+            }
+
             if ($property->variant === 'uri') {
                 $property->value = urldecode($property->value);
             }
@@ -61,6 +67,7 @@ trait ModulePropertyTrait
         foreach ($this->properties as $property) {
             $value = $property->value;
 
+            // TODO: should we cast values to their appropriate field formats.
             if ($decorateForOutput) {
                 // Does this property have library references?
                 if ($property->allowLibraryRefs) {

--- a/lib/Event/DataSetDataRequestEvent.php
+++ b/lib/Event/DataSetDataRequestEvent.php
@@ -1,0 +1,49 @@
+<?php
+/*
+ * Copyright (C) 2023 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - http://www.xibo.org.uk
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace Xibo\Event;
+
+use Xibo\Widget\Provider\DataProviderInterface;
+
+/**
+ * Event raised when a widget requests data.
+ */
+class DataSetDataRequestEvent extends Event
+{
+    public static $NAME = 'dataset.data.request.event';
+
+    /** @var \Xibo\Widget\Provider\DataProviderInterface */
+    private $dataProvider;
+
+    public function __construct(DataProviderInterface $dataProvider)
+    {
+        $this->dataProvider = $dataProvider;
+    }
+
+    /**
+     * The data provider should be updated with data for its widget.
+     * @return \Xibo\Widget\Provider\DataProviderInterface
+     */
+    public function getDataProvider(): DataProviderInterface
+    {
+        return $this->dataProvider;
+    }
+}

--- a/lib/Listener/DataSetDataProviderListener.php
+++ b/lib/Listener/DataSetDataProviderListener.php
@@ -183,6 +183,7 @@ class DataSetDataProviderListener
             // Add the mapping we've generated to the metadata
             $dataProvider->addOrUpdateMeta('mapping', $mappings);
         } catch (\Exception $exception) {
+            $this->getLogger()->debug('onDataRequest: ' . $exception->getTraceAsString());
             $this->getLogger()->error('onDataRequest: unable to get data for dataSetId ' . $dataSet->dataSetId
                 . ' e: ' . $exception->getMessage());
         }

--- a/lib/Listener/DataSetDataProviderListener.php
+++ b/lib/Listener/DataSetDataProviderListener.php
@@ -1,8 +1,8 @@
 <?php
 /*
- * Copyright (c) 2023  Xibo Signage Ltd
+ * Copyright (C) 2023 Xibo Signage Ltd
  *
- * Xibo - Digital Signage - https://xibosignage.com
+ * Xibo - Digital Signage - http://www.xibo.org.uk
  *
  * This file is part of Xibo.
  *
@@ -18,7 +18,6 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
- *
  */
 
 namespace Xibo\Listener;
@@ -26,7 +25,7 @@ namespace Xibo\Listener;
 use Carbon\Carbon;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Xibo\Entity\DataSet;
-use Xibo\Event\WidgetDataRequestEvent;
+use Xibo\Event\DataSetDataRequestEvent;
 use Xibo\Factory\DataSetFactory;
 use Xibo\Factory\DisplayFactory;
 use Xibo\Service\ConfigServiceInterface;
@@ -58,8 +57,7 @@ class DataSetDataProviderListener
         ConfigServiceInterface $config,
         DataSetFactory $dataSetFactory,
         DisplayFactory $displayFactory
-    )
-    {
+    ) {
         $this->store = $store;
         $this->config = $config;
         $this->dataSetFactory = $dataSetFactory;
@@ -68,11 +66,11 @@ class DataSetDataProviderListener
 
     public function registerWithDispatcher(EventDispatcherInterface $dispatcher): DataSetDataProviderListener
     {
-        $dispatcher->addListener(WidgetDataRequestEvent::$NAME, [$this, 'onDataRequest']);
+        $dispatcher->addListener(DataSetDataRequestEvent::$NAME, [$this, 'onDataRequest']);
         return $this;
     }
 
-    public function onDataRequest(WidgetDataRequestEvent $event)
+    public function onDataRequest(DataSetDataRequestEvent $event)
     {
         if ($event->getDataProvider()->getDataSource() === 'dataSet') {
             $dataProvider = $event->getDataProvider();
@@ -273,10 +271,10 @@ class DataSetDataProviderListener
             $timeZone = ($timeZone == '') ? $this->config->getSetting('defaultTimezone') : $timeZone;
             $dateNow->timezone($timeZone);
             $this->logger->debug(sprintf(
-                    'Display Timezone Resolved: %s. Time: %s.',
-                    $timeZone,
-                    $dateNow->toDateTimeString())
-            );
+                'Display Timezone Resolved: %s. Time: %s.',
+                $timeZone,
+                $dateNow->toDateTimeString()
+            ));
         }
 
         // Run this command on a new connection so that we do not interfere with any other queries on this connection.

--- a/lib/Listener/DataSetDataProviderListener.php
+++ b/lib/Listener/DataSetDataProviderListener.php
@@ -72,26 +72,26 @@ class DataSetDataProviderListener
 
     public function onDataRequest(DataSetDataRequestEvent $event)
     {
-        if ($event->getDataProvider()->getDataSource() === 'dataSet') {
-            $dataProvider = $event->getDataProvider();
+        $this->getLogger()->error('onDataRequest: data source is ' . $event->getDataProvider()->getDataSource());
 
-            // We must have a dataSetId configured.
-            $dataSetId = $dataProvider->getProperty('dataSetId', 0);
-            if (empty($dataSetId)) {
-                $this->getLogger()->debug('onDataRequest: no dataSetId.');
-                return;
-            }
+        $dataProvider = $event->getDataProvider();
 
-            // Get this dataset
-            try {
-                $dataSet = $this->dataSetFactory->getById($dataSetId);
-            } catch (NotFoundException $notFoundException) {
-                $this->getLogger()->error('onDataRequest: dataSetId ' . $dataSetId . ' not found.');
-                return;
-            }
-
-            $this->getData($dataSet, $dataProvider);
+        // We must have a dataSetId configured.
+        $dataSetId = $dataProvider->getProperty('dataSetId', 0);
+        if (empty($dataSetId)) {
+            $this->getLogger()->debug('onDataRequest: no dataSetId.');
+            return;
         }
+
+        // Get this dataset
+        try {
+            $dataSet = $this->dataSetFactory->getById($dataSetId);
+        } catch (NotFoundException $notFoundException) {
+            $this->getLogger()->error('onDataRequest: dataSetId ' . $dataSetId . ' not found.');
+            return;
+        }
+
+        $this->getData($dataSet, $dataProvider);
     }
 
     private function getData(DataSet $dataSet, DataProviderInterface $dataProvider): void

--- a/lib/Listener/DataSetDataProviderListener.php
+++ b/lib/Listener/DataSetDataProviderListener.php
@@ -1,0 +1,285 @@
+<?php
+/*
+ * Copyright (c) 2023  Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Xibo\Listener;
+
+use Carbon\Carbon;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Xibo\Entity\DataSet;
+use Xibo\Event\WidgetDataRequestEvent;
+use Xibo\Factory\DataSetFactory;
+use Xibo\Factory\DisplayFactory;
+use Xibo\Service\ConfigServiceInterface;
+use Xibo\Storage\StorageServiceInterface;
+use Xibo\Support\Exception\NotFoundException;
+use Xibo\Widget\Provider\DataProviderInterface;
+
+/**
+ * Listens to requests for data from DataSets.
+ */
+class DataSetDataProviderListener
+{
+    use ListenerLoggerTrait;
+
+    /** @var \Xibo\Storage\StorageServiceInterface */
+    private $store;
+
+    /** @var \Xibo\Service\ConfigServiceInterface */
+    private $config;
+
+    /** @var \Xibo\Factory\DataSetFactory */
+    private $dataSetFactory;
+
+    /** @var \Xibo\Factory\DisplayFactory */
+    private $displayFactory;
+
+    public function __construct(
+        StorageServiceInterface $store,
+        ConfigServiceInterface $config,
+        DataSetFactory $dataSetFactory,
+        DisplayFactory $displayFactory
+    )
+    {
+        $this->store = $store;
+        $this->config = $config;
+        $this->dataSetFactory = $dataSetFactory;
+        $this->displayFactory = $displayFactory;
+    }
+
+    public function registerWithDispatcher(EventDispatcherInterface $dispatcher): DataSetDataProviderListener
+    {
+        $dispatcher->addListener(WidgetDataRequestEvent::$NAME, [$this, 'onDataRequest']);
+        return $this;
+    }
+
+    public function onDataRequest(WidgetDataRequestEvent $event)
+    {
+        if ($event->getDataProvider()->getDataSource() === 'dataSet') {
+            $dataProvider = $event->getDataProvider();
+
+            // We must have a dataSetId configured.
+            $dataSetId = $dataProvider->getProperty('dataSetId', 0);
+            if (empty($dataSetId)) {
+                $this->getLogger()->debug('onDataRequest: no dataSetId.');
+                return;
+            }
+
+            // Get this dataset
+            try {
+                $dataSet = $this->dataSetFactory->getById($dataSetId);
+            } catch (NotFoundException $notFoundException) {
+                $this->getLogger()->error('onDataRequest: dataSetId ' . $dataSetId . ' not found.');
+                return;
+            }
+
+            $this->getData($dataSet, $dataProvider);
+        }
+    }
+
+    private function getData(DataSet $dataSet, DataProviderInterface $dataProvider): void
+    {
+        $dataSet->load();
+
+        // Columns
+        // Build a list of column mappings we will make available as metadata
+        $mappings = [];
+        $columnIds = $dataProvider->getProperty('columns');
+        $columnIds = $columnIds !== null ? explode(',', $columnIds) : null;
+
+        foreach ($dataSet->columns as $column) {
+            if ($columnIds === null || in_array($column->dataSetColumnId, $columnIds)) {
+                $mappings[] = [
+                    'dataSetColumnId' => $column->dataSetColumnId,
+                    'heading' => $column->heading,
+                    'dataTypeId' => $column->dataTypeId
+                ];
+            }
+        }
+
+        // Build filter, order and limit parameters to pass to the DataSet entity
+        // Ordering
+        $ordering = '';
+        if ($dataProvider->getProperty('useOrderingClause', 1) == 1) {
+            $ordering = $dataProvider->getProperty('ordering');
+        } else {
+            // Build an order string
+            foreach (json_decode($dataProvider->getProperty('orderClauses', '[]'), true) as $clause) {
+                $ordering .= $clause['orderClause'] . ' ' . $clause['orderClauseDirection'] . ',';
+            }
+
+            $ordering = rtrim($ordering, ',');
+        }
+
+        // Build a filter to pass to the dataset
+        $filter = [
+            'filter' => $this->buildFilterClause($dataProvider),
+            'order' => $ordering,
+            'displayId' => $dataProvider->getDisplayId(),
+        ];
+
+        // limits?
+        $upperLimit = $dataProvider->getProperty('upperLimit', 0);
+        $lowerLimit = $dataProvider->getProperty('lowerLimit', 0);
+        if ($lowerLimit !== 0 || $upperLimit !== 0) {
+            // Start should be the lower limit
+            // Size should be the distance between upper and lower
+            $filter['start'] = $lowerLimit;
+            $filter['size'] = $upperLimit - $lowerLimit;
+        }
+
+        // Expiry time for any images
+        $expires = Carbon::now()
+            ->addSeconds($dataProvider->getProperty('updateInterval', 3600) * 60)
+            ->format('U');
+
+        try {
+            $this->setTimezone($dataProvider);
+
+            $dataSetResults = $dataSet->getData($filter);
+
+            foreach ($dataSetResults as $row) {
+                // Add an item containing the columns we have selected
+                $item = [];
+                foreach ($mappings as $mapping) {
+                    // This column is selected
+                    $cellValue = $row[$mapping['heading']];
+                    if ($mapping['dataTypeId'] === 4) {
+                        // Grab the external image
+                        $item[$mapping['heading']] = $dataProvider->addImage(
+                            'dataset_' . md5($dataSet->dataSetId . $mapping['dataSetColumnId'] . $cellValue),
+                            str_replace(' ', '%20', htmlspecialchars_decode($cellValue)),
+                            $expires
+                        );
+                    } else if ($mapping['dataTypeId'] === 5) {
+                        // Library Image
+                        // The content is the ID of the image
+                        $item[$mapping['heading']] = $dataProvider->addLibraryFile(intval($cellValue));
+                    } else {
+                        // Just a normal column
+                        $item[$mapping['heading']] = $cellValue;
+                    }
+                }
+                $dataProvider->addItem($item);
+            }
+
+            // Add the mapping we've generated to the metadata
+            $dataProvider->addOrUpdateMeta('mapping', $mappings);
+        } catch (\Exception $exception) {
+            $this->getLogger()->error('onDataRequest: unable to get data for dataSetId ' . $dataSet->dataSetId
+                . ' e: ' . $exception->getMessage());
+        }
+    }
+
+    private function buildFilterClause(DataProviderInterface $dataProvider): ?string
+    {
+        $filter = '';
+
+        if ($dataProvider->getProperty('useFilteringClause', 1) == 1) {
+            $filter = $dataProvider->getProperty('filter');
+        } else {
+            // Build
+            $i = 0;
+            foreach (json_decode($dataProvider->getProperty('filterClauses', '[]'), true) as $clause) {
+                $i++;
+
+                switch ($clause['filterClauseCriteria']) {
+                    case 'starts-with':
+                        $criteria = 'LIKE \'' . $clause['filterClauseValue'] . '%\'';
+                        break;
+
+                    case 'ends-with':
+                        $criteria = 'LIKE \'%' . $clause['filterClauseValue'] . '\'';
+                        break;
+
+                    case 'contains':
+                        $criteria = 'LIKE \'%' . $clause['filterClauseValue'] . '%\'';
+                        break;
+
+                    case 'equals':
+                        $criteria = '= \'' . $clause['filterClauseValue'] . '\'';
+                        break;
+
+                    case 'not-contains':
+                        $criteria = 'NOT LIKE \'%' . $clause['filterClauseValue'] . '%\'';
+                        break;
+
+                    case 'not-starts-with':
+                        $criteria = 'NOT LIKE \'' . $clause['filterClauseValue'] . '%\'';
+                        break;
+
+                    case 'not-ends-with':
+                        $criteria = 'NOT LIKE \'%' . $clause['filterClauseValue'] . '\'';
+                        break;
+
+                    case 'not-equals':
+                        $criteria = '<> \'' . $clause['filterClauseValue'] . '\'';
+                        break;
+
+                    case 'greater-than':
+                        $criteria = '> \'' . $clause['filterClauseValue'] . '\'';
+                        break;
+
+                    case 'less-than':
+                        $criteria = '< \'' . $clause['filterClauseValue'] . '\'';
+                        break;
+
+                    default:
+                        continue 2;
+                }
+
+                if ($i > 1) {
+                    $filter .= ' ' . $clause['filterClauseOperator'] . ' ';
+                }
+
+                $filter .= $clause['filterClause'] . ' ' . $criteria;
+            }
+        }
+
+        return $filter;
+    }
+
+    /**
+     * @param \Xibo\Widget\Provider\DataProviderInterface $dataProvider
+     * @return void
+     * @throws \Xibo\Support\Exception\NotFoundException
+     */
+    private function setTimezone(DataProviderInterface $dataProvider)
+    {
+        // Set the timezone for SQL
+        $dateNow = Carbon::now();
+        if ($dataProvider->getDisplayId() != 0) {
+            $display = $this->displayFactory->getById($dataProvider->getDisplayId());
+            $timeZone = $display->getSetting('displayTimeZone', '');
+            $timeZone = ($timeZone == '') ? $this->config->getSetting('defaultTimezone') : $timeZone;
+            $dateNow->timezone($timeZone);
+            $this->logger->debug(sprintf(
+                    'Display Timezone Resolved: %s. Time: %s.',
+                    $timeZone,
+                    $dateNow->toDateTimeString())
+            );
+        }
+
+        // Run this command on a new connection so that we do not interfere with any other queries on this connection.
+        $this->store->setTimeZone($dateNow->format('P'), 'dataset');
+    }
+}

--- a/lib/Middleware/ListenersMiddleware.php
+++ b/lib/Middleware/ListenersMiddleware.php
@@ -1,8 +1,8 @@
 <?php
 /*
- * Copyright (C) 2022 Xibo Signage Ltd
+ * Copyright (c) 2023  Xibo Signage Ltd
  *
- * Xibo - Digital Signage - http://www.xibo.org.uk
+ * Xibo - Digital Signage - https://xibosignage.com
  *
  * This file is part of Xibo.
  *
@@ -18,6 +18,7 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 
 namespace Xibo\Middleware;
@@ -38,6 +39,7 @@ use Xibo\Event\PlaylistMaxNumberChangedEvent;
 use Xibo\Event\SystemUserChangedEvent;
 use Xibo\Event\UserDeleteEvent;
 use Xibo\Listener\CampaignListener;
+use Xibo\Listener\DataSetDataProviderListener;
 use Xibo\Listener\DisplayGroupListener;
 use Xibo\Listener\LayoutListener;
 use Xibo\Listener\MediaListener;
@@ -308,6 +310,16 @@ class ListenersMiddleware implements MiddlewareInterface
         $dispatcher->addListener(DependencyFileSizeEvent::$NAME, (new \Xibo\Listener\OnGettingDependencyFileSize\PlayerVersionListener(
             $c->get('playerVersionFactory')
         )));
+
+        // Widget related listeners for getting core data
+        (new DataSetDataProviderListener(
+            $c->get('store'),
+            $c->get('configService'),
+            $c->get('dataSetFactory'),
+            $c->get('displayFactory')
+        ))
+            ->useLogger($c->get('logger'))
+            ->registerWithDispatcher($dispatcher);
     }
 
     /**

--- a/lib/Widget/DataSetProvider.php
+++ b/lib/Widget/DataSetProvider.php
@@ -1,0 +1,54 @@
+<?php
+/*
+ * Copyright (C) 2023 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - http://www.xibo.org.uk
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Xibo\Widget;
+
+use Xibo\Event\DataSetDataRequestEvent;
+use Xibo\Widget\Provider\DataProviderInterface;
+use Xibo\Widget\Provider\DurationProviderInterface;
+use Xibo\Widget\Provider\WidgetProviderInterface;
+use Xibo\Widget\Provider\WidgetProviderTrait;
+
+/**
+ * Provides data from DataSets.
+ */
+class DataSetProvider implements WidgetProviderInterface
+{
+    use WidgetProviderTrait;
+
+    public function fetchData(DataProviderInterface $dataProvider): WidgetProviderInterface
+    {
+        $this->getDispatcher()->dispatch(new DataSetDataRequestEvent($dataProvider));
+        return $this;
+    }
+
+    public function fetchDuration(DurationProviderInterface $durationProvider): WidgetProviderInterface
+    {
+        return $this;
+    }
+
+    public function getDataCacheKey(DataProviderInterface $dataProvider): ?string
+    {
+        // No special cache key requirements.
+        return null;
+    }
+}

--- a/lib/Widget/DataSetProvider.php
+++ b/lib/Widget/DataSetProvider.php
@@ -37,7 +37,11 @@ class DataSetProvider implements WidgetProviderInterface
 
     public function fetchData(DataProviderInterface $dataProvider): WidgetProviderInterface
     {
-        $this->getDispatcher()->dispatch(new DataSetDataRequestEvent($dataProvider));
+        $this->getLog()->debug('fetchData: DataSetProvider passing to event');
+        $this->getDispatcher()->dispatch(
+            new DataSetDataRequestEvent($dataProvider),
+            DataSetDataRequestEvent::$NAME
+        );
         return $this;
     }
 

--- a/lib/Widget/Provider/DataProvider.php
+++ b/lib/Widget/Provider/DataProvider.php
@@ -1,8 +1,8 @@
 <?php
 /*
- * Copyright (c) 2023  Xibo Signage Ltd
+ * Copyright (C) 2023 Xibo Signage Ltd
  *
- * Xibo - Digital Signage - https://xibosignage.com
+ * Xibo - Digital Signage - http://www.xibo.org.uk
  *
  * This file is part of Xibo.
  *
@@ -18,7 +18,6 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
- *
  */
 
 namespace Xibo\Widget\Provider;
@@ -162,7 +161,14 @@ class DataProvider implements DataProviderInterface
         if ($this->properties === null) {
             $this->properties = $this->module->getPropertyValues(false);
         }
-        return $this->properties[$property] ?? $default;
+
+        $value = $this->properties[$property] ?? $default;
+        if (is_integer($default)) {
+            return intval($value);
+        } else if (is_numeric($value)) {
+            return doubleval($value);
+        }
+        return $value;
     }
 
     /**

--- a/lib/Widget/Provider/DataProvider.php
+++ b/lib/Widget/Provider/DataProvider.php
@@ -229,8 +229,12 @@ class DataProvider implements DataProviderInterface
     /**
      * @inheritDoc
      */
-    public function addOrUpdateMeta(string $key, \JsonSerializable $item): DataProviderInterface
+    public function addOrUpdateMeta(string $key, $item): DataProviderInterface
     {
+        if (!is_array($item) && !($item instanceof \JsonSerializable)) {
+            throw new \RuntimeException('Item must be an array or a JSON serializable object');
+        }
+
         $this->meta[$key] = $item;
         return $this;
     }
@@ -241,6 +245,17 @@ class DataProvider implements DataProviderInterface
     public function addImage(string $id, string $url, int $expiresAt): string
     {
         $media = $this->mediaFactory->queueDownload($id, $url, $expiresAt);
+        $this->media[] = $media;
+
+        return '[[mediaId=' . $media->mediaId . ']]';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function addLibraryFile(int $mediaId): string
+    {
+        $media = $this->mediaFactory->getById($mediaId);
         $this->media[] = $media;
 
         return '[[mediaId=' . $media->mediaId . ']]';

--- a/lib/Widget/Provider/DataProvider.php
+++ b/lib/Widget/Provider/DataProvider.php
@@ -1,8 +1,8 @@
 <?php
 /*
- * Copyright (C) 2022 Xibo Signage Ltd
+ * Copyright (c) 2023  Xibo Signage Ltd
  *
- * Xibo - Digital Signage - http://www.xibo.org.uk
+ * Xibo - Digital Signage - https://xibosignage.com
  *
  * This file is part of Xibo.
  *
@@ -18,6 +18,7 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 
 namespace Xibo\Widget\Provider;
@@ -47,11 +48,17 @@ class DataProvider implements DataProviderInterface
     /** @var array the data */
     private $data = [];
 
+    /** @var array the metadata */
+    private $meta = [];
+
     /** @var \Xibo\Entity\Media[] */
     private $media = [];
 
     /** @var int the cache ttl in seconds - default to 7 days */
     private $cacheTtl = 86400 * 7;
+
+    /** @var int the displayId */
+    private $displayId = 0;
 
     /** @var float the display latitude */
     private $latitude;
@@ -82,16 +89,18 @@ class DataProvider implements DataProviderInterface
     }
 
     /**
-     * Set the latitue and longitude for this data provider.
+     * Set the latitude and longitude for this data provider.
      *  This is primary used if a widget is display specific
      * @param $latitude
      * @param $longitude
+     * @param int $displayId
      * @return \Xibo\Widget\Provider\DataProviderInterface
      */
-    public function setDisplayProperties($latitude, $longitude): DataProviderInterface
+    public function setDisplayProperties($latitude, $longitude, int $displayId = 0): DataProviderInterface
     {
         $this->latitude = $latitude;
         $this->longitude = $longitude;
+        $this->displayId = $displayId;
         return $this;
     }
 
@@ -119,6 +128,14 @@ class DataProvider implements DataProviderInterface
     public function getDataType(): string
     {
         return $this->module->dataType;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getDisplayId(): int
+    {
+        return $this->displayId ?? 0;
     }
 
     /**
@@ -176,6 +193,14 @@ class DataProvider implements DataProviderInterface
     /**
      * @inheritDoc
      */
+    public function getMeta(): array
+    {
+        return $this->meta;
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function addItem($item): DataProviderInterface
     {
         if (!is_array($item) && !is_object($item)) {
@@ -204,6 +229,15 @@ class DataProvider implements DataProviderInterface
     /**
      * @inheritDoc
      */
+    public function addOrUpdateMeta(string $key, \JsonSerializable $item): DataProviderInterface
+    {
+        $this->meta[$key] = $item;
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function addImage(string $id, string $url, int $expiresAt): string
     {
         $media = $this->mediaFactory->queueDownload($id, $url, $expiresAt);
@@ -226,6 +260,15 @@ class DataProvider implements DataProviderInterface
     public function clearData(): DataProviderInterface
     {
         $this->data = [];
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function clearMeta(): DataProviderInterface
+    {
+        $this->meta = [];
         return $this;
     }
 

--- a/lib/Widget/Provider/DataProviderInterface.php
+++ b/lib/Widget/Provider/DataProviderInterface.php
@@ -1,8 +1,8 @@
 <?php
 /*
- * Copyright (C) 2022 Xibo Signage Ltd
+ * Copyright (c) 2023  Xibo Signage Ltd
  *
- * Xibo - Digital Signage - http://www.xibo.org.uk
+ * Xibo - Digital Signage - https://xibosignage.com
  *
  * This file is part of Xibo.
  *
@@ -18,6 +18,7 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 
 namespace Xibo\Widget\Provider;
@@ -47,6 +48,12 @@ interface DataProviderInterface
      * @return string
      */
     public function getDataType(): string;
+
+    /**
+     * Get the ID for this display
+     * @return int
+     */
+    public function getDisplayId(): int;
 
     /**
      * Get the latitude for this display
@@ -107,6 +114,12 @@ interface DataProviderInterface
     public function getData(): array;
 
     /**
+     * Get metadata already added to this provider
+     * @return array
+     */
+    public function getMeta(): array;
+
+    /**
      * Add an item to the provider
      * You should ensure that you provide all properties required by the datatype you are returning
      * example data types would be: article, social, event, menu, tabular
@@ -125,6 +138,15 @@ interface DataProviderInterface
     public function addItems(array $items): DataProviderInterface;
 
     /**
+     * Add metadata to the provider
+     * This is a key/value array of metadata which should be delivered alongside the data
+     * @param string $key
+     * @param \JsonSerializable $item An array containing the metadata, which must be JSON serializable
+     * @return \Xibo\Widget\Provider\DataProviderInterface
+     */
+    public function addOrUpdateMeta(string $key, \JsonSerializable $item): DataProviderInterface;
+
+    /**
      * Add an image to the data provider and return the URL for that image
      * @param string $id A unique ID for this image, we recommend adding a module/connector specific prefix
      * @param string $url The URL on which this image should be downloaded
@@ -139,6 +161,12 @@ interface DataProviderInterface
      * @return \Xibo\Widget\Provider\DataProviderInterface
      */
     public function clearData(): DataProviderInterface;
+
+    /**
+     * Clear any metadata already added to this provider
+     * @return \Xibo\Widget\Provider\DataProviderInterface
+     */
+    public function clearMeta(): DataProviderInterface;
 
     /**
      * Set the cache TTL

--- a/lib/Widget/Provider/DataProviderInterface.php
+++ b/lib/Widget/Provider/DataProviderInterface.php
@@ -141,10 +141,10 @@ interface DataProviderInterface
      * Add metadata to the provider
      * This is a key/value array of metadata which should be delivered alongside the data
      * @param string $key
-     * @param \JsonSerializable $item An array containing the metadata, which must be JSON serializable
+     * @param mixed $item An array/object containing the metadata, which must be JSON serializable
      * @return \Xibo\Widget\Provider\DataProviderInterface
      */
-    public function addOrUpdateMeta(string $key, \JsonSerializable $item): DataProviderInterface;
+    public function addOrUpdateMeta(string $key, $item): DataProviderInterface;
 
     /**
      * Add an image to the data provider and return the URL for that image
@@ -155,6 +155,14 @@ interface DataProviderInterface
      * @throws \Xibo\Support\Exception\GeneralException
      */
     public function addImage(string $id, string $url, int $expiresAt): string;
+
+    /**
+     * Add a library file
+     * @param int $mediaId The mediaId for this file.
+     * @return string
+     * @throws \Xibo\Support\Exception\GeneralException
+     */
+    public function addLibraryFile(int $mediaId): string;
 
     /**
      * Clear any data already added to this provider

--- a/lib/Widget/Provider/WidgetProviderInterface.php
+++ b/lib/Widget/Provider/WidgetProviderInterface.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2022 Xibo Signage Ltd
+ * Copyright (C) 2023 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - http://www.xibo.org.uk
  *
@@ -23,6 +23,7 @@
 namespace Xibo\Widget\Provider;
 
 use Psr\Log\LoggerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * The Widget Provider Interface should be implemented by any Widget which specifies a `class` in its Module
@@ -37,6 +38,19 @@ interface WidgetProviderInterface
 {
     public function getLog(): LoggerInterface;
     public function setLog(LoggerInterface $logger): WidgetProviderInterface;
+
+    /**
+     * Get the event dispatcher
+     * @return \Symfony\Component\EventDispatcher\EventDispatcherInterface
+     */
+    public function getDispatcher(): EventDispatcherInterface;
+
+    /**
+     * Set the event dispatcher
+     * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $logger
+     * @return \Xibo\Widget\Provider\WidgetProviderInterface
+     */
+    public function setDispatcher(EventDispatcherInterface $logger): WidgetProviderInterface;
 
     /**
      * Fetch data

--- a/lib/Widget/Provider/WidgetProviderTrait.php
+++ b/lib/Widget/Provider/WidgetProviderTrait.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2022 Xibo Signage Ltd
+ * Copyright (C) 2023 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - http://www.xibo.org.uk
  *
@@ -24,6 +24,8 @@ namespace Xibo\Widget\Provider;
 
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * A trait to set common objects on a Widget Provider Interface
@@ -31,6 +33,7 @@ use Psr\Log\NullLogger;
 trait WidgetProviderTrait
 {
     private $log;
+    private $dispatcher;
 
     public function getLog(): LoggerInterface
     {
@@ -43,6 +46,22 @@ trait WidgetProviderTrait
     public function setLog(LoggerInterface $logger): WidgetProviderInterface
     {
         $this->log = $logger;
+        return $this;
+    }
+
+    /** @inheritDoc */
+    public function getDispatcher(): EventDispatcherInterface
+    {
+        if ($this->dispatcher === null) {
+            $this->dispatcher = new EventDispatcher();
+        }
+        return $this->dispatcher;
+    }
+
+    /** @inheritDoc */
+    public function setDispatcher(EventDispatcherInterface $dispatcher): WidgetProviderInterface
+    {
+        $this->dispatcher = $dispatcher;
         return $this;
     }
 }

--- a/lib/Widget/Render/WidgetDataProviderCache.php
+++ b/lib/Widget/Render/WidgetDataProviderCache.php
@@ -1,8 +1,8 @@
 <?php
 /*
- * Copyright (c) 2023  Xibo Signage Ltd
+ * Copyright (C) 2023 Xibo Signage Ltd
  *
- * Xibo - Digital Signage - https://xibosignage.com
+ * Xibo - Digital Signage - http://www.xibo.org.uk
  *
  * This file is part of Xibo.
  *
@@ -18,7 +18,6 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
- *
  */
 
 namespace Xibo\Widget\Render;
@@ -152,9 +151,9 @@ class WidgetDataProviderCache
         foreach ($data as $item) {
             // This is either an object or an array
             if (is_array($item)) {
-                for ($i = 0; $i < count($item); $i++) {
-                    if (is_string($item[$i])) {
-                        $item[$i] = $this->decorateMediaForPreview($libraryUrl, $item[$i]);
+                foreach ($item as $key => $value) {
+                    if (is_string($value)) {
+                        $item[$key] = $this->decorateMediaForPreview($libraryUrl, $value);
                     }
                 }
             } else if (is_object($item)) {

--- a/lib/Widget/Render/WidgetDataProviderCache.php
+++ b/lib/Widget/Render/WidgetDataProviderCache.php
@@ -1,8 +1,8 @@
 <?php
 /*
- * Copyright (C) 2022 Xibo Signage Ltd
+ * Copyright (c) 2023  Xibo Signage Ltd
  *
- * Xibo - Digital Signage - http://www.xibo.org.uk
+ * Xibo - Digital Signage - https://xibosignage.com
  *
  * This file is part of Xibo.
  *
@@ -18,6 +18,7 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 
 namespace Xibo\Widget\Render;
@@ -99,7 +100,12 @@ class WidgetDataProviderCache
             return false;
         } else {
             $dataProvider->clearData();
-            $dataProvider->addItems($data);
+            $dataProvider->clearMeta();
+            $dataProvider->addItems($data['data'] ?? []);
+
+            foreach (($data['meta'] ?? []) as $key => $item) {
+                $dataProvider->addOrUpdateMeta($key, $item);
+            }
             return true;
         }
     }
@@ -115,7 +121,10 @@ class WidgetDataProviderCache
         }
 
         // Set our cache from the data provider.
-        $this->cache->set($dataProvider->getData());
+        $this->cache->set([
+            'data' => $dataProvider->getData(),
+            'meta' => $dataProvider->getMeta(),
+        ]);
         $this->cache->expiresAfter($dataProvider->getCacheTtl());
 
         // Save to the pool

--- a/lib/XTR/WidgetSyncTask.php
+++ b/lib/XTR/WidgetSyncTask.php
@@ -1,8 +1,8 @@
 <?php
 /*
- * Copyright (c) 2023  Xibo Signage Ltd
+ * Copyright (C) 2023 Xibo Signage Ltd
  *
- * Xibo - Digital Signage - https://xibosignage.com
+ * Xibo - Digital Signage - http://www.xibo.org.uk
  *
  * This file is part of Xibo.
  *
@@ -18,7 +18,6 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
- *
  */
 
 namespace Xibo\XTR;
@@ -96,7 +95,7 @@ class WidgetSyncTask implements TaskInterface
                 $widget->load();
 
                 $module = $this->moduleFactory->getByType($widget->type);
-                if ($module->isDataProviderExpected()) {
+                if ($module->isDataProviderExpected() || $module->isWidgetProviderAvailable()) {
                     // Record start time
                     $countWidgets++;
                     $startTime = microtime(true);

--- a/lib/XTR/WidgetSyncTask.php
+++ b/lib/XTR/WidgetSyncTask.php
@@ -1,8 +1,8 @@
 <?php
 /*
- * Copyright (C) 2022 Xibo Signage Ltd
+ * Copyright (c) 2023  Xibo Signage Ltd
  *
- * Xibo - Digital Signage - http://www.xibo.org.uk
+ * Xibo - Digital Signage - https://xibosignage.com
  *
  * This file is part of Xibo.
  *
@@ -18,6 +18,7 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 
 namespace Xibo\XTR;
@@ -182,7 +183,7 @@ class WidgetSyncTask implements TaskInterface
         // Set our provider up for the displays
         if ($displayId !== null) {
             $display = $this->displayFactory->getById($displayId);
-            $dataProvider->setDisplayProperties($display->latitude, $display->longitude);
+            $dataProvider->setDisplayProperties($display->latitude, $display->longitude, $displayId);
         } else {
             $dataProvider->setDisplayProperties(
                 $this->getConfig()->getSetting('DEFAULT_LAT'),

--- a/lib/Xmds/Soap.php
+++ b/lib/Xmds/Soap.php
@@ -1,8 +1,8 @@
 <?php
 /*
- * Copyright (C) 2023 Xibo Signage Ltd
+ * Copyright (c) 2023  Xibo Signage Ltd
  *
- * Xibo - Digital Signage - http://www.xibo.org.uk
+ * Xibo - Digital Signage - https://xibosignage.com
  *
  * This file is part of Xibo.
  *
@@ -18,6 +18,7 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 
 namespace Xibo\Xmds;
@@ -2260,7 +2261,10 @@ class Soap
                                 . ', e: ' . $exception->getMessage());
                         }
 
-                        $data[$widget->widgetId] = $dataProvider->getData();
+                        $data[$widget->widgetId] = [
+                            'data' => $data,
+                            'meta' => $dataProvider->getMeta()
+                        ];
                     }
                 }
             }

--- a/lib/Xmds/Soap.php
+++ b/lib/Xmds/Soap.php
@@ -1,8 +1,8 @@
 <?php
 /*
- * Copyright (c) 2023  Xibo Signage Ltd
+ * Copyright (C) 2023 Xibo Signage Ltd
  *
- * Xibo - Digital Signage - https://xibosignage.com
+ * Xibo - Digital Signage - http://www.xibo.org.uk
  *
  * This file is part of Xibo.
  *
@@ -18,7 +18,6 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
- *
  */
 
 namespace Xibo\Xmds;
@@ -2235,7 +2234,7 @@ class Soap
             if (!$isSupportsDataUrl) {
                 foreach ($widgets as $widget) {
                     $dataModule = $this->moduleFactory->getByType($widget->type);
-                    if ($dataModule->isDataProviderExpected()) {
+                    if ($dataModule->isDataProviderExpected() || $dataModule->isWidgetProviderAvailable()) {
                         // We only ever return cache.
                         $dataProvider = $module->createDataProvider($widget);
 

--- a/lib/Xmds/Soap7.php
+++ b/lib/Xmds/Soap7.php
@@ -1,8 +1,8 @@
 <?php
 /*
- * Copyright (C) 2022 Xibo Signage Ltd
+ * Copyright (c) 2023  Xibo Signage Ltd
  *
- * Xibo - Digital Signage - http://www.xibo.org.uk
+ * Xibo - Digital Signage - https://xibosignage.com
  *
  * This file is part of Xibo.
  *
@@ -18,6 +18,7 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 
 namespace Xibo\Xmds;
@@ -221,16 +222,17 @@ class Soap7 extends Soap6
                         $media[$row['mediaId']] = $row['storedAs'];
                     };
 
-                    $data = $widgetDataProviderCache->decorateForPlayer($dataProvider->getData(), $media);
+                    $resource = json_encode([
+                        'data' => $widgetDataProviderCache->decorateForPlayer($dataProvider->getData(), $media),
+                        'meta' => $dataProvider->getMeta(),
+                    ]);
                 } catch (GeneralException $exception) {
                     // We ignore this.
                     $this->getLog()->debug('Failed to get data cache for widgetId ' . $widget->widgetId);
-                    $data = [];
+                    $resource = '{"data":[], "meta": {}}';
                 }
-
-                $resource = json_encode($data);
             } else {
-                $resource = '{}';
+                $resource = '{"data":[], "meta": {}}';
             }
 
             // Log bandwidth


### PR DESCRIPTION
This is still a work in progress which needs testing.
xibosignageltd/xibo-private#95

A listener has been implemented to serve DataSet data from the core software instead of a Connector, which is called from a Widget Provider. This should allow reuse of that data across multiple widgets. A connector didn't seem appropriate as the dataset is internal to Xibo - so we aren't connecting to a third party to retrieve it.

The Widget Provider uses an event to request this data so that it is not polluted with factories the developer shouldn't have access to.

A breaking change to the data output structure has been implemented. Previously calls to getData and the `json` file served to players contained an array of data points.

```json
[]
```

Now it will be enveloped:

```json
{
  "data": [],
  "meta": {}
}
```

This was done so that we have a more extensible model, and in particular for datasets, we're able to output the header mappings.