### PR TITLE
Layout Editor: Fix "name" in dynamic fields

### DIFF
--- a/ui/src/templates/forms/inputs/checkbox.hbs
+++ b/ui/src/templates/forms/inputs/checkbox.hbs
@@ -1,5 +1,5 @@
 <div class="form-check pb-3 xibo-form-input {{customClass}}" {{#if visibility}}data-visibility="{{visibility}}"{{/if}}>
-    <input type="checkbox" class="form-check-input" id="{{id}}" name="{{name}}" {{#eq (number value) 1}}checked="checked"{{/eq}}
+    <input type="checkbox" class="form-check-input" id="{{id}}" name="{{#if name}}{{name}}{{else}}{{id}}{{/if}}" {{#eq (number value) 1}}checked="checked"{{/eq}}
         {{#each customData}}
             data-{{this.name}}="{{this.value}}"
         {{/each}}

--- a/ui/src/templates/forms/inputs/code.hbs
+++ b/ui/src/templates/forms/inputs/code.hbs
@@ -1,7 +1,7 @@
 <div class="form-group code-input-group xibo-code-input xibo-form-input {{customClass}}" {{#if visibility}}data-visibility="{{visibility}}"{{/if}}>
     <label for="{{id}}" class="control-label"><strong>{{title}}</strong></label>
     <div class="input-info-container"></div>
-    <textarea class="form-control code-input d-none" id="{{id}}" name="{{name}}" rows="{{rows}}" data-code-type="{{variant}}"
+    <textarea class="form-control code-input d-none" id="{{id}}" name="{{#if name}}{{name}}{{else}}{{id}}{{/if}}" rows="{{rows}}" data-code-type="{{variant}}"
         {{#each customData}}
             data-{{this.name}}="{{this.value}}"
         {{/each}}

--- a/ui/src/templates/forms/inputs/color.hbs
+++ b/ui/src/templates/forms/inputs/color.hbs
@@ -7,6 +7,6 @@
         <div class="input-group-prepend">
             <i class="input-group-text input-group-addon" id="{{id}}_label"></i>
         </div>
-        <input type="text" class="form-control" id="{{id}}" name="{{name}}" value="{{value}}" />
+        <input type="text" class="form-control" id="{{id}}" name="{{#if name}}{{name}}{{else}}{{id}}{{/if}}" value="{{value}}" />
     </div>
 </div>

--- a/ui/src/templates/forms/inputs/custom.hbs
+++ b/ui/src/templates/forms/inputs/custom.hbs
@@ -1,6 +1,6 @@
 <div class="xibo-form-input custom-input {{customClass}}"
     {{#if visibility}}data-visibility="{{visibility}}"{{/if}}>
-    <input type="hidden" id="{{id}}" name="{{name}}" value="{{value}}"
+    <input type="hidden" id="{{id}}" name="{{#if name}}{{name}}{{else}}{{id}}{{/if}}" value="{{value}}"
     {{#each customData}}
         data-{{this.name}}="{{this.value}}"
     {{/each}}" />

--- a/ui/src/templates/forms/inputs/date.hbs
+++ b/ui/src/templates/forms/inputs/date.hbs
@@ -2,7 +2,7 @@
     <label for="{{id}}" class="control-label"><strong>{{title}}</strong></label>
     <div class="input-info-container"></div>
     <div class="input-group">
-        <input type="text" class="form-control dateControl {{variant}}" id="{{id}}" name="{{name}}" value="{{value}}" {{#if format }}data-custom-format="{{ format }}"{{/if}}
+        <input type="text" class="form-control dateControl {{variant}}" id="{{id}}" name="{{#if name}}{{name}}{{else}}{{id}}{{/if}}" value="{{value}}" {{#if format }}data-custom-format="{{ format }}"{{/if}}
             {{#each customData}}
                 data-{{this.name}}="{{this.value}}"
             {{/each}}

--- a/ui/src/templates/forms/inputs/dropdown.hbs
+++ b/ui/src/templates/forms/inputs/dropdown.hbs
@@ -1,7 +1,7 @@
 <div class="form-group xibo-form-input {{customClass}}" {{#if visibility}}data-visibility="{{visibility}}"{{/if}}>
     <label for="{{id}}" class="control-label"><strong>{{title}}</strong></label>
     <div class="input-info-container"></div>
-    <select class="form-control" id="{{id}}" name="{{name}}"
+    <select class="form-control" id="{{id}}" name="{{#if name}}{{name}}{{else}}{{id}}{{/if}}"
         {{#each customData}}
             data-{{this.name}}="{{this.value}}"
         {{/each}}

--- a/ui/src/templates/forms/inputs/hidden.hbs
+++ b/ui/src/templates/forms/inputs/hidden.hbs
@@ -1,4 +1,4 @@
-<input name="{{ name }}" class="{{customClass}}" type="hidden" id="{{ id }}" value="{{ value }}"
+<input name="{{#if name}}{{name}}{{else}}{{id}}{{/if}}" class="{{customClass}}" type="hidden" id="{{ id }}" value="{{ value }}"
     {{#each customData}}
         data-{{this.name}}="{{this.value}}"
     {{/each}}

--- a/ui/src/templates/forms/inputs/number.hbs
+++ b/ui/src/templates/forms/inputs/number.hbs
@@ -1,7 +1,7 @@
 <div class="form-group xibo-form-input {{customClass}}" {{#if visibility}}data-visibility="{{visibility}}"{{/if}}>
     <label for="{{id}}" class="control-label"><strong>{{title}}</strong></label>
     <div class="input-info-container"></div>
-    <input type="number" class="form-control" {{#if step}}step="{{step}}"{{/if}} id="{{id}}" name="{{name}}" value="{{value}}"
+    <input type="number" class="form-control" {{#if step}}step="{{step}}"{{/if}} id="{{id}}" name="{{#if name}}{{name}}{{else}}{{id}}{{/if}}" value="{{value}}"
         {{#each customData}}
             data-{{this.name}}="{{this.value}}"
         {{/each}}

--- a/ui/src/templates/forms/inputs/richText.hbs
+++ b/ui/src/templates/forms/inputs/richText.hbs
@@ -2,7 +2,7 @@
     <label for="{{id}}" class="control-label"><strong>{{title}}</strong></label>
     <div class="input-info-container"></div>
     <div class="rich-text-container">
-        <textarea type="text" class="form-control rich-text" id="{{id}}" name="{{name}}"
+        <textarea type="text" class="form-control rich-text" id="{{id}}" name="{{#if name}}{{name}}{{else}}{{id}}{{/if}}"
             {{#each customData}}
                 data-{{this.name}}="{{this.value}}"
             {{/each}}

--- a/ui/src/templates/forms/inputs/text.hbs
+++ b/ui/src/templates/forms/inputs/text.hbs
@@ -1,7 +1,7 @@
 <div class="form-group xibo-form-input {{customClass}}" {{#if visibility}}data-visibility="{{visibility}}"{{/if}}>
     <label for="{{id}}" class="control-label"><strong>{{title}}</strong></label>
     <div class="input-info-container"></div>
-    <input type="text" class="form-control" id="{{id}}" name="{{name}}" value="{{value}}"
+    <input type="text" class="form-control" id="{{id}}" name="{{#if name}}{{name}}{{else}}{{id}}{{/if}}" value="{{value}}"
         {{#each customData}}
             data-{{this.name}}="{{this.value}}"
         {{/each}}


### PR DESCRIPTION
relates to xibosignageltd/xibo-private#100

Name field was being populated for the new XML form fields but not for the existing HBS forms like region and layout, and it was preventing those forms to save correctly.
We now check for `name`, and if it doesn't exist, we re-use `id` for it