### PR TITLE
Stocks Widget : Protect against unexpected data results

### DIFF
--- a/lib/Widget/AlphaVantageBase.php
+++ b/lib/Widget/AlphaVantageBase.php
@@ -150,6 +150,11 @@ abstract class AlphaVantageBase extends ModuleWidget
 
                 $data = json_decode($request->getBody(), true);
 
+                if (!array_key_exists('Time Series (Daily)', $data)) {
+                    $this->getLog()->debug('getStockQuote Data: ' . var_export($data, true));
+                    throw new InvalidArgumentException(__('Stocks data invalid'), 'Time Series (Daily)');
+                }
+
                 // Cache this and expire in the cache period
                 $cache->set($data);
                 $cache->expiresAt(Carbon::now()->addSeconds($this->getSetting('cachePeriod', 14400)));


### PR DESCRIPTION
Protect against attempts at parsing data not matching expected format, which leads to bunch of php warnings/notices

This is mostly for the case where a free Alpha Vantage API key was marked as paid key in the module, as we will not get the data from their API in such case.

https://github.com/xibosignage/xibo/issues/2995