### PR TITLE
Module Settings: Form save isn't working

### DIFF
--- a/lib/Controller/Module.php
+++ b/lib/Controller/Module.php
@@ -198,7 +198,7 @@ class Module extends Base
 
         // Parse out any settings we ought to expect.
         foreach ($module->settings as $setting) {
-            $setting->setValueByType($sanitizedParams);
+            $setting->setValueByType($sanitizedParams, null, true);
         }
 
         // Save

--- a/lib/Widget/Definition/Property.php
+++ b/lib/Widget/Definition/Property.php
@@ -202,15 +202,16 @@ class Property implements \JsonSerializable
     }
 
     /**
-     * @param \Xibo\Support\Sanitizer\SanitizerInterface $params
+     * @param SanitizerInterface $params
      * @param string|null $key
-     * @return \Xibo\Widget\Definition\Property
-     * @throws \Xibo\Support\Exception\InvalidArgumentException
+     * @param bool $ignoreDefault
+     * @return Property
+     * @throws InvalidArgumentException
      */
-    public function setValueByType(SanitizerInterface $params, string $key = null): Property
+    public function setValueByType(SanitizerInterface $params, string $key = null, bool $ignoreDefault = false): Property
     {
         $value = $this->getByType($params, $key);
-        if ($value !== $this->default) {
+        if ($value !== $this->default || $ignoreDefault) {
             $this->value = $value;
         }
         return $this;


### PR DESCRIPTION
Fixes: https://github.com/xibosignageltd/xibo-private/issues/145

Update the setting value even if the new setting value matches with the default value. Previously, we were ignoring update if the new value matched the default.

