### PR TITLE
XMDS: submit stats shouldn't error if the ad campaign isn't found

### DIFF
--- a/lib/Xmds/Soap.php
+++ b/lib/Xmds/Soap.php
@@ -1747,15 +1747,21 @@ class Soap
             // Cache a count for this scheduleId
             $parentCampaignId = 0;
             $parentCampaign = null;
+            $deletedScheduleIds = [];
             $deletedCampaignIds = [];
 
-            if ($scheduleId > 0) {
-                // Lookup this schedule
-                if (!array_key_exists($scheduleId, $schedules)) {
-                    // Look up the campaign.
-                    $schedules[$scheduleId] = $this->scheduleFactory->getById($scheduleId);
+            if ($scheduleId > 0 && !in_array($scheduleId, $deletedScheduleIds)) {
+                try {
+                    // Lookup this schedule
+                    if (!array_key_exists($scheduleId, $schedules)) {
+                        // Look up the campaign.
+                        $schedules[$scheduleId] = $this->scheduleFactory->getById($scheduleId);
+                    }
+                    $parentCampaignId = $schedules[$scheduleId]->parentCampaignId ?? 0;
+                } catch (NotFoundException $notFoundException) {
+                    $this->getLog()->error('Schedule with ID ' . $scheduleId . ' no-longer exists');
+                    $deletedScheduleIds[] = $scheduleId;
                 }
-                $parentCampaignId = $schedules[$scheduleId]->parentCampaignId ?? 0;
 
                 // Does this event have a parent campaign?
                 if (!empty($parentCampaignId) && !in_array($parentCampaignId, $deletedCampaignIds)) {

--- a/lib/Xmds/Soap.php
+++ b/lib/Xmds/Soap.php
@@ -1567,9 +1567,11 @@ class Soap
         $widgetIdsNotFound = [];
         $memoryCache = [];
 
-        // Cache of scheduleIds and counts
+        // Cache of scheduleIds, counts and deleted entities
         $schedules = [];
         $campaigns = [];
+        $deletedScheduleIds = [];
+        $deletedCampaignIds = [];
 
         foreach ($document->documentElement->childNodes as $node) {
             /* @var \DOMElement $node */
@@ -1747,8 +1749,6 @@ class Soap
             // Cache a count for this scheduleId
             $parentCampaignId = 0;
             $parentCampaign = null;
-            $deletedScheduleIds = [];
-            $deletedCampaignIds = [];
 
             if ($scheduleId > 0 && !in_array($scheduleId, $deletedScheduleIds)) {
                 try {


### PR DESCRIPTION
This turned out to be a two-fold issue - the first being the campaign lookup, but before that the schedule look up. The final commit being where I had put the arrays to track deleted IDs inside the loop :facepalm: 

xibosignage/xibo#2989