### PR TITLE
Fix recurring schedules which cross the month boundary. Optimise submit stats (date checking in wrong place)

### DIFF
--- a/lib/Entity/Schedule.php
+++ b/lib/Entity/Schedule.php
@@ -1177,7 +1177,7 @@ class Schedule implements \JsonSerializable
                                 continue;
                             }
 
-                            if ($start >= $generateFromDt) {
+                            if ($end > $generateFromDt && $start < $generateToDt) {
                                 $this->getLog()->debug('Adding detail for ' . $start->toAtomString() . ' to ' . $end->toAtomString());
 
                                 if ($this->eventTypeId == self::$COMMAND_EVENT) {

--- a/lib/Xmds/Soap.php
+++ b/lib/Xmds/Soap.php
@@ -1622,13 +1622,6 @@ class Soap
                 continue;
             }
 
-            // From date cannot be ahead of to date
-            if ($fromDt > $toDt) {
-                $this->getLog()->debug('Ignoring a Stat record because the fromDt ('
-                    . $fromDt . ') is greater than toDt (' . $toDt . ')');
-                continue;
-            }
-
             // Adjust the date according to the display timezone
             // stats are returned in player local date/time
             // the CMS will have been configured with that Player's timezone, so we can convert accordingly.
@@ -1653,6 +1646,13 @@ class Soap
                 // Protect against the date format being unreadable
                 $this->getLog()->error('Stat with a from or to date that cannot be understood. fromDt: '
                     . $fromDt . ', toDt: ' . $toDt . '. E = ' . $e->getMessage());
+                continue;
+            }
+
+            // From date cannot be ahead of to date
+            if ($fromDt > $toDt) {
+                $this->getLog()->debug('Ignoring a Stat record because the fromDt ('
+                    . $fromDt . ') is greater than toDt (' . $toDt . ')');
                 continue;
             }
 


### PR DESCRIPTION
XMDS: it looks like we're checking strings using `>` instead of waiting until they are actually dates.
Schedule: we are only including recurring events where the start date is greater than the month start - using an inclusive date check means we grab events which started in the prior month.