### PR TITLE
Widgets : Stocks use different endpoint for free and paid plan

### DIFF
--- a/lib/Widget/AlphaVantageBase.php
+++ b/lib/Widget/AlphaVantageBase.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (c) 2022 Xibo Signage Ltd
+ * Copyright (C) 2023 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - http://www.xibo.org.uk
  *
@@ -125,8 +125,9 @@ abstract class AlphaVantageBase extends ModuleWidget
      */
     protected function getStockQuote($symbol)
     {
+        $isPaidPlan = $this->getSetting('isPaidPlan', 0) == 1;
         try {
-            $cache = $this->getPool()->getItem($this->makeCacheKey(md5($symbol)));
+            $cache = $this->getPool()->getItem($this->makeCacheKey(md5($symbol . $isPaidPlan)));
             $cache->setInvalidationMethod(Invalidation::SLEEP, 5000, 15);
 
             $data = $cache->get();
@@ -141,7 +142,7 @@ abstract class AlphaVantageBase extends ModuleWidget
 
                 $request = $client->request('GET', 'https://www.alphavantage.co/query', $this->getConfig()->getGuzzleProxy([
                     'query' => [
-                        'function' => 'TIME_SERIES_DAILY',
+                        'function' => $isPaidPlan ? 'TIME_SERIES_DAILY' : 'TIME_SERIES_DAILY_ADJUSTED',
                         'symbol' => $symbol,
                         'apikey' => $this->getApiKey()
                     ]

--- a/lib/Widget/Stocks.php
+++ b/lib/Widget/Stocks.php
@@ -1,6 +1,6 @@
 <?php
-/**
- * Copyright (C) 2020 Xibo Signage Ltd
+/*
+ * Copyright (C) 2023 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - http://www.xibo.org.uk
  *
@@ -103,6 +103,7 @@ class Stocks extends AlphaVantageBase
     {
         $sanitizedParams = $this->getSanitizer($request->getParams());
         $apiKey = $sanitizedParams->getString('apiKey');
+        $isPaidPlan = $sanitizedParams->getCheckbox('isPaidPlan');
         $cachePeriod = $sanitizedParams->getInt('cachePeriod', ['default' => 14400]);
 
         if ($this->module->enabled != 0) {
@@ -114,6 +115,7 @@ class Stocks extends AlphaVantageBase
         }
 
         $this->module->settings['apiKey'] = $apiKey;
+        $this->module->settings['isPaidPlan'] = $isPaidPlan;
         $this->module->settings['cachePeriod'] = $cachePeriod;
 
         // Return an array of the processed settings.

--- a/modules/stocks-form-settings.twig
+++ b/modules/stocks-form-settings.twig
@@ -30,6 +30,10 @@
     {% set helpText %}{% trans "Enter your API Key from Alpha Advantage: https://www.alphavantage.co/support/#api-key." %}{% endset %}
     {{ forms.input("apiKey", title, module.getSetting("apiKey"), helpText) }}
 
+    {% set title %}{% trans "Paid plan?" %}{% endset %}
+    {% set helpText %}{% trans "Is the above key on a paid plan?" %}{% endset %}
+    {{ forms.checkbox("isPaidPlan", title, module.getSetting("isPaidPlan"), helpText) }}
+
     {% set title %}{% trans "Cache Period" %}{% endset %}
     {% set helpText %}{% trans "This module uses 3rd party data. Please enter the number of seconds you would like to cache results." %}{% endset %}
     {{ forms.input("cachePeriod", title, module.getSetting("cachePeriod", 3600), helpText) }}


### PR DESCRIPTION
- Stocks add isPaidPlan flag to Module settings
- Use different function in data query based on isPaidPlan flag

Data format is the same for both endpoints.

Fixes xibosignage/xibo#2995