### PR TITLE
XMDS commercial licence on Register and misc fixes from v3

### DIFF
--- a/lib/Controller/UserGroup.php
+++ b/lib/Controller/UserGroup.php
@@ -1,8 +1,8 @@
 <?php
 /*
- * Copyright (c) 2022 Xibo Signage Ltd
+ * Copyright (C) 2023 Xibo Signage Ltd
  *
- * Xibo - Digital Signage - http://www.xibo.org.uk
+ * Xibo - Digital Signage - https://xibosignage.com
  *
  * This file is part of Xibo.
  *
@@ -20,6 +20,7 @@
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
  */
 namespace Xibo\Controller;
+
 use Slim\Http\Response as Response;
 use Slim\Http\ServerRequest as Request;
 use Xibo\Entity\Permission;
@@ -143,7 +144,7 @@ class UserGroup extends Base
 
             // we only want to show certain buttons, depending on the user logged in
             if ($this->getUser()->featureEnabled('usergroup.modify')
-                && $this->isEditable($group)
+                && $this->getUser->checkEditable($group)
             ) {
                 // Edit
                 $group->buttons[] = array(
@@ -234,7 +235,7 @@ class UserGroup extends Base
     {
         $group = $this->userGroupFactory->getById($id);
 
-        if (!$this->isEditable($group)) {
+        if (!$this->getuser()->checkEditable($group)) {
             throw new AccessDeniedException();
         }
 
@@ -264,7 +265,7 @@ class UserGroup extends Base
     {
         $group = $this->userGroupFactory->getById($id);
 
-        if (!$this->isEditable($group)) {
+        if (!$this->getuser()->checkEditable($group)) {
             throw new AccessDeniedException();
         }
 
@@ -490,7 +491,7 @@ class UserGroup extends Base
 
         $group = $this->userGroupFactory->getById($id);
 
-        if (!$this->isEditable($group)) {
+        if (!$this->getuser()->checkEditable($group)) {
             throw new AccessDeniedException();
         }
 
@@ -567,7 +568,7 @@ class UserGroup extends Base
 
         $group = $this->userGroupFactory->getById($id);
 
-        if (!$this->isEditable($group)) {
+        if (!$this->getuser()->checkEditable($group)) {
             throw new AccessDeniedException();
         }
 
@@ -681,7 +682,7 @@ class UserGroup extends Base
     {
         $group = $this->userGroupFactory->getById($id);
 
-        if (!$this->isEditable($group)) {
+        if (!$this->getuser()->checkEditable($group)) {
             throw new AccessDeniedException();
         }
 
@@ -775,7 +776,8 @@ class UserGroup extends Base
         $sanitizedParams = $this->getSanitizer($request->getParams());
 
         $group = $this->userGroupFactory->getById($id);
-        if (!$this->isEditable($group)) {
+
+        if (!$this->getuser()->checkEditable($group)) {
             throw new AccessDeniedException();
         }
 
@@ -879,7 +881,7 @@ class UserGroup extends Base
         $group = $this->userGroupFactory->getById($id);
         $sanitizedParams = $this->getSanitizer($request->getParams());
 
-        if (!$this->isEditable($group)) {
+        if (!$this->getuser()->checkEditable($group)) {
             throw new AccessDeniedException();
         }
 
@@ -915,7 +917,7 @@ class UserGroup extends Base
     {
         $group = $this->userGroupFactory->getById($id);
 
-        if (!$this->isEditable($group)) {
+        if (!$this->getuser()->checkEditable($group)) {
             throw new AccessDeniedException();
         }
 
@@ -991,7 +993,7 @@ class UserGroup extends Base
         $sanitizedParams = $this->getSanitizer($request->getParams());
 
         // Check we have permission to view this group
-        if (!$this->isEditable($group)) {
+        if (!$this->getuser()->checkEditable($group)) {
             throw new AccessDeniedException();
         }
 
@@ -1026,15 +1028,5 @@ class UserGroup extends Base
         ]);
 
         return $this->render($request, $response);
-    }
-
-    /**
-     * @param \Xibo\Entity\UserGroup $group
-     * @return bool
-     */
-    private function isEditable($group)
-    {
-        return $this->getUser()->isSuperAdmin()
-            || ($this->getUser()->isGroupAdmin() && count(array_intersect($this->getUser()->groups, [$group])));
     }
 }

--- a/lib/Entity/User.php
+++ b/lib/Entity/User.php
@@ -2,7 +2,7 @@
 /*
  * Copyright (C) 2023 Xibo Signage Ltd
  *
- * Xibo - Digital Signage - http://www.xibo.org.uk
+ * Xibo - Digital Signage - https://xibosignage.com
  *
  * This file is part of Xibo.
  *
@@ -1159,13 +1159,23 @@ class User implements \JsonSerializable, UserEntityInterface
         $this->checkObjectCompatibility($object);
 
         // Admin users
-        if ($this->isSuperAdmin() || $this->userId == $object->getOwnerId())
+        if ($this->isSuperAdmin() || $this->userId == $object->getOwnerId()) {
             return true;
+        }
 
         // Group Admins
-        if ($this->userTypeId == 2 && count(array_intersect($this->groups, $this->userGroupFactory->getByUserId($object->getOwnerId()))))
-            // Group Admin and in the same group as the owner.
-            return true;
+        if ($object->permissionsClass() === 'Xibo\Entity\UserGroup') {
+            // userGroup does not have an owner (getOwnerId() returns 0 ), we need to handle it in a different way.
+            if ($this->userTypeId == 2 && count(array_intersect($this->groups, [$object]))) {
+                // Group Admin and group object in the user array of groups
+                return true;
+            }
+        } else {
+            if ($this->userTypeId == 2 && count(array_intersect($this->groups, $this->userGroupFactory->getByUserId($object->getOwnerId())))) {
+                // Group Admin and in the same group as the owner.
+                return true;
+            }
+        }
 
         // Get the permissions for that entity
         $permissions = $this->loadPermissions($object->permissionsClass());

--- a/lib/Xmds/service_v7.wsdl
+++ b/lib/Xmds/service_v7.wsdl
@@ -1,7 +1,7 @@
 <!--
-  ~ Copyright (C) 2022 Xibo Signage Ltd
+  ~ Copyright (C) 2023 Xibo Signage Ltd
   ~
-  ~ Xibo - Digital Signage - http://www.xibo.org.uk
+  ~ Xibo - Digital Signage - https://xibosignage.com
   ~
   ~ This file is part of Xibo.
   ~
@@ -38,6 +38,7 @@
         <part name="macAddress" type="xsd:string" />
         <part name="xmrChannel" type="xsd:string" />
         <part name="xmrPubKey" type="xsd:string" />
+        <part name="licenceResult" type="xsd:string" />
     </message>
     <message name="RegisterDisplayResponse">
         <part name="ActivationMessage" type="xsd:string" />

--- a/ui/src/core/xibo-cms.js
+++ b/ui/src/core/xibo-cms.js
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) 2022 Xibo Signage Ltd
+ * Copyright (C) 2023 Xibo Signage Ltd
  *
- * Xibo - Digital Signage - http://www.xibo.org.uk
+ * Xibo - Digital Signage - https://xibosignage.com
  *
  * This file is part of Xibo.
  *
@@ -1353,11 +1353,17 @@ function dataTableDraw(e, settings, callBack) {
  * @returns {*}
  */
 function dataTableButtonsColumn(data, type, row, meta) {
-    if (type != "display")
+    if (type != "display") {
         return "";
+    }
 
-    if (buttonsTemplate == null)
+    if (data.buttons.length <= 0) {
+        return "";
+    }
+
+    if (buttonsTemplate == null) {
         buttonsTemplate = Handlebars.compile($("#buttons-template").html());
+    }
 
     return buttonsTemplate({buttons: data.buttons});
 }

--- a/views/campaign-builder.twig
+++ b/views/campaign-builder.twig
@@ -99,7 +99,7 @@
                                     {% if currentUser.featureEnabled("tag.tagging") %}
                                         {% set title %}{% trans "Tags" %}{% endset %}
                                         {% set helpText %}{% trans "Tags for this Campaign - Comma separated string of Tags or Tag|Value format. If you choose a Tag that has associated values, they will be shown for selection below." %}{% endset %}
-                                        {{ forms.inputWithTags("tags", title, campaign.tags, helpText, 'tags-with-value') }}
+                                        {{ forms.inputWithTags("tags", title, campaign.getTagString(), helpText, 'tags-with-value') }}
 
                                         <p id="loadingValues" style="margin-left: 17%"></p>
 


### PR DESCRIPTION
- XMDS, add licenceResult to wsdl7 and soap5 RegisterDisplay function
- Group Admin : Fix permission check related to User Group object (from v3)
- UX : hide row menu dropdown if there are no buttons to show inside of it (from v3)
- Campaign Builder form : Fix the existing tags displayed in the form - different format post Tag refactor in v4