### PR TITLE
Fix: userAgent should be in headers

### DIFF
--- a/lib/Widget/Ticker.php
+++ b/lib/Widget/Ticker.php
@@ -688,7 +688,7 @@ class Ticker extends ModuleWidget
                 ];
 
                 if (!empty($this->getOption('userAgent'))) {
-                    $httpOptions['User-Agent'] = $this->getOption('userAgent');
+                    $httpOptions['headers']['User-Agent'] = trim($this->getOption('userAgent'));
                 }
 
                 // Create a Guzzle Client to get the Feed XML


### PR DESCRIPTION
- Fix for accidental placement for the Guzzle 'User-Agent'  in headers