### PR TITLE
Audience Connector Bug Fix: If a block of stats has nothing to send, progress next stat block

### DIFF
--- a/lib/Connector/XiboAudienceReportingConnector.php
+++ b/lib/Connector/XiboAudienceReportingConnector.php
@@ -404,7 +404,7 @@ class XiboAudienceReportingConnector implements ConnectorInterface
                         $body = $response->getBody()->getContents();
                         $json = json_decode($body, true);
                     } catch (RequestException $requestException) {
-                        $this->getLogger()->debug('Get '. $type.': failed. e = ' . $requestException->getMessage());
+                        $this->getLogger()->error('Get '. $type.': failed. e = ' . $requestException->getMessage());
                         $error = 'Failed to get campaign proofofplay result: '.$requestException->getMessage();
                     }
                     break;
@@ -422,7 +422,7 @@ class XiboAudienceReportingConnector implements ConnectorInterface
                         $body = $response->getBody()->getContents();
                         $json = json_decode($body, true);
                     } catch (RequestException $requestException) {
-                        $this->getLogger()->debug('Get '. $type.': failed. e = ' . $requestException->getMessage());
+                        $this->getLogger()->error('Get '. $type.': failed. e = ' . $requestException->getMessage());
                         $error = 'Failed to get mobile proofofplay result: '.$requestException->getMessage();
                     }
                     break;
@@ -440,7 +440,7 @@ class XiboAudienceReportingConnector implements ConnectorInterface
                         $body = $response->getBody()->getContents();
                         $json = json_decode($body, true);
                     } catch (RequestException $requestException) {
-                        $this->getLogger()->debug('Get '. $type.': failed. e = ' . $requestException->getMessage());
+                        $this->getLogger()->error('Get '. $type.': failed. e = ' . $requestException->getMessage());
                         $error = 'Failed to get display adplays result: '.$requestException->getMessage();
                     }
                     break;
@@ -458,13 +458,13 @@ class XiboAudienceReportingConnector implements ConnectorInterface
                         $body = $response->getBody()->getContents();
                         $json = json_decode($body, true);
                     } catch (RequestException $requestException) {
-                        $this->getLogger()->debug('Get '. $type.': failed. e = ' . $requestException->getMessage());
+                        $this->getLogger()->error('Get '. $type.': failed. e = ' . $requestException->getMessage());
                         $error = 'Failed to get display played percentage result: '.$requestException->getMessage();
                     }
                     break;
 
                 default:
-                    $this->getLogger()->debug('Connector Report not found ');
+                    $this->getLogger()->error('Connector Report not found ');
             }
 
             $event->setResults([
@@ -598,7 +598,7 @@ class XiboAudienceReportingConnector implements ConnectorInterface
                 'recordsTotal' => count($body),
             ];
         } catch (\Exception $e) {
-            $this->getLogger()->debug('activity: e = ' . $e->getMessage());
+            $this->getLogger()->error('activity: e = ' . $e->getMessage());
         }
 
         return [
@@ -797,7 +797,7 @@ class XiboAudienceReportingConnector implements ConnectorInterface
                 ]
             ]);
         } catch (\Exception $e) {
-            $this->getLogger()->debug('Exception updating Displays for dmaId: ' . $dmaId
+            $this->getLogger()->error('Exception updating Displays for dmaId: ' . $dmaId
                 . ', e: ' . $e->getMessage());
         }
     }
@@ -843,7 +843,7 @@ class XiboAudienceReportingConnector implements ConnectorInterface
                 throw new InvalidArgumentException(__('Invalid request'));
             }
         } elseif ($exception instanceof ServerException) {
-            $this->getLogger()->debug('handleException:' . $exception->getMessage());
+            $this->getLogger()->error('handleException:' . $exception->getMessage());
             throw new GeneralException(__('There was a problem processing your request, please try again'));
         } else {
             throw new GeneralException(__('Unknown Error'));

--- a/lib/Connector/XiboAudienceReportingConnector.php
+++ b/lib/Connector/XiboAudienceReportingConnector.php
@@ -171,183 +171,197 @@ class XiboAudienceReportingConnector implements ConnectorInterface
             $json = json_decode($body, true);
             $watermark = $json['watermark'];
 
-            $params =   [
-                'type' => 'layout',
-                'start' => 0,
-                'length' => 5000,
-                'mustHaveParentCampaign' => true
-            ];
+            // If a block of stats could not be processed then do a while loop until we save a watermark
+            // This would mean we are progressing
+            $skip = 0;
+            $length = 5000;
+            $requireSendingStat = true;
+            while ($requireSendingStat) {
+                $params =   [
+                    'type' => 'layout',
+                    'start' => $skip,
+                    'length' => $length,
+                    'mustHaveParentCampaign' => true
+                ];
 
-            if (!empty($watermark)) {
-                $params['statId'] = $watermark;
-            }
-
-            // Call the time series interface getStats
-            $resultSet = $this->timeSeriesStore->getStats($params);
-
-            // Array of campaigns for which we will update the total spend, impresssions, and plays
-            $campaigns = [];
-            $adCampaignCache = [];
-            $listCampaignCache = [];
-            $displayCache = [];
-            $erroredCampaign = [];
-
-            $rows = [];
-            while ($row = $resultSet->getNextRow()) {
-                $sanitizedRow = $this->sanitizer->getSanitizer($row);
-
-                $parentCampaignId = $sanitizedRow->getInt('parentCampaignId', ['default' => 0]);
-                $displayId = $sanitizedRow->getInt(('displayId'));
-
-                if (empty($parentCampaignId) || empty($displayId) || array_key_exists($parentCampaignId, $erroredCampaign)) {
-                    continue;
+                if (!empty($watermark)) {
+                    $params['statId'] = $watermark;
                 }
 
-                if (array_key_exists($parentCampaignId, $listCampaignCache)) {
-                    $this->getLogger()->debug('onRegularMaintenance: Campaign is a list campaign ' . $parentCampaignId);
-                    continue;
-                }
+                // Call the time series interface getStats
+                $resultSet = $this->timeSeriesStore->getStats($params);
 
-                $entry['parentCampaignId'] = $parentCampaignId;
+                // Array of campaigns for which we will update the total spend, impresssions, and plays
+                $campaigns = [];
+                $adCampaignCache = [];
+                $listCampaignCache = [];
+                $displayCache = [];
+                $erroredCampaign = [];
+                $rows = [];
+                while ($row = $resultSet->getNextRow()) {
+                    $sanitizedRow = $this->sanitizer->getSanitizer($row);
 
-                // Stat id
-                $entry['id'] = $resultSet->getIdFromRow($row);
+                    $parentCampaignId = $sanitizedRow->getInt('parentCampaignId', ['default' => 0]);
+                    $displayId = $sanitizedRow->getInt(('displayId'));
 
-                // --------
-                // Get Campaign
-                // Campaign start and end date
-                if (array_key_exists($parentCampaignId, $adCampaignCache)) {
-                    $entry['campaignStart'] = $adCampaignCache[$parentCampaignId]['start'];
-                    $entry['campaignEnd'] = $adCampaignCache[$parentCampaignId]['end'];
-                } else {
-                    // Get Campaign
-                    try {
-                        $parentCampaign = $this->campaignFactory->getById($parentCampaignId);
-
-                        if ($parentCampaign->type == 'ad') {
-                            $adCampaignCache[$parentCampaignId]['type'] = $parentCampaign->type;
-                        } else {
-                            $listCampaignCache[$parentCampaignId] = $parentCampaignId;
-                            continue;
-                        }
-
-                        if (!empty($parentCampaign->getStartDt()) && !empty($parentCampaign->getEndDt())) {
-                            $adCampaignCache[$parentCampaignId]['start'] =  $parentCampaign->getStartDt()->format(DateFormatHelper::getSystemFormat());
-                            $adCampaignCache[$parentCampaignId]['end'] = $parentCampaign->getEndDt()->format(DateFormatHelper::getSystemFormat());
-                            $entry['campaignStart'] = $adCampaignCache[$parentCampaignId]['start'];
-                            $entry['campaignEnd'] = $adCampaignCache[$parentCampaignId]['end'];
-                        }
-                    } catch (\Exception $exception) {
-                        $erroredCampaign[$parentCampaignId] = $entry['id']; // first stat id
+                    if (empty($parentCampaignId) || empty($displayId) || array_key_exists($parentCampaignId, $erroredCampaign)) {
                         continue;
                     }
-                }
 
-                // --------
-                // Get Display
-                // Cost per play and impressions per play
-                $entry['displayId'] = $displayId;
-                if (array_key_exists($displayId, $displayCache)) {
-                    $entry['costPerPlay'] = $displayCache[$displayId]['costPerPlay'];
-                    $entry['impressionsPerPlay'] = $displayCache[$displayId]['impressionsPerPlay'];
-                } else {
-                    $display = $this->displayFactory->getById($displayId);
-                    $displayCache[$displayId]['costPerPlay'] =  $display->costPerPlay;
-                    $displayCache[$displayId]['impressionsPerPlay'] = $display->impressionsPerPlay;
-                    $entry['costPerPlay'] = $displayCache[$displayId]['costPerPlay'];
-                    $entry['impressionsPerPlay'] = $displayCache[$displayId]['impressionsPerPlay'];
-                }
-
-                try {
-                    if ($this->timeSeriesStore->getEngine() == 'mongodb') {
-                        $start = Carbon::createFromTimestamp($row['start']->toDateTime()->format('U'))->format(DateFormatHelper::getSystemFormat());
-                        $end = Carbon::createFromTimestamp($row['end']->toDateTime()->format('U'))->format(DateFormatHelper::getSystemFormat());
-                    } else {
-                        $start = Carbon::createFromTimestamp($row['start'])->format(DateFormatHelper::getSystemFormat());
-                        $end = Carbon::createFromTimestamp($row['end'])->format(DateFormatHelper::getSystemFormat());
+                    if (array_key_exists($parentCampaignId, $listCampaignCache)) {
+                        $this->getLogger()->debug('onRegularMaintenance: Campaign is a list campaign ' . $parentCampaignId);
+                        continue;
                     }
-                } catch (\Exception $exception) {
-                    $this->getLogger()->error('onRegularMaintenance: Date convert failed ' . $exception->getMessage());
-                    continue;
-                }
 
-                $entry['layoutId'] = $sanitizedRow->getInt('layoutId', ['default' => 0]);
-                $entry['numberPlays'] = $sanitizedRow->getInt('count', ['default' => 0]);
-                $entry['duration'] = $sanitizedRow->getInt('duration', ['default' => 0]);
-                $entry['start'] = $start;
-                $entry['end'] = $end;
-                $entry['engagements'] = $resultSet->getEngagementsFromRow($row);
+                    $entry['parentCampaignId'] = $parentCampaignId;
 
-                $rows[] = $entry;
+                    // Stat id
+                    $entry['id'] = $resultSet->getIdFromRow($row);
 
-                // Campaign list in array
-                if (!in_array($parentCampaignId, $campaigns)) {
-                    $campaigns[] = $parentCampaignId;
-                }
-            }
+                    // --------
+                    // Get Campaign
+                    // Campaign start and end date
+                    if (array_key_exists($parentCampaignId, $adCampaignCache)) {
+                        $entry['campaignStart'] = $adCampaignCache[$parentCampaignId]['start'];
+                        $entry['campaignEnd'] = $adCampaignCache[$parentCampaignId]['end'];
+                    } else {
+                        // Get Campaign
+                        try {
+                            $parentCampaign = $this->campaignFactory->getById($parentCampaignId);
 
-            if (count($erroredCampaign) > 0) {
-                $event->addMessage(__('Error caching ad/list campaign:') . ' CampaignId/StatId:' . json_encode($erroredCampaign));
-                $this->getLogger()->error('onRegularMaintenance: caching ad/list campaign failed for StatId: ' .
-                    ' Errored CampaignId/StatId:' . json_encode($erroredCampaign));
-            }
+                            if ($parentCampaign->type == 'ad') {
+                                $adCampaignCache[$parentCampaignId]['type'] = $parentCampaign->type;
+                            } else {
+                                $listCampaignCache[$parentCampaignId] = $parentCampaignId;
+                                continue;
+                            }
 
-            $this->getLogger()->debug('onRegularMaintenance: Records sent: ' . count($rows) . ', Watermark: ' . $watermark);
-            $this->getLogger()->debug('onRegularMaintenance: Campaigns: ' . json_encode($campaigns));
+                            if (!empty($parentCampaign->getStartDt()) && !empty($parentCampaign->getEndDt())) {
+                                $adCampaignCache[$parentCampaignId]['start'] =  $parentCampaign->getStartDt()->format(DateFormatHelper::getSystemFormat());
+                                $adCampaignCache[$parentCampaignId]['end'] = $parentCampaign->getEndDt()->format(DateFormatHelper::getSystemFormat());
+                                $entry['campaignStart'] = $adCampaignCache[$parentCampaignId]['start'];
+                                $entry['campaignEnd'] = $adCampaignCache[$parentCampaignId]['end'];
+                            }
+                        } catch (\Exception $exception) {
+                            $erroredCampaign[$parentCampaignId] = $entry['id']; // first stat id
+                            continue;
+                        }
+                    }
 
-            $statusCode = 0;
-            if (count($rows) > 0) {
-                try {
-                    $response = $this->getClient()->post($this->getServiceUrl() . '/audience/receiveStats', [
-                        'timeout' => 300, // 5 minutes
-                        'headers' => [
-                            'X-API-KEY' => $this->getSetting('apiKey')
-                        ],
-                        'json' => $rows
-                    ]);
-
-                    $statusCode = $response->getStatusCode();
-                } catch (RequestException $requestException) {
-                    $event->addMessage(__('Error calling audience receiveStats'. $requestException->getMessage()));
-                    $this->getLogger()->error('Audience receiveStats: failed e = ' . $requestException->getMessage());
-                }
-
-                $this->getLogger()->debug('onRegularMaintenance: Receive Stats StatusCode: ' . $statusCode);
-
-                // Get Campaign Total
-                if ($statusCode == 204) {
-                    $this->getLogger()->debug('onRegularMaintenance: Get Campaign Total');
+                    // --------
+                    // Get Display
+                    // Cost per play and impressions per play
+                    $entry['displayId'] = $displayId;
+                    if (array_key_exists($displayId, $displayCache)) {
+                        $entry['costPerPlay'] = $displayCache[$displayId]['costPerPlay'];
+                        $entry['impressionsPerPlay'] = $displayCache[$displayId]['impressionsPerPlay'];
+                    } else {
+                        $display = $this->displayFactory->getById($displayId);
+                        $displayCache[$displayId]['costPerPlay'] =  $display->costPerPlay;
+                        $displayCache[$displayId]['impressionsPerPlay'] = $display->impressionsPerPlay;
+                        $entry['costPerPlay'] = $displayCache[$displayId]['costPerPlay'];
+                        $entry['impressionsPerPlay'] = $displayCache[$displayId]['impressionsPerPlay'];
+                    }
 
                     try {
-                        $response = $this->getClient()->get($this->getServiceUrl() . '/audience/campaignTotal', [
+                        if ($this->timeSeriesStore->getEngine() == 'mongodb') {
+                            $start = Carbon::createFromTimestamp($row['start']->toDateTime()->format('U'))->format(DateFormatHelper::getSystemFormat());
+                            $end = Carbon::createFromTimestamp($row['end']->toDateTime()->format('U'))->format(DateFormatHelper::getSystemFormat());
+                        } else {
+                            $start = Carbon::createFromTimestamp($row['start'])->format(DateFormatHelper::getSystemFormat());
+                            $end = Carbon::createFromTimestamp($row['end'])->format(DateFormatHelper::getSystemFormat());
+                        }
+                    } catch (\Exception $exception) {
+                        $this->getLogger()->error('onRegularMaintenance: Date convert failed ' . $exception->getMessage());
+                        continue;
+                    }
+
+                    $entry['layoutId'] = $sanitizedRow->getInt('layoutId', ['default' => 0]);
+                    $entry['numberPlays'] = $sanitizedRow->getInt('count', ['default' => 0]);
+                    $entry['duration'] = $sanitizedRow->getInt('duration', ['default' => 0]);
+                    $entry['start'] = $start;
+                    $entry['end'] = $end;
+                    $entry['engagements'] = $resultSet->getEngagementsFromRow($row);
+
+                    $rows[] = $entry;
+
+                    // Campaign list in array
+                    if (!in_array($parentCampaignId, $campaigns)) {
+                        $campaigns[] = $parentCampaignId;
+                    }
+                }
+
+                if (count($erroredCampaign) > 0) {
+                    $event->addMessage(__('Error caching ad/list campaign:') . ' CampaignId/StatId:' . json_encode($erroredCampaign));
+                    $this->getLogger()->error('onRegularMaintenance: caching ad/list campaign failed for StatId: ' .
+                        ' Errored CampaignId/StatId:' . json_encode($erroredCampaign));
+                }
+
+                $this->getLogger()->debug('onRegularMaintenance: Records sent: ' . count($rows) . ', Watermark: ' . $watermark);
+                $this->getLogger()->debug('onRegularMaintenance: Campaigns: ' . json_encode($campaigns));
+
+                $statusCode = 0;
+                if (count($rows) > 0) {
+                    try {
+                        $response = $this->getClient()->post($this->getServiceUrl() . '/audience/receiveStats', [
+                            'timeout' => 300, // 5 minutes
                             'headers' => [
                                 'X-API-KEY' => $this->getSetting('apiKey')
                             ],
-                            'query' => [
-                                'campaigns' => $campaigns
-                            ]
+                            'json' => $rows
                         ]);
 
-                        $body = $response->getBody()->getContents();
-                        $results = json_decode($body, true);
-                        $this->getLogger()->debug('onRegularMaintenance: Campaign Total Results: ' . json_encode($results));
-
-
-                        foreach ($results as $item) {
-                            // Save the total in the camapign
-                            $campaign = $this->campaignFactory->getById($item['id']);
-                            $this->getLogger()->debug('onRegularMaintenance: Campaign Id: ' . $item['id'] . ' Spend: ' . $campaign->spend . ' Impressions: ' . $campaign->impressions);
-
-                            $campaign->spend = $item['spend'];
-                            $campaign->impressions = $item['impressions'];
-
-                            $campaign->overwritePlays();
-                            $this->getLogger()->debug('onRegularMaintenance: Campaign Id: ' . $item['id'] . ' Spend(U): ' . $campaign->spend . ' Impressions(U): ' . $campaign->impressions);
-                        }
+                        $statusCode = $response->getStatusCode();
                     } catch (RequestException $requestException) {
-                        $event->addMessage(__('Error getting campaign total:'. $requestException->getMessage()));
-                        $this->getLogger()->error('Campaign total: e = ' . $requestException->getMessage());
+                        // if there is an error what should we do?
+                        // We log the error and stop
+                        // we will not send any more stats
+                        $requireSendingStat = false;
+                        $event->addMessage(__('Error calling audience receiveStats'. $requestException->getMessage()));
+                        $this->getLogger()->error('Audience receiveStats: failed e = ' . $requestException->getMessage());
                     }
+
+                    $this->getLogger()->debug('onRegularMaintenance: Receive Stats StatusCode: ' . $statusCode);
+
+                    // Get Campaign Total
+                    if ($statusCode == 204) {
+                        // We will not send any more stat in this run
+                        $requireSendingStat = false;
+                        $this->getLogger()->debug('onRegularMaintenance: Get Campaign Total');
+
+                        try {
+                            $response = $this->getClient()->get($this->getServiceUrl() . '/audience/campaignTotal', [
+                                'headers' => [
+                                    'X-API-KEY' => $this->getSetting('apiKey')
+                                ],
+                                'query' => [
+                                    'campaigns' => $campaigns
+                                ]
+                            ]);
+
+                            $body = $response->getBody()->getContents();
+                            $results = json_decode($body, true);
+                            $this->getLogger()->debug('onRegularMaintenance: Campaign Total Results: ' . json_encode($results));
+
+                            foreach ($results as $item) {
+                                // Save the total in the camapign
+                                $campaign = $this->campaignFactory->getById($item['id']);
+                                $this->getLogger()->debug('onRegularMaintenance: Campaign Id: ' . $item['id'] . ' Spend: ' . $campaign->spend . ' Impressions: ' . $campaign->impressions);
+
+                                $campaign->spend = $item['spend'];
+                                $campaign->impressions = $item['impressions'];
+
+                                $campaign->overwritePlays();
+                                $this->getLogger()->debug('onRegularMaintenance: Campaign Id: ' . $item['id'] . ' Spend(U): ' . $campaign->spend . ' Impressions(U): ' . $campaign->impressions);
+                            }
+                        } catch (RequestException $requestException) {
+                            $event->addMessage(__('Error getting campaign total:'. $requestException->getMessage()));
+                            $this->getLogger()->error('Campaign total: e = ' . $requestException->getMessage());
+                        }
+                    }
+                } else { // We send the next block
+                    $requireSendingStat = true;
+                    $skip = $skip + $length;
                 }
             }
         } catch (RequestException $requestException) {
@@ -390,7 +404,7 @@ class XiboAudienceReportingConnector implements ConnectorInterface
                         $body = $response->getBody()->getContents();
                         $json = json_decode($body, true);
                     } catch (RequestException $requestException) {
-                        $this->getLogger()->error('Get '. $type.': failed. e = ' . $requestException->getMessage());
+                        $this->getLogger()->debug('Get '. $type.': failed. e = ' . $requestException->getMessage());
                         $error = 'Failed to get campaign proofofplay result: '.$requestException->getMessage();
                     }
                     break;
@@ -408,7 +422,7 @@ class XiboAudienceReportingConnector implements ConnectorInterface
                         $body = $response->getBody()->getContents();
                         $json = json_decode($body, true);
                     } catch (RequestException $requestException) {
-                        $this->getLogger()->error('Get '. $type.': failed. e = ' . $requestException->getMessage());
+                        $this->getLogger()->debug('Get '. $type.': failed. e = ' . $requestException->getMessage());
                         $error = 'Failed to get mobile proofofplay result: '.$requestException->getMessage();
                     }
                     break;
@@ -426,7 +440,7 @@ class XiboAudienceReportingConnector implements ConnectorInterface
                         $body = $response->getBody()->getContents();
                         $json = json_decode($body, true);
                     } catch (RequestException $requestException) {
-                        $this->getLogger()->error('Get '. $type.': failed. e = ' . $requestException->getMessage());
+                        $this->getLogger()->debug('Get '. $type.': failed. e = ' . $requestException->getMessage());
                         $error = 'Failed to get display adplays result: '.$requestException->getMessage();
                     }
                     break;
@@ -444,13 +458,13 @@ class XiboAudienceReportingConnector implements ConnectorInterface
                         $body = $response->getBody()->getContents();
                         $json = json_decode($body, true);
                     } catch (RequestException $requestException) {
-                        $this->getLogger()->error('Get '. $type.': failed. e = ' . $requestException->getMessage());
+                        $this->getLogger()->debug('Get '. $type.': failed. e = ' . $requestException->getMessage());
                         $error = 'Failed to get display played percentage result: '.$requestException->getMessage();
                     }
                     break;
 
                 default:
-                    $this->getLogger()->error('Connector Report not found ');
+                    $this->getLogger()->debug('Connector Report not found ');
             }
 
             $event->setResults([
@@ -584,7 +598,7 @@ class XiboAudienceReportingConnector implements ConnectorInterface
                 'recordsTotal' => count($body),
             ];
         } catch (\Exception $e) {
-            $this->getLogger()->error('activity: e = ' . $e->getMessage());
+            $this->getLogger()->debug('activity: e = ' . $e->getMessage());
         }
 
         return [
@@ -783,7 +797,7 @@ class XiboAudienceReportingConnector implements ConnectorInterface
                 ]
             ]);
         } catch (\Exception $e) {
-            $this->getLogger()->error('Exception updating Displays for dmaId: ' . $dmaId
+            $this->getLogger()->debug('Exception updating Displays for dmaId: ' . $dmaId
                 . ', e: ' . $e->getMessage());
         }
     }
@@ -829,7 +843,7 @@ class XiboAudienceReportingConnector implements ConnectorInterface
                 throw new InvalidArgumentException(__('Invalid request'));
             }
         } elseif ($exception instanceof ServerException) {
-            $this->getLogger()->error('handleException:' . $exception->getMessage());
+            $this->getLogger()->debug('handleException:' . $exception->getMessage());
             throw new GeneralException(__('There was a problem processing your request, please try again'));
         } else {
             throw new GeneralException(__('Unknown Error'));


### PR DESCRIPTION
- When a block of 5000 stats, all are skipped, (never called the `receiveStats()`, watermark has not updated) we move to the next block of 5000 stats. This would mean we are progressing.
- When `receiveStats()` is successful (a watermark has been saved) we no longer process the next block

https://github.com/xibosignage/xibo/issues/2990