### PR TITLE
Bug Fix 3.3.3: Fix for MySQL Audience Connector send stats

### DIFF
--- a/lib/Connector/XiboAudienceReportingConnector.php
+++ b/lib/Connector/XiboAudienceReportingConnector.php
@@ -190,7 +190,7 @@ class XiboAudienceReportingConnector implements ConnectorInterface
                 . json_encode($params));
 
             // Call the time series interface getStats
-            $resultSet = $this->timeSeriesStore->getStats($params);
+            $resultSet = $this->timeSeriesStore->getStats($params, true);
 
             // Array of campaigns for which we will update the total spend, impresssions, and plays
             $campaigns = [];

--- a/lib/Storage/MongoDbTimeSeriesStore.php
+++ b/lib/Storage/MongoDbTimeSeriesStore.php
@@ -443,7 +443,7 @@ class MongoDbTimeSeriesStore implements TimeSeriesStoreInterface
     /**
      * @inheritdoc
      */
-    public function getStats($filterBy = [])
+    public function getStats($filterBy = [], $isBufferedQuery = false)
     {
         // do we consider that the fromDt and toDt will always be provided?
         $fromDt = $filterBy['fromDt'] ?? null;

--- a/lib/Storage/MySqlTimeSeriesStore.php
+++ b/lib/Storage/MySqlTimeSeriesStore.php
@@ -189,7 +189,7 @@ class MySqlTimeSeriesStore implements TimeSeriesStoreInterface
     }
 
     /** @inheritdoc */
-    public function getStats($filterBy = [])
+    public function getStats($filterBy = [], $isBufferedQuery = false)
     {
         $fromDt = $filterBy['fromDt'] ?? null;
         $toDt = $filterBy['toDt'] ?? null;
@@ -426,7 +426,8 @@ class MySqlTimeSeriesStore implements TimeSeriesStoreInterface
 
         // Run our query using a connection object (to save memory)
         $connection = $this->store->getConnection();
-        $connection->setAttribute(\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, false);
+        $connection->setAttribute(\PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, $isBufferedQuery);
+
 
         // Prepare the statement
         $statement = $connection->prepare($sql);

--- a/lib/Storage/TimeSeriesStoreInterface.php
+++ b/lib/Storage/TimeSeriesStoreInterface.php
@@ -89,10 +89,11 @@ interface TimeSeriesStoreInterface
     /**
      * Get statistics
      * @param $filterBy array[mixed]|null
+     * @param $isBufferedQuery bool Option to set buffered queries in MySQL
      * @throws GeneralException
      * @return TimeSeriesResultsInterface
      */
-    public function getStats($filterBy = []);
+    public function getStats($filterBy = [], $isBufferedQuery = false);
 
     /**
      * Get total count of export statistics


### PR DESCRIPTION
To ensure that the results of the "getStats" query are stored in memory, set the MYSQL_ATTR_USE_BUFFERED_QUERY attribute to true when sending stats.

Fixes: https://github.com/xibosignage/xibo/issues/3009