### PR TITLE
Ticker widget: add option to set the user agent (4.0.0)

### DIFF
--- a/lib/Widget/RssProvider.php
+++ b/lib/Widget/RssProvider.php
@@ -60,14 +60,20 @@ class RssProvider implements WidgetProviderInterface
             ->format('U');
 
         try {
+            $httpOptions = [
+                'headers' => [
+                    'Accept' => 'application/rss+xml, application/rdf+xml;q=0.8, application/atom+xml;q=0.6,'
+                        . 'application/xml;q=0.4, text/xml;q=0.4, text/html;q=0.2, text/*;q=0.1'
+                ],
+                'timeout' => 20, // wait no more than 20 seconds
+            ];
+
+            if (!empty($dataProvider->getProperty('userAgent'))) {
+                $httpOptions['User-Agent'] = $dataProvider->getProperty('userAgent');
+            }
+
             $response = $dataProvider
-                ->getGuzzleClient([
-                    'headers' => [
-                        'Accept' => 'application/rss+xml, application/rdf+xml;q=0.8, application/atom+xml;q=0.6,'
-                            . 'application/xml;q=0.4, text/xml;q=0.4, text/html;q=0.2, text/*;q=0.1'
-                    ],
-                    'timeout' => 20, // wait no more than 20 seconds
-                ])
+                ->getGuzzleClient($httpOptions)
                 ->get($uri);
 
             // Pull out the content type

--- a/lib/Widget/RssProvider.php
+++ b/lib/Widget/RssProvider.php
@@ -69,7 +69,7 @@ class RssProvider implements WidgetProviderInterface
             ];
 
             if (!empty($dataProvider->getProperty('userAgent'))) {
-                $httpOptions['User-Agent'] = $dataProvider->getProperty('userAgent');
+                $httpOptions['headers']['User-Agent'] = trim($dataProvider->getProperty('userAgent'));
             }
 
             $response = $dataProvider

--- a/lib/Widget/Ticker.php
+++ b/lib/Widget/Ticker.php
@@ -1,6 +1,6 @@
 <?php
-/**
- * Copyright (C) 2020 Xibo Signage Ltd
+/*
+ * Copyright (C) 2023 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - http://www.xibo.org.uk
  *
@@ -376,6 +376,7 @@ class Ticker extends ModuleWidget
         $this->setOption('dateFormat', $sanitizedParams->getString('dateFormat', ['defaultOnEmptyString' => true]));
         $this->setOption('allowedAttributes', $sanitizedParams->getString('allowedAttributes'));
         $this->setOption('stripTags', $sanitizedParams->getString('stripTags'));
+        $this->setOption('userAgent', $sanitizedParams->getString('userAgent'));
         $this->setOption('decodeHtml', $sanitizedParams->getCheckbox('decodeHtml'));
         $this->setOption('backgroundColor', $sanitizedParams->getString('backgroundColor'));
         $this->setOption('disableDateSort', $sanitizedParams->getCheckbox('disableDateSort'));
@@ -672,14 +673,20 @@ class Ticker extends ModuleWidget
             $cache->lock(120);
 
             try {
-                // Create a Guzzle Client to get the Feed XML
-                $client = new Client();
-                $response = $client->get($feedUrl, $this->getConfig()->getGuzzleProxy([
+                $httpOptions = [
                     'headers' => [
                         'Accept' => 'application/rss+xml, application/rdf+xml;q=0.8, application/atom+xml;q=0.6, application/xml;q=0.4, text/xml;q=0.4, text/html;q=0.2, text/*;q=0.1'
                     ],
                     'timeout' => 20 // wait no more than 20 seconds: https://github.com/xibosignage/xibo/issues/1401
-                ]));
+                ];
+
+                if (!empty($this->getOption('userAgent'))) {
+                    $httpOptions['User-Agent'] = $this->getOption('userAgent');
+                }
+                
+                // Create a Guzzle Client to get the Feed XML
+                $client = new Client();
+                $response = $client->get($feedUrl, $this->getConfig()->getGuzzleProxy($httpOptions));
 
                 // Pull out the content type
                 $contentType = $response->getHeaderLine('Content-Type');

--- a/lib/Widget/Ticker.php
+++ b/lib/Widget/Ticker.php
@@ -673,20 +673,14 @@ class Ticker extends ModuleWidget
             $cache->lock(120);
 
             try {
-                $httpOptions = [
+                // Create a Guzzle Client to get the Feed XML
+                $client = new Client();
+                $response = $client->get($feedUrl, $this->getConfig()->getGuzzleProxy([
                     'headers' => [
                         'Accept' => 'application/rss+xml, application/rdf+xml;q=0.8, application/atom+xml;q=0.6, application/xml;q=0.4, text/xml;q=0.4, text/html;q=0.2, text/*;q=0.1'
                     ],
                     'timeout' => 20 // wait no more than 20 seconds: https://github.com/xibosignage/xibo/issues/1401
-                ];
-
-                if (!empty($this->getOption('userAgent'))) {
-                    $httpOptions['User-Agent'] = $this->getOption('userAgent');
-                }
-                
-                // Create a Guzzle Client to get the Feed XML
-                $client = new Client();
-                $response = $client->get($feedUrl, $this->getConfig()->getGuzzleProxy($httpOptions));
+                ]));
 
                 // Pull out the content type
                 $contentType = $response->getHeaderLine('Content-Type');

--- a/modules/rss-ticker.xml
+++ b/modules/rss-ticker.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (C) 2022 Xibo Signage Ltd
+  ~ Copyright (C) 2023 Xibo Signage Ltd
   ~
   ~ Xibo - Digital Signage - http://www.xibo.org.uk
   ~
@@ -84,6 +84,11 @@
         <property id="stripTags" type="text">
             <title>Strip Tags</title>
             <helpText>A comma separated list of HTML tags that should be stripped from the feed in addition to the default ones.</helpText>
+            <default></default>
+        </property>
+        <property id="userAgent" type="text">
+            <title>User Agent</title>
+            <helpText>Optionally set specific User Agent for this request, provide only the value, relevant header will be added automatically.</helpText>
             <default></default>
         </property>
         <property id="decodeHtml" type="checkbox">


### PR DESCRIPTION
In Layout Editor, RSS Ticker widget will now have the option to set userAgent
Relates to: https://github.com/xibosignage/xibo/issues/2999