### PR TITLE
Campaign start/end date should be in CMS timezone

### DIFF
--- a/lib/Entity/Campaign.php
+++ b/lib/Entity/Campaign.php
@@ -338,7 +338,7 @@ class Campaign implements \JsonSerializable
      */
     public function getStartDt()
     {
-        return $this->startDt == 0 ? null : Carbon::createFromFormat('U', $this->startDt);
+        return $this->startDt == 0 ? null : Carbon::createFromTimestamp($this->startDt);
     }
 
     /**
@@ -346,7 +346,7 @@ class Campaign implements \JsonSerializable
      */
     public function getEndDt()
     {
-        return $this->endDt == 0 ? null : Carbon::createFromFormat('U', $this->endDt);
+        return $this->endDt == 0 ? null : Carbon::createFromTimestamp( $this->endDt);
     }
 
     /**

--- a/lib/Entity/Campaign.php
+++ b/lib/Entity/Campaign.php
@@ -346,7 +346,7 @@ class Campaign implements \JsonSerializable
      */
     public function getEndDt()
     {
-        return $this->endDt == 0 ? null : Carbon::createFromTimestamp( $this->endDt);
+        return $this->endDt == 0 ? null : Carbon::createFromTimestamp($this->endDt);
     }
 
     /**


### PR DESCRIPTION
This is a fix for missing hours in the `campaign proof of play` report
- Audience Connector API should have a stat with the campaign start/end date in CMS timezone
- The "createFromFormat" function does not automatically use the CMS timezone, while the "createFromTimestamp" function does.

https://github.com/xibosignage/xibo/issues/3003
https://github.com/xibosignageltd/xibo-private/issues/114