### PR TITLE
Connector Report/Receive Stat: Send the start/end date in the local time zone

### DIFF
--- a/lib/Controller/Stats.php
+++ b/lib/Controller/Stats.php
@@ -710,7 +710,7 @@ class Stats extends Base
         $toDt = $sanitizedParams->getDate('toDt');
         $displayId = $sanitizedParams->getInt('displayId');
         $tempFileName = $this->getConfig()->getSetting('LIBRARY_LOCATION') . 'temp/stats_' . Random::generateString();
-        $dateFormat = $sanitizedParams->getString('dateFormat'); // UTC/CMS local time
+        $dateFormat = $sanitizedParams->getCheckbox('dateFormat');
 
         // Do not filter by display if super admin and no display is selected
         // Super admin will be able to see stat records of deleted display, we will not filter by display later
@@ -786,7 +786,7 @@ class Stats extends Base
 
             // For MySQL, dates are already in CMS Local Time
             // For MongoDB, dates are in UTC
-            if ($dateFormat == 'utc') {
+            if ($dateFormat) {
                 if ($this->timeSeriesStore->getEngine() == 'mysql') {
                     $fromDt = $fromDt->setTimezone('UTC');
                     $toDt = $toDt->setTimezone('UTC');

--- a/lib/Controller/Stats.php
+++ b/lib/Controller/Stats.php
@@ -710,7 +710,7 @@ class Stats extends Base
         $toDt = $sanitizedParams->getDate('toDt');
         $displayId = $sanitizedParams->getInt('displayId');
         $tempFileName = $this->getConfig()->getSetting('LIBRARY_LOCATION') . 'temp/stats_' . Random::generateString();
-        $dateFormat = $sanitizedParams->getCheckbox('dateFormat');
+        $isOutputUtc = $sanitizedParams->getCheckbox('isOutputUtc');
 
         // Do not filter by display if super admin and no display is selected
         // Super admin will be able to see stat records of deleted display, we will not filter by display later
@@ -786,7 +786,7 @@ class Stats extends Base
 
             // For MySQL, dates are already in CMS Local Time
             // For MongoDB, dates are in UTC
-            if ($dateFormat) {
+            if ($isOutputUtc) {
                 if ($this->timeSeriesStore->getEngine() == 'mysql') {
                     $fromDt = $fromDt->setTimezone('UTC');
                     $toDt = $toDt->setTimezone('UTC');

--- a/views/statistics-form-export.twig
+++ b/views/statistics-form-export.twig
@@ -60,15 +60,8 @@
                 ] %}
                 {{ forms.dropdown("displayId", "single", title, "", null, "displayId", "display", "", "pagedSelect", "", "d", "", attributes) }}
 
-                {% set title %}{% trans "Date Format" %}{% endset %}
-                {% set helpText %}{% trans "Select a date format, either in UTC or in the local time of the CMS" %}{% endset %}
-                {% set utc %}{% trans "UTC" %}{% endset %}
-                {% set localcms %}{% trans "CMS local time" %}{% endset %}
-                {% set options = [
-                    { formatid: "utc", format: utc },
-                    { formatid: "localcms", format: localcms },
-                ] %}
-                {{ forms.dropdown("dateFormat", "single", title, "", options, "formatid", "format", helpText) }}
+                {% set title %}{% trans "Output dates as UTC? Leave unchecked for local CMS time." %}{% endset %}
+                {{ forms.checkbox("dateFormat", title, true) }}
 
                 <div id="totalStat"></div>
                 <div class="loading-overlay" style="display: none">

--- a/views/statistics-form-export.twig
+++ b/views/statistics-form-export.twig
@@ -61,7 +61,7 @@
                 {{ forms.dropdown("displayId", "single", title, "", null, "displayId", "display", "", "pagedSelect", "", "d", "", attributes) }}
 
                 {% set title %}{% trans "Output dates as UTC? Leave unchecked for local CMS time." %}{% endset %}
-                {{ forms.checkbox("dateFormat", title, true) }}
+                {{ forms.checkbox("isOutputUtc", title, true) }}
 
                 <div id="totalStat"></div>
                 <div class="loading-overlay" style="display: none">

--- a/views/statistics-form-export.twig
+++ b/views/statistics-form-export.twig
@@ -60,6 +60,16 @@
                 ] %}
                 {{ forms.dropdown("displayId", "single", title, "", null, "displayId", "display", "", "pagedSelect", "", "d", "", attributes) }}
 
+                {% set title %}{% trans "Date Format" %}{% endset %}
+                {% set helpText %}{% trans "Select a date format, either in UTC or in the local time of the CMS" %}{% endset %}
+                {% set utc %}{% trans "UTC" %}{% endset %}
+                {% set localcms %}{% trans "CMS local time" %}{% endset %}
+                {% set options = [
+                    { formatid: "utc", format: utc },
+                    { formatid: "localcms", format: localcms },
+                ] %}
+                {{ forms.dropdown("dateFormat", "single", title, "", options, "formatid", "format", helpText) }}
+
                 <div id="totalStat"></div>
                 <div class="loading-overlay" style="display: none">
                     <i class="fa fa-spinner fa-spin loading-icon"></i>


### PR DESCRIPTION
Audience Connector/Send Stat:

- Start/End dates are saved in UTC format in MongoDB
- Convert those dates to the display time zone if a timezone is set on the display, otherwise use the CMS time zone

Proof of play CSV export:
- allow users to select a date format (UTC/CMS local time) when exporting stats

 https://github.com/xibosignageltd/xibo-private/issues/114

