### PR TITLE
Ad Campaigns : tidy up interrupt schedules after 90 days.

### DIFF
--- a/lib/Entity/Schedule.php
+++ b/lib/Entity/Schedule.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2022 Xibo Signage Ltd
+ * Copyright (C) 2023 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - http://www.xibo.org.uk
  *
@@ -689,9 +689,13 @@ class Schedule implements \JsonSerializable
     /**
      * Delete this Schedule Event
      */
-    public function delete()
+    public function delete($options = [])
     {
         $this->load();
+
+        $options = array_merge([
+            'notify' => true
+        ], $options);
 
         // Notify display groups
         $notify = $this->displayGroups;
@@ -722,15 +726,19 @@ class Schedule implements \JsonSerializable
         $this->getStore()->update('DELETE FROM `schedule` WHERE eventId = :eventId', ['eventId' => $this->eventId]);
 
         // Notify
-        // Only if the schedule effects the immediate future - i.e. within the RF Look Ahead
-        if ($this->inScheduleLookAhead() && $this->displayNotifyService !== null) {
-            $this->getLog()->debug('Schedule changing is within the schedule look ahead, will notify ' . count($notify) . ' display groups');
-            foreach ($notify as $displayGroup) {
-                /* @var DisplayGroup $displayGroup */
-                $this->getDisplayNotifyService()->collectNow()->notifyByDisplayGroupId($displayGroup->displayGroupId);
+        if ($options['notify']) {
+            // Only if the schedule effects the immediate future - i.e. within the RF Look Ahead
+            if ($this->inScheduleLookAhead() && $this->displayNotifyService !== null) {
+                $this->getLog()->debug('Schedule changing is within the schedule look ahead, will notify ' . count($notify) . ' display groups');
+                foreach ($notify as $displayGroup) {
+                    /* @var DisplayGroup $displayGroup */
+                    $this->getDisplayNotifyService()->collectNow()->notifyByDisplayGroupId($displayGroup->displayGroupId);
+                }
+            } else if ($this->displayNotifyService === null) {
+                $this->getLog()->info('Notify disabled, dependencies not set');
             }
-        } else if ($this->displayNotifyService === null) {
-            $this->getLog()->info('Notify disabled, dependencies not set');
+        } else {
+            $this->getLog()->debug('Event delete: Notify disabled, option set to false');
         }
 
         // Drop the cache for this event

--- a/lib/Factory/ScheduleFactory.php
+++ b/lib/Factory/ScheduleFactory.php
@@ -368,6 +368,11 @@ class ScheduleFactory extends BaseFactory
             $params['parentCampaignId'] = $parsedFilter->getInt('parentCampaignId');
         }
 
+        if ($parsedFilter->getInt('adCampaignsOnly') === 1) {
+            $sql .= ' AND `schedule`.parentCampaignId IS NOT NULL AND `schedule`.eventTypeId = :eventTypeId ';
+            $params['eventTypeId'] = Schedule::$INTERRUPT_EVENT;
+        }
+
         if ($parsedFilter->getInt('ownerId') !== null) {
             $sql .= ' AND `schedule`.userId = :ownerId ';
             $params['ownerId'] = $parsedFilter->getInt('ownerId');

--- a/lib/XTR/MaintenanceRegularTask.php
+++ b/lib/XTR/MaintenanceRegularTask.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (c) 2022 Xibo Signage Ltd
+ * Copyright (C) 2023 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - http://www.xibo.org.uk
  *
@@ -24,6 +24,7 @@
 namespace Xibo\XTR;
 use Carbon\Carbon;
 use Xibo\Controller\Display;
+use Xibo\Entity\Schedule;
 use Xibo\Event\DisplayGroupLoadEvent;
 use Xibo\Event\MaintenanceRegularEvent;
 use Xibo\Factory\DisplayFactory;
@@ -32,6 +33,7 @@ use Xibo\Factory\LayoutFactory;
 use Xibo\Factory\ModuleFactory;
 use Xibo\Factory\NotificationFactory;
 use Xibo\Factory\PlaylistFactory;
+use Xibo\Factory\ScheduleFactory;
 use Xibo\Factory\UserGroupFactory;
 use Xibo\Helper\ByteFormatter;
 use Xibo\Helper\DateFormatHelper;
@@ -78,6 +80,10 @@ class MaintenanceRegularTask implements TaskInterface
 
     /** @var  \Xibo\Helper\SanitizerService */
     private $sanitizerService;
+    /**
+     * @var ScheduleFactory
+     */
+    private $scheduleFactory;
 
     /** @inheritdoc */
     public function setFactories($container)
@@ -93,6 +99,7 @@ class MaintenanceRegularTask implements TaskInterface
         $this->playlistFactory = $container->get('playlistFactory');
         $this->moduleFactory = $container->get('moduleFactory');
         $this->sanitizerService = $container->get('sanitizerService');
+        $this->scheduleFactory = $container->get('scheduleFactory');
         return $this;
     }
 
@@ -120,6 +127,8 @@ class MaintenanceRegularTask implements TaskInterface
         $this->publishLayouts();
 
         $this->assessDynamicDisplayGroups();
+
+        $this->tidyAdCampaignSchedules();
 
         // Dispatch an event so that consumers can hook into regular maintenance.
         $event = new MaintenanceRegularEvent();
@@ -522,5 +531,28 @@ class MaintenanceRegularTask implements TaskInterface
         } else {
             $this->runMessage .= ' - Done (not required)' . PHP_EOL . PHP_EOL;
         }
+    }
+
+    private function tidyAdCampaignSchedules()
+    {
+        $this->runMessage .= '## ' . __('Tidy Ad Campaign Schedules') . PHP_EOL;
+        Profiler::start('RegularMaintenance::tidyAdCampaignSchedules', $this->log);
+        $count = 0;
+
+        foreach ($this->scheduleFactory->query(null, [
+            'eventTypeId' => Schedule::$INTERRUPT_EVENT,
+            'toDt' => Carbon::now()->subDays(90)->unix()
+        ]) as $event) {
+            if (!empty($event->parentCampaignId)) {
+                $count++;
+                $this->log->debug('tidyAdCampaignSchedules : Found old Ad Campaign interrupt event ID '
+                    . $event->eventId . ' deleting');
+                $event->delete(['notify' => false]);
+            }
+        }
+
+        $this->log->debug('tidyAdCampaignSchedules : Deleted ' . $count . ' events');
+        Profiler::end('RegularMaintenance::tidyAdCampaignSchedules', $this->log);
+        $this->runMessage .= ' - Done ' . $count . PHP_EOL . PHP_EOL;
     }
 }

--- a/lib/XTR/MaintenanceRegularTask.php
+++ b/lib/XTR/MaintenanceRegularTask.php
@@ -540,7 +540,7 @@ class MaintenanceRegularTask implements TaskInterface
         $count = 0;
 
         foreach ($this->scheduleFactory->query(null, [
-            'eventTypeId' => Schedule::$INTERRUPT_EVENT,
+            'adCampaignsOnly' => 1,
             'toDt' => Carbon::now()->subDays(90)->unix()
         ]) as $event) {
             if (!empty($event->parentCampaignId)) {


### PR DESCRIPTION
- Regular Maintenance : new function that looks for 90 days + old interrupt events with set parentCampaignId and deletes them making sure to not notify Displays (notify => false).
- Schedule Entity delete : add array of options with default notify true, do not even attempt to check inScheduleLookAhead if notify is set to false

Fixes xibosignage/xibo#2977