### PR TITLE
BugFixes for 3.3.3 : Display Profile available types and Task next run sorting

### DIFF
--- a/views/task-page.twig
+++ b/views/task-page.twig
@@ -134,6 +134,7 @@
                 },
                 {
                     "data": "nextRunDt",
+                    "orderable": false,
                     "render": dataTableDateFromUnix
                 },
                 {


### PR DESCRIPTION
- Task : disable sorting on next run column
- Display Profile : make the default profile types always available, do not rely solely on database query on displayprofile table