### PR TITLE
Report: Proof of play schedule report cannot filter by media/layout

### DIFF
--- a/lib/Report/ProofOfPlay.php
+++ b/lib/Report/ProofOfPlay.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2022 Xibo Signage Ltd
+ * Copyright (C) 2023 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - http://www.xibo.org.uk
  *
@@ -155,9 +155,8 @@ class ProofOfPlay implements ReportInterface
         $filterCriteria = [
             'filter' => $filter,
             'displayId' => $sanitizedParams->getInt('displayId'),
-            'displayIds' => $sanitizedParams->getIntArray('displayIds'),
-            'layoutIds' => $sanitizedParams->getIntArray('layoutId'),
-            'mediaIds' => $sanitizedParams->getIntArray('mediaId'),
+            'layoutId' => $sanitizedParams->getIntArray('layoutId'),
+            'mediaId' => $sanitizedParams->getIntArray('mediaId'),
             'type' => $sanitizedParams->getString('type'),
             'sortBy' => $sanitizedParams->getString('sortBy'),
             'tagsType' => $sanitizedParams->getString('tagsType'),


### PR DESCRIPTION
I am not sure when this bug was introduced, apparently no one noticed this. We will have to fix that in 3.3.4 as well.

- Fixes https://github.com/xibosignage/xibo/issues/3032