### PR TITLE
Displays: Commercial license column

### DIFF
--- a/lib/Controller/Display.php
+++ b/lib/Controller/Display.php
@@ -716,8 +716,10 @@ class Display extends Base
                     $display->commercialLicenceDescription = __('Display is not licensed');
             }
 
-            $display->commercialLicenceDescription .= ' (' . __('The status will be updated with each Commercial Licence check') . ')';
-            
+            if ($display->clientCode < 400) {
+                $display->commercialLicenceDescription .= ' (' . __('The status will be updated with each Commercial Licence check') . ')';
+            }
+
             // Thumbnail
             $display->thumbnail = '';
             // If we aren't logged in, and we are showThumbnail == 2, then show a circle


### PR DESCRIPTION
- Displays: Clarify that the commercial license column is only up-to-date as of the last command run. Fixes https://github.com/xibosignage/xibo/issues/3031 