### PR TITLE
Schedule : Fix paging on Schedule grid, default to and from date filters

### DIFF
--- a/lib/Controller/Schedule.php
+++ b/lib/Controller/Schedule.php
@@ -2016,7 +2016,11 @@ class Schedule extends Base
         // Call to render the template
         $this->getState()->template = 'schedule-grid-page';
         $this->getState()->setData([
-            'eventTypes' => \Xibo\Entity\Schedule::getEventTypes()
+            'eventTypes' => \Xibo\Entity\Schedule::getEventTypes(),
+            'defaults' => [
+                'fromDate' => Carbon::now()->startOfMonth()->format(DateFormatHelper::getSystemFormat()),
+                'toDate' => Carbon::now()->startOfMonth()->addMonth()->format(DateFormatHelper::getSystemFormat()),
+            ],
         ]);
         return $this->render($request, $response);
     }

--- a/lib/Controller/Schedule.php
+++ b/lib/Controller/Schedule.php
@@ -310,7 +310,7 @@ class Schedule extends Base
             }
         }
 
-        foreach ($this->scheduleFactory->query('FromDT', $filter) as $row) {
+        foreach ($this->scheduleFactory->query(['FromDT'], $filter) as $row) {
             /* @var \Xibo\Entity\Schedule $row */
 
             // Generate this event
@@ -2111,7 +2111,8 @@ class Schedule extends Base
                 'geoAware' => $params->getInt('geoAware'),
                 'recurring' => $params->getInt('recurring'),
                 'campaignId' => $params->getInt('filterCampaignId'),
-                'displayGroupIds' => $params->getIntArray('filterDisplayGroupIds')
+                'displayGroupIds' => $params->getIntArray('filterDisplayGroupIds'),
+                'gridFilter' => 1
             ], $params)
         );
 

--- a/lib/Factory/ScheduleFactory.php
+++ b/lib/Factory/ScheduleFactory.php
@@ -298,7 +298,7 @@ class ScheduleFactory extends BaseFactory
         $entries = [];
         $params = [];
 
-        $sql = '
+        $select = '
         SELECT `schedule`.eventId, 
             `schedule`.eventTypeId,
             `schedule`.fromDt,
@@ -331,7 +331,9 @@ class ScheduleFactory extends BaseFactory
             `schedule`.parentCampaignId,
             `daypart`.isAlways,
             `daypart`.isCustom
-          FROM `schedule`
+        ';
+
+        $body = ' FROM `schedule`
             INNER JOIN `daypart`
             ON `daypart`.dayPartId = `schedule`.dayPartId
             LEFT OUTER JOIN `campaign`
@@ -340,99 +342,98 @@ class ScheduleFactory extends BaseFactory
             ON parentCampaign.campaignId = `schedule`.parentCampaignId
             LEFT OUTER JOIN `command`
             ON `command`.commandId = `schedule`.commandId
-          WHERE 1 = 1
-        ';
+          WHERE 1 = 1';
 
         if ($parsedFilter->getInt('eventId') !== null) {
-            $sql .= ' AND `schedule`.eventId = :eventId ';
+            $body .= ' AND `schedule`.eventId = :eventId ';
             $params['eventId'] = $parsedFilter->getInt('eventId');
         }
 
         if ($parsedFilter->getInt('eventTypeId') !== null) {
-            $sql .= ' AND `schedule`.eventTypeId = :eventTypeId ';
+            $body .= ' AND `schedule`.eventTypeId = :eventTypeId ';
             $params['eventTypeId'] = $parsedFilter->getInt('eventTypeId');
         }
 
         if ($parsedFilter->getInt('campaignId') !== null) {
-            $sql .= ' AND `schedule`.campaignId = :campaignId ';
+            $body .= ' AND `schedule`.campaignId = :campaignId ';
             $params['campaignId'] = $parsedFilter->getInt('campaignId');
         }
 
         if ($parsedFilter->getInt('parentCampaignId') !== null) {
-            $sql .= ' AND `schedule`.parentCampaignId = :parentCampaignId ';
+            $body .= ' AND `schedule`.parentCampaignId = :parentCampaignId ';
             $params['parentCampaignId'] = $parsedFilter->getInt('parentCampaignId');
         }
 
         if ($parsedFilter->getInt('adCampaignsOnly') === 1) {
-            $sql .= ' AND `schedule`.parentCampaignId IS NOT NULL AND `schedule`.eventTypeId = :eventTypeId ';
+            $body .= ' AND `schedule`.parentCampaignId IS NOT NULL AND `schedule`.eventTypeId = :eventTypeId ';
             $params['eventTypeId'] = Schedule::$INTERRUPT_EVENT;
         }
 
         if ($parsedFilter->getInt('recurring') !== null) {
             if ($parsedFilter->getInt('recurring') === 1) {
-                $sql .= ' AND `schedule`.recurrence_type IS NOT NULL ';
+                $body .= ' AND `schedule`.recurrence_type IS NOT NULL ';
             } else if ($parsedFilter->getInt('recurring') === 0) {
-                $sql .= ' AND `schedule`.recurrence_type IS NULL ';
+                $body .= ' AND `schedule`.recurrence_type IS NULL ';
             }
         }
 
         if ($parsedFilter->getInt('geoAware') !== null) {
-            $sql .= ' AND `schedule`.isGeoAware = :geoAware ';
+            $body .= ' AND `schedule`.isGeoAware = :geoAware ';
             $params['geoAware'] = $parsedFilter->getInt('geoAware');
         }
 
         if ($parsedFilter->getInt('ownerId') !== null) {
-            $sql .= ' AND `schedule`.userId = :ownerId ';
+            $body .= ' AND `schedule`.userId = :ownerId ';
             $params['ownerId'] = $parsedFilter->getInt('ownerId');
         }
 
         if ($parsedFilter->getInt('dayPartId') !== null) {
-            $sql .= ' AND `schedule`.dayPartId = :dayPartId ';
+            $body .= ' AND `schedule`.dayPartId = :dayPartId ';
             $params['dayPartId'] = $parsedFilter->getInt('dayPartId');
         }
 
         // Only 1 date
         if ($parsedFilter->getInt('fromDt') !== null && $parsedFilter->getInt('toDt') === null) {
-            $sql .= ' AND schedule.fromDt > :fromDt ';
+            $body .= ' AND schedule.fromDt > :fromDt ';
             $params['fromDt'] = $parsedFilter->getInt('fromDt');
         }
 
         if ($parsedFilter->getInt('toDt') !== null && $parsedFilter->getInt('fromDt') === null) {
-            $sql .= ' AND IFNULL(schedule.toDt, schedule.fromDt) <= :toDt ';
+            $body .= ' AND IFNULL(schedule.toDt, schedule.fromDt) <= :toDt ';
             $params['toDt'] = $parsedFilter->getInt('toDt');
         }
         // End only 1 date
 
         // Both dates
         if ($parsedFilter->getInt('fromDt') !== null && $parsedFilter->getInt('toDt') !== null) {
-            $sql .= ' AND schedule.fromDt < :toDt ';
-            $sql .= ' AND IFNULL(schedule.toDt, schedule.fromDt) >= :fromDt ';
+            $body .= ' AND schedule.fromDt < :toDt ';
+            $body .= ' AND IFNULL(schedule.toDt, schedule.fromDt) >= :fromDt ';
             $params['fromDt'] = $parsedFilter->getInt('fromDt');
             $params['toDt'] = $parsedFilter->getInt('toDt');
         }
         // End both dates
 
         if ($parsedFilter->getIntArray('displayGroupIds') != null) {
-            $sql .= ' AND `schedule`.eventId IN (SELECT `lkscheduledisplaygroup`.eventId FROM `lkscheduledisplaygroup` WHERE displayGroupId IN (' . implode(',', $parsedFilter->getIntArray('displayGroupIds')) . ')) ';
+            $body .= ' AND `schedule`.eventId IN (SELECT `lkscheduledisplaygroup`.eventId FROM `lkscheduledisplaygroup` WHERE displayGroupId IN (' . implode(',', $parsedFilter->getIntArray('displayGroupIds')) . ')) ';
         }
 
         // Future schedules?
         if ($parsedFilter->getInt('futureSchedulesFrom') !== null && $parsedFilter->getInt('futureSchedulesTo') === null) {
             // Get schedules that end after this date, or that recur after this date
-            $sql .= ' AND (IFNULL(`schedule`.toDt, `schedule`.fromDt) >= :futureSchedulesFrom OR `schedule`.recurrence_range >= :futureSchedulesFrom OR (IFNULL(`schedule`.recurrence_range, 0) = 0) AND IFNULL(`schedule`.recurrence_type, \'\') <> \'\') ';
+            $body .= ' AND (IFNULL(`schedule`.toDt, `schedule`.fromDt) >= :futureSchedulesFrom OR `schedule`.recurrence_range >= :futureSchedulesFrom OR (IFNULL(`schedule`.recurrence_range, 0) = 0) AND IFNULL(`schedule`.recurrence_type, \'\') <> \'\') ';
             $params['futureSchedulesFrom'] = $parsedFilter->getInt('futureSchedulesFrom');
         }
 
         if ($parsedFilter->getInt('futureSchedulesFrom') !== null && $parsedFilter->getInt('futureSchedulesTo') !== null) {
             // Get schedules that end after this date, or that recur after this date
-            $sql .= ' AND ((schedule.fromDt < :futureSchedulesTo AND IFNULL(`schedule`.toDt, `schedule`.fromDt) >= :futureSchedulesFrom) OR `schedule`.recurrence_range >= :futureSchedulesFrom OR (IFNULL(`schedule`.recurrence_range, 0) = 0 AND IFNULL(`schedule`.recurrence_type, \'\') <> \'\') ) ';
+            $body .= ' AND ((schedule.fromDt < :futureSchedulesTo AND IFNULL(`schedule`.toDt, `schedule`.fromDt) >= :futureSchedulesFrom) OR `schedule`.recurrence_range >= :futureSchedulesFrom OR (IFNULL(`schedule`.recurrence_range, 0) = 0 AND IFNULL(`schedule`.recurrence_type, \'\') <> \'\') ) ';
             $params['futureSchedulesFrom'] = $parsedFilter->getInt('futureSchedulesFrom');
             $params['futureSchedulesTo'] = $parsedFilter->getInt('futureSchedulesTo');
         }
 
         // Restrict to mediaId - meaning layout schedules of which the layouts contain the selected mediaId
         if ($parsedFilter->getInt('mediaId') !== null) {
-            $sql .= '
+            $body .= '
                 AND schedule.campaignId IN (
                     SELECT `lkcampaignlayout`.campaignId
                       FROM `lkwidgetmedia`
@@ -462,8 +463,7 @@ class ScheduleFactory extends BaseFactory
 
         // Restrict to playlistId - meaning layout schedules of which the layouts contain the selected playlistId
         if ($parsedFilter->getInt('playlistId') !== null) {
-
-            $sql .= '
+            $body .= '
                 AND schedule.campaignId IN (
                     SELECT `lkcampaignlayout`.campaignId
                       FROM `lkplaylistplaylist` 
@@ -485,8 +485,20 @@ class ScheduleFactory extends BaseFactory
         }
 
         // Sorting?
-        if (is_array($sortOrder))
-            $sql .= 'ORDER BY ' . implode(',', $sortOrder);
+        $order = '';
+        if (is_array($sortOrder)) {
+            $order .= 'ORDER BY ' . implode(',', $sortOrder);
+        }
+
+        // Paging
+        $limit = '';
+        // Paging
+        if ($parsedFilter->hasParam('start') && $parsedFilter->hasParam('length')) {
+            $limit = ' LIMIT ' . $parsedFilter->getInt('start', ['default' => 0])
+                . ', ' . $parsedFilter->getInt('length', ['default' => 10]);
+        }
+
+        $sql = $select . $body . $order . $limit;
 
         foreach ($this->getStore()->select($sql, $params) as $row) {
             $entries[] = $this->createEmpty()->hydrate($row, [
@@ -501,6 +513,12 @@ class ScheduleFactory extends BaseFactory
                     'maxPlaysPerHour',
                 ]
             ]);
+        }
+
+        // Paging
+        if ($limit != '' && count($entries) > 0) {
+            $results = $this->getStore()->select('SELECT COUNT(*) AS total ' . $body, $params);
+            $this->_countLast = intval($results[0]['total']);
         }
 
         return $entries;

--- a/ui/src/core/xibo-cms.js
+++ b/ui/src/core/xibo-cms.js
@@ -1567,72 +1567,76 @@ function dataTableConfigureRefresh(gridId, table, refresh) {
     });
 }
 
-function dataTableAddButtons(table, filter, allButtons) {
+function dataTableAddButtons(table, filter, allButtons, resetSort) {
     allButtons = (allButtons === undefined) ? true : allButtons;
+    resetSort = (resetSort === undefined) ? false : resetSort;
+
+    let buttons = [
+        {
+            extend: 'colvis',
+            columns: ':not(.rowMenu)',
+            text: function (dt, button, config) {
+                return dt.i18n('buttons.colvis');
+            }
+        },
+    ];
+
+    if (resetSort) {
+        buttons.push(
+          {
+              text: translations.defaultSorting,
+              action: function ( e, dt, node, config ) {
+                  table.order([]).draw();
+              }
+          }
+        )
+    }
 
     if (allButtons) {
-        var colVis = new $.fn.dataTable.Buttons(table, {
-            buttons: [
-                {
-                    extend: 'colvis',
-                    columns: ':not(.rowMenu)',
-                    text: function (dt, button, config) {
-                        return dt.i18n('buttons.colvis');
-                    }
-                },
-                {
-                    extend: 'print',
-                    text: function (dt, button, config) {
-                        return dt.i18n('buttons.print');
-                    },
-                    exportOptions: {
-                        orthogonal: 'export',
-                        format: {
-                            body: function (data, row, column, node) {
-                                if (data === null || data === "" || data === "null")
-                                    return "";
-                                else
-                                    return data;
-                            }
-                        }
-                    },
-                  customize: function (win) {
-                    let table = $(win.document.body).find('table');
-                    table.removeClass('nowrap responsive dataTable no-footer dtr-inline');
-                    if (table.find('th').length > 16) {
+        buttons.push(
+          {
+              extend: 'print',
+              text: function (dt, button, config) {
+                  return dt.i18n('buttons.print');
+              },
+              exportOptions: {
+                  orthogonal: 'export',
+                  format: {
+                      body: function (data, row, column, node) {
+                          if (data === null || data === "" || data === "null")
+                              return "";
+                          else
+                              return data;
+                      }
+                  }
+              },
+              customize: function (win) {
+                  let table = $(win.document.body).find('table');
+                  table.removeClass('nowrap responsive dataTable no-footer dtr-inline');
+                  if (table.find('th').length > 16) {
                       table.addClass('table-sm');
                       table.css('font-size', '6px');
-                    }
                   }
-                },
-                {
-                    extend: 'csv',
-                    exportOptions: {
-                        orthogonal: 'export',
-                        format: {
-                            body: function (data, row, column, node) {
-                                if (data === null || data === "")
-                                    return "";
-                                else
-                                    return data;
-                            }
-                        }
-                    }
-                }
-            ]
-        });
-    } else {
-        var colVis = new $.fn.dataTable.Buttons(table, {
-            buttons: [
-                {
-                    extend: 'colvis',
-                    text: function (dt, button, config) {
-                        return dt.i18n('buttons.colvis');
-                    }
-                }
-            ]
-        });
+              }
+          },
+          {
+              extend: 'csv',
+              exportOptions: {
+                  orthogonal: 'export',
+                  format: {
+                      body: function (data, row, column, node) {
+                          if (data === null || data === "")
+                              return "";
+                          else
+                              return data;
+                      }
+                  }
+              }
+          },
+        )
     }
+
+    new $.fn.dataTable.Buttons(table, {buttons: buttons});
 
     table.buttons( 0, null ).container().prependTo(filter);
     $(filter).addClass('text-right');

--- a/views/base.twig
+++ b/views/base.twig
@@ -114,6 +114,7 @@
             translations.notUpToDate = "{{ "Not up to date"|trans }}";
             translations.publishedStatusFuture = "{{ "Publishing"|trans }}";
             translations.publishedStatusFailed = "{{ "Publish failed."|trans }}";
+            translations.defaultSorting = "{{ "Default Sorting"|trans }}";
             {% endautoescape %}
 
             var calendarType = "{{ settings.CALENDAR_TYPE }}";

--- a/views/schedule-form-add.twig
+++ b/views/schedule-form-add.twig
@@ -130,7 +130,7 @@
 
                         {{ forms.hidden('fullScreenCampaignId') }}
 
-                        {% set title %}{% trans "Layout Duration" %}{% endset %}
+                        {% set title %}{% trans "Duration in Loop" %}{% endset %}
                         {% set helpText %}{% trans "For long should this Media be displayed in each loop? If left empty it will default to Media duration" %}{% endset %}
                         {{ forms.number('layoutDuration', title, "", helpText, 'media-control no-full-screen-layout') }}
 

--- a/views/schedule-form-edit.twig
+++ b/views/schedule-form-edit.twig
@@ -138,7 +138,7 @@
 
                         {{ forms.hidden('fullScreenCampaignId') }}
 
-                        {% set title %}{% trans "Layout Duration" %}{% endset %}
+                        {% set title %}{% trans "Duration in Loop" %}{% endset %}
                         {% set helpText %}{% trans "For long should this Media be displayed in each loop? If left empty it will default to Media duration" %}{% endset %}
                         {{ forms.number('layoutDuration', title, "", helpText, 'media-control no-full-screen-layout') }}
 

--- a/views/schedule-form-now.twig
+++ b/views/schedule-form-now.twig
@@ -92,7 +92,7 @@
 
                 {{ forms.hidden('fullScreenCampaignId') }}
 
-                {% set title %}{% trans "Layout Duration" %}{% endset %}
+                {% set title %}{% trans "Duration in Loop" %}{% endset %}
                 {% set helpText %}{% trans "For long should this Media be displayed in each loop? If left empty it will default to Media duration" %}{% endset %}
                 {{ forms.number('layoutDuration', title, "", helpText, 'media-control no-full-screen-layout') }}
 

--- a/views/schedule-grid-page.twig
+++ b/views/schedule-grid-page.twig
@@ -20,10 +20,10 @@
                     <div class="FilterDiv card-body" id="Filter">
                         <form class="form-inline">
                             {% set title %}{% trans 'From Date' %}{% endset %}
-                            {{ inline.dateTime("fromDt", title, "", "", "", "", "") }}
+                            {{ inline.dateTime("fromDt", title, defaults.fromDate, "", "", "", "") }}
 
                             {% set title %}{% trans 'To Date' %}{% endset %}
-                            {{ inline.dateTime("toDt", title, "", "", "", "", "") }}
+                            {{ inline.dateTime("toDt", title, defaults.toDate, "", "", "", "") }}
 
                             {% set title %}{% trans 'Event Type' %}{% endset %}
                             {{ inline.dropdown("filterEventTypeId", "single", title, "", [{id: null, value: ""}]|merge(eventTypes), "eventTypeId", "eventTypeName") }}
@@ -130,7 +130,8 @@
           columns: [
             {
               data: 'eventId',
-              responsivePriority: 2
+              responsivePriority: 5,
+              className: 'none',
             },
             {
               name: 'eventTypeId',
@@ -167,7 +168,8 @@
             },
             {
               data: 'campaignId',
-              responsivePriority: 3,
+              responsivePriority: 5,
+              className: 'none',
             },
             {
               name: 'displayGroups',

--- a/views/schedule-grid-page.twig
+++ b/views/schedule-grid-page.twig
@@ -120,7 +120,7 @@
           stateSaveCallback: dataTableStateSaveCallback,
           filter: false,
           searchDelay: 3000,
-          order: [[0, 'desc']],
+          order: [],
           ajax: {
             url: '{{ url_for("schedule.search") }}',
             data: function (d) {
@@ -174,6 +174,7 @@
             {
               name: 'displayGroups',
               responsivePriority: 2,
+              sortable: false,
               data: function (data) {
                 if (data.displayGroups.length > 1) {
                   return '<span class="badge" style="background-color: green; color: white" ' +
@@ -260,7 +261,7 @@
           $('[data-toggle="popover"]').popover();
         });
         table.on('processing.dt', dataTableProcessing);
-        dataTableAddButtons(table, $('#schedule-grid_wrapper').find('.dataTables_buttons'));
+        dataTableAddButtons(table, $('#schedule-grid_wrapper').find('.dataTables_buttons'), true, true);
       });
     </script>
 {% endblock %}


### PR DESCRIPTION
- Fix Schedule grid paging
- Add default from/to date filters (to be improved later on with date range input)
- Hide event and campaignId by default (still accessible under `+` button)
- Rename `Layout Duration` to `Duration in Loop` in schedule forms for Media Library event Type
- Attempt at a clever default sort on Schedule grid - first always events, then recurring events, then everything else
- A new grid button to reset the filter (only on Schedule grid at the moment)
- Fix some sorting/ordering issues with Schedule grid