### PR TITLE
Modules: refactor WidgetEditOptionRequestEvent to make it generic 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,25 @@
+/*
+ * Copyright (c) 2023  Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
 module.exports = {
   env: {
     browser: true,
@@ -12,5 +34,6 @@ module.exports = {
     indent: ['error', 2],
     'quote-props': ['warn', 'as-needed'],
     'dot-location': ['warn', 'property'],
+    'linebreak-style': [0, 'error', 'windows'],
   },
 };

--- a/lib/Connector/XiboDashboardConnector.php
+++ b/lib/Connector/XiboDashboardConnector.php
@@ -488,7 +488,7 @@ class XiboDashboardConnector implements ConnectorInterface
             $services = $services['serviceType'] ?? [];
 
             foreach ($services as $option) {
-                // If we have already selected a type of dashboard, do not let it be changed.
+                // Filter the list of options by the property value provided (if there is one).
                 if (empty($existingType) || $option['type'] === $existingType) {
                     $options[] = $option;
                 }

--- a/lib/Event/WidgetEditOptionRequestEvent.php
+++ b/lib/Event/WidgetEditOptionRequestEvent.php
@@ -1,8 +1,8 @@
 <?php
 /*
- * Copyright (C) 2022 Xibo Signage Ltd
+ * Copyright (c) 2023  Xibo Signage Ltd
  *
- * Xibo - Digital Signage - http://www.xibo.org.uk
+ * Xibo - Digital Signage - https://xibosignage.com
  *
  * This file is part of Xibo.
  *
@@ -18,6 +18,7 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 
 namespace Xibo\Event;
@@ -27,19 +28,28 @@ use Xibo\Entity\Widget;
 /**
  * An event fired by a widget when presenting its properties
  * should be used by a connector to provide additional options to a dropdown
- *
- * TODO: this is pulled in from 3.2.0, but the code to fire the event doesn't exist in the new widget system
- *  this will need some thought
  */
 class WidgetEditOptionRequestEvent extends Event
 {
     public static $NAME = 'widget.edit.option.event';
+
+    /** @var \Xibo\Entity\Widget  */
     private $widget;
+
+    /** @var string  */
+    private $propertyId;
+
+    /** @var mixed  */
+    private $propertyValue;
+
+    /** @var array|null */
     private $options;
 
-    public function __construct($widget)
+    public function __construct(Widget $widget, string $propertyId, $propertyValue)
     {
         $this->widget = $widget;
+        $this->propertyId = $propertyId;
+        $this->propertyValue = $propertyValue;
     }
 
     /**
@@ -51,6 +61,24 @@ class WidgetEditOptionRequestEvent extends Event
     }
 
     /**
+     * Which property is making this request?
+     * @return string|null The ID of the property `id=""`
+     */
+    public function getPropertyId(): ?string
+    {
+        return $this->propertyId;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getPropertyValue()
+    {
+        return $this->propertyValue;
+    }
+
+    /**
+     * Get the options array
      */
     public function getOptions(): array
     {
@@ -62,6 +90,7 @@ class WidgetEditOptionRequestEvent extends Event
     }
 
     /**
+     * Set a new options array
      * @return $this
      */
     public function setOptions(array $options): WidgetEditOptionRequestEvent

--- a/ui/src/core/forms.js
+++ b/ui/src/core/forms.js
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) 2023 Xibo Signage Ltd
+ * Copyright (c) 2023  Xibo Signage Ltd
  *
- * Xibo - Digital Signage - http://www.xibo.org.uk
+ * Xibo - Digital Signage - https://xibosignage.com
  *
  * This file is part of Xibo.
  *
@@ -17,6 +17,7 @@
  *
  * You should have received a copy of the GNU Affero General Public License
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 /* eslint-disable new-cap */
 // Common functions/tools
@@ -143,14 +144,16 @@ window.forms = {
         // dashboards available services
         if (property.type === 'connectorProperties') {
           property.connectorPropertiesUrl =
-            urlsForApi.connectorProperties.search.url.replace(':id', targetId);
+            urlsForApi.connectorProperties.search.url.replace(':id', targetId) +
+              '?propertyId=' + property.id;
+
           // If we don't have a value, set value key pair to null
           if (property.value == '') {
             property.initialValue = null;
             property.initialKey = null;
           } else {
             property.initialValue = property.value;
-            property.initialKey = 'type';
+            property.initialKey = property.id;
           }
         }
 


### PR DESCRIPTION
I've made a change here so that the front end passes in a propertyId with the request and as the initialKey. The back end then passes that directly into the event so that it can be handled entirely by the connector (or whatever handles the event).