### PR TITLE
3.3.4 - hide empty row menu and fix group admin userGroup permissions

### DIFF
--- a/lib/Controller/UserGroup.php
+++ b/lib/Controller/UserGroup.php
@@ -1,8 +1,8 @@
 <?php
 /*
- * Copyright (c) 2022 Xibo Signage Ltd
+ * Copyright (C) 2023 Xibo Signage Ltd
  *
- * Xibo - Digital Signage - http://www.xibo.org.uk
+ * Xibo - Digital Signage - https://xibosignage.com
  *
  * This file is part of Xibo.
  *
@@ -20,6 +20,7 @@
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
  */
 namespace Xibo\Controller;
+
 use Slim\Http\Response as Response;
 use Slim\Http\ServerRequest as Request;
 use Xibo\Entity\Permission;
@@ -143,7 +144,7 @@ class UserGroup extends Base
 
             // we only want to show certain buttons, depending on the user logged in
             if ($this->getUser()->featureEnabled('usergroup.modify')
-                && $this->isEditable($group)
+                && $this->getUser()->checkEditable($group)
             ) {
                 // Edit
                 $group->buttons[] = array(
@@ -234,7 +235,7 @@ class UserGroup extends Base
     {
         $group = $this->userGroupFactory->getById($id);
 
-        if (!$this->isEditable($group)) {
+        if (!$this->getuser()->checkEditable($group)) {
             throw new AccessDeniedException();
         }
 
@@ -264,7 +265,7 @@ class UserGroup extends Base
     {
         $group = $this->userGroupFactory->getById($id);
 
-        if (!$this->isEditable($group)) {
+        if (!$this->getuser()->checkEditable($group)) {
             throw new AccessDeniedException();
         }
 
@@ -490,7 +491,7 @@ class UserGroup extends Base
 
         $group = $this->userGroupFactory->getById($id);
 
-        if (!$this->isEditable($group)) {
+        if (!$this->getuser()->checkEditable($group)) {
             throw new AccessDeniedException();
         }
 
@@ -567,7 +568,7 @@ class UserGroup extends Base
 
         $group = $this->userGroupFactory->getById($id);
 
-        if (!$this->isEditable($group)) {
+        if (!$this->getuser()->checkEditable($group)) {
             throw new AccessDeniedException();
         }
 
@@ -681,7 +682,7 @@ class UserGroup extends Base
     {
         $group = $this->userGroupFactory->getById($id);
 
-        if (!$this->isEditable($group)) {
+        if (!$this->getuser()->checkEditable($group)) {
             throw new AccessDeniedException();
         }
 
@@ -775,7 +776,7 @@ class UserGroup extends Base
         $sanitizedParams = $this->getSanitizer($request->getParams());
 
         $group = $this->userGroupFactory->getById($id);
-        if (!$this->isEditable($group)) {
+        if (!$this->getuser()->checkEditable($group)) {
             throw new AccessDeniedException();
         }
 
@@ -879,7 +880,7 @@ class UserGroup extends Base
         $group = $this->userGroupFactory->getById($id);
         $sanitizedParams = $this->getSanitizer($request->getParams());
 
-        if (!$this->isEditable($group)) {
+        if (!$this->getuser()->checkEditable($group)) {
             throw new AccessDeniedException();
         }
 
@@ -915,7 +916,7 @@ class UserGroup extends Base
     {
         $group = $this->userGroupFactory->getById($id);
 
-        if (!$this->isEditable($group)) {
+        if (!$this->getuser()->checkEditable($group)) {
             throw new AccessDeniedException();
         }
 
@@ -991,7 +992,7 @@ class UserGroup extends Base
         $sanitizedParams = $this->getSanitizer($request->getParams());
 
         // Check we have permission to view this group
-        if (!$this->isEditable($group)) {
+        if (!$this->getuser()->checkEditable($group)) {
             throw new AccessDeniedException();
         }
 
@@ -1026,15 +1027,5 @@ class UserGroup extends Base
         ]);
 
         return $this->render($request, $response);
-    }
-
-    /**
-     * @param \Xibo\Entity\UserGroup $group
-     * @return bool
-     */
-    private function isEditable($group)
-    {
-        return $this->getUser()->isSuperAdmin()
-            || ($this->getUser()->isGroupAdmin() && count(array_intersect($this->getUser()->groups, [$group])));
     }
 }

--- a/lib/Entity/User.php
+++ b/lib/Entity/User.php
@@ -1,8 +1,8 @@
 <?php
 /*
- * Copyright (c) 2022 Xibo Signage Ltd
+ * Copyright (C) 2023 Xibo Signage Ltd
  *
- * Xibo - Digital Signage - http://www.xibo.org.uk
+ * Xibo - Digital Signage - https://xibosignage.com
  *
  * This file is part of Xibo.
  *
@@ -1172,9 +1172,18 @@ class User implements \JsonSerializable, UserEntityInterface
             return true;
 
         // Group Admins
-        if ($this->userTypeId == 2 && count(array_intersect($this->groups, $this->userGroupFactory->getByUserId($object->getOwnerId()))))
-            // Group Admin and in the same group as the owner.
-            return true;
+        if ($object->permissionsClass() === 'Xibo\Entity\UserGroup') {
+            // userGroup does not have an owner (getOwnerId() returns 0 ), we need to handle it in a different way.
+            if ($this->userTypeId == 2 && count(array_intersect($this->groups, [$object]))) {
+                // Group Admin and group object in the user array of groups
+                return true;
+            }
+        } else {
+            if ($this->userTypeId == 2 && count(array_intersect($this->groups, $this->userGroupFactory->getByUserId($object->getOwnerId())))) {
+                // Group Admin and in the same group as the owner.
+                return true;
+            }
+        }
 
         // Get the permissions for that entity
         $permissions = $this->loadPermissions($object->permissionsClass());

--- a/ui/src/core/xibo-cms.js
+++ b/ui/src/core/xibo-cms.js
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) 2022 Xibo Signage Ltd
+ * Copyright (C) 2023 Xibo Signage Ltd
  *
- * Xibo - Digital Signage - http://www.xibo.org.uk
+ * Xibo - Digital Signage - https://xibosignage.com
  *
  * This file is part of Xibo.
  *
@@ -1486,11 +1486,17 @@ function dataTableDraw(e, settings, callBack) {
  * @returns {*}
  */
 function dataTableButtonsColumn(data, type, row, meta) {
-    if (type != "display")
+    if (type != "display") {
         return "";
+    }
 
-    if (buttonsTemplate == null)
+    if (data.buttons.length <= 0) {
+        return "";
+    }
+
+    if (buttonsTemplate == null) {
         buttonsTemplate = Handlebars.compile($("#buttons-template").html());
+    }
 
     return buttonsTemplate({buttons: data.buttons});
 }


### PR DESCRIPTION
- User Group : Group admin permissions fix, specific handling for User Group entity, as we can't rely on ownerId (it's not a thing for user groups ) - https://github.com/xibosignage/xibo/issues/3019
- If we do not have any buttons to show in the row menu dropdown, then do not show the dropdown at all - easiest example would be the system tags on Tags page - https://github.com/xibosignage/xibo/issues/3006