### PR TITLE
Schedule full screen : wording adjustments and minor fixes

### DIFF
--- a/lib/Controller/Schedule.php
+++ b/lib/Controller/Schedule.php
@@ -1089,7 +1089,7 @@ class Schedule extends Base
         $schedule->recurrenceRepeatsOn = (empty($recurrenceRepeatsOn)) ? null : implode(',', $recurrenceRepeatsOn);
         $schedule->recurrenceMonthlyRepeatsOn = $sanitizedParams->getInt('recurrenceMonthlyRepeatsOn', ['default' => 0]);
 
-        foreach ($sanitizedParams->getIntArray('displayGroupIds') as $displayGroupId) {
+        foreach ($sanitizedParams->getIntArray('displayGroupIds', ['default' => []]) as $displayGroupId) {
             $schedule->assignDisplayGroup($this->displayGroupFactory->getById($displayGroupId));
         }
 
@@ -1666,7 +1666,7 @@ class Schedule extends Base
             $schedule->dayPartId = $this->dayPartFactory->getCustomDayPart()->dayPartId;
         }
 
-        foreach ($sanitizedParams->getIntArray('displayGroupIds') as $displayGroupId) {
+        foreach ($sanitizedParams->getIntArray('displayGroupIds', ['default' => []]) as $displayGroupId) {
             $schedule->assignDisplayGroup($this->displayGroupFactory->getById($displayGroupId));
         }
 

--- a/lib/Entity/Schedule.php
+++ b/lib/Entity/Schedule.php
@@ -1732,8 +1732,8 @@ class Schedule implements \JsonSerializable
             ['eventTypeId' => self::$INTERRUPT_EVENT, 'eventTypeName' => __('Interrupt Layout')],
             ['eventTypeId' => self::$CAMPAIGN_EVENT, 'eventTypeName' => __('Campaign')],
             ['eventTypeId' => self::$ACTION_EVENT, 'eventTypeName' => __('Action')],
-            ['eventTypeId' => self::$MEDIA_EVENT, 'eventTypeName' => __('Library Media')],
-            ['eventTypeId' => self::$PLAYLIST_EVENT, 'eventTypeName' => __('Playlist')],
+            ['eventTypeId' => self::$MEDIA_EVENT, 'eventTypeName' => __('Full Screen Video/Image')],
+            ['eventTypeId' => self::$PLAYLIST_EVENT, 'eventTypeName' => __('Full Screen Playlist')],
         ];
     }
 }

--- a/ui/src/core/xibo-calendar.js
+++ b/ui/src/core/xibo-calendar.js
@@ -746,8 +746,12 @@ var beforeSubmitScheduleForm = function(form) {
           .then(
             (response) => {
                 if (!response.success) {
-                    SystemMessage((response.message == '') ? translation.failure : response.message, false);
+                    SystemMessageInline(
+                      (response.message === '') ? translations.failure : response.message,
+                      form.closest('.modal'),
+                    );
                 }
+
                 form.find('#fullScreenCampaignId').val(response.data.campaignId);
                 form.submit();
             }, (xhr) => {

--- a/views/base.twig
+++ b/views/base.twig
@@ -115,6 +115,7 @@
             translations.publishedStatusFuture = "{{ "Publishing"|trans }}";
             translations.publishedStatusFailed = "{{ "Publish failed."|trans }}";
             translations.defaultSorting = "{{ "Default Sorting"|trans }}";
+            translations.unlimited = "{{ "Unlimited"|trans }}";
             {% endautoescape %}
 
             var calendarType = "{{ settings.CALENDAR_TYPE }}";

--- a/views/schedule-form-add.twig
+++ b/views/schedule-form-add.twig
@@ -105,10 +105,10 @@
 
 
                         {% set title %}{% trans "Media" %}{% endset %}
-                        {% set helpText %}{% trans "Select a Media from Library - a full screen Layout containing this Media will be created and scheduled in one step" %}{% endset %}
+                        {% set helpText %}{% trans "Choose a media item on the library you want shown full screen" %}{% endset %}
                         {% set attributes = [
                             { name: "data-width", value: "100%" },
-                            { name: "data-search-url", value: url_for("library.search") ~ "?fullScreenScheduleCheck=true" },
+                            { name: "data-search-url", value: url_for("library.search") ~ "?fullScreenScheduleCheck=true&types[]=image&types[]=video" },
                             { name: "data-search-term", value: "media" },
                             { name: "data-id-property", value: "mediaId" },
                             { name: "data-text-property", value: "name" },
@@ -117,7 +117,7 @@
                         {{ forms.dropdown("mediaId", "single", title, "", null, "mediaId", "name", helpText, "pagedSelect media-control", "", "", "", attributes) }}
 
                         {% set title %}{% trans "Playlist" %}{% endset %}
-                        {% set helpText %}{% trans "Select a Playlist - a full screen Layout containing this Playlist will be created and scheduled in one step" %}{% endset %}
+                        {% set helpText %}{% trans "Choose a Playlist you want shown full screen" %}{% endset %}
                         {% set attributes = [
                             { name: "data-width", value: "100%" },
                             { name: "data-search-url", value: url_for("playlist.search") ~ "?fullScreenScheduleCheck=true" },
@@ -130,24 +130,24 @@
 
                         {{ forms.hidden('fullScreenCampaignId') }}
 
-                        {% set title %}{% trans "Duration in Loop" %}{% endset %}
-                        {% set helpText %}{% trans "For long should this Media be displayed in each loop? If left empty it will default to Media duration" %}{% endset %}
+                        {% set title %}{% trans "Duration in loop" %}{% endset %}
+                        {% set helpText %}{% trans "Set how long this item should be shown each time it appears in the schedule. Leave blank to use the Media Duration set in the Library" %}{% endset %}
                         {{ forms.number('layoutDuration', title, "", helpText, 'media-control no-full-screen-layout') }}
 
                         {% set title %}{% trans "Resolution" %}{% endset %}
-                        {% set helpText %}{% trans "Optionally select a Resolution for this Full screen Layout, if left empty it will default to existing resolution matching the Media size the closest" %}{% endset %}
+                        {% set helpText %}{% trans "Optionally select a Resolution to use for the selected Media. Leave blank to match with an existing Resolution closest in size to the selected media." %}{% endset %}
                         {% set attributes = [
                             { name: "data-search-url", value: url_for("resolution.search") },
                             { name: "data-search-term", value: "resolution" },
                             { name: "data-id-property", value: "resolutionId" },
                             { name: "data-text-property", value: "resolution" },
-                            { name: "data-trans-media-help-text", value: "Optionally select a Resolution for Full screen Layout containing selected Media, if left empty it will default to existing resolution closest in size to selected Media"|trans },
-                            { name: "data-trans-playlist-help-text", value: "Optionally select a Resolution for Full screen Layout containing this Playlist, if left empty it will default to 1080p Resolution"|trans },
+                            { name: "data-trans-media-help-text", value: "Optionally select a Resolution to use for the selected Media. Leave blank to match with an existing Resolution closest in size to the selected media."|trans },
+                            { name: "data-trans-playlist-help-text", value: "Optionally select a Resolution to use for the selected Playlist. Leave blank to default to a 1080p Resolution"|trans },
                         ] %}
                         {{ forms.dropdown("resolutionId", "single", title, "", null, "resolutionId", "resolution", helpText, "pagedSelect media-playlist-control resolution-control no-full-screen-layout", "", "", "", attributes) }}
 
                         {% set title %}{% trans "Background Colour" %}{% endset %}
-                        {% set helpText %}{% trans "Optionally use the colour picker to select the Layout background colour" %}{% endset %}
+                        {% set helpText %}{% trans "Optionally set a colour to use as a background for if the item selected does not fill the entire screen" %}{% endset %}
                         {{ forms.colorPicker("backgroundColor", title, '#000', helpText, 'media-playlist-control no-full-screen-layout') }}
 
                         <div class="form-group row preview-button-container">

--- a/views/schedule-form-edit.twig
+++ b/views/schedule-form-edit.twig
@@ -109,10 +109,10 @@
                         {{ forms.dropdown("campaignId", "single", title, event.campaignId, [campaign], "campaignId", "campaign", helpText, "layout-control", "", "", "", attributes) }}
 
                         {% set title %}{% trans "Media" %}{% endset %}
-                        {% set helpText %}{% trans "Select a Media from Library - a full screen Layout containing this Media will be created and scheduled in one step" %}{% endset %}
+                        {% set helpText %}{% trans "Choose a media item on the library you want shown full screen" %}{% endset %}
                         {% set attributes = [
                             { name: "data-width", value: "100%" },
-                            { name: "data-search-url", value: url_for("library.search") ~ "?fullScreenScheduleCheck=true" },
+                            { name: "data-search-url", value: url_for("library.search") ~ "?fullScreenScheduleCheck=true&types[]=image&types[]=video" },
                             { name: "data-search-term", value: "media" },
                             { name: "data-id-property", value: "mediaId" },
                             { name: "data-text-property", value: "name" },
@@ -123,7 +123,7 @@
                         {{ forms.dropdown("mediaId", "single", title, media.mediaId, [media], "mediaId", "name", helpText, "pagedSelect media-control", "", "", "", attributes) }}
 
                         {% set title %}{% trans "Playlist" %}{% endset %}
-                        {% set helpText %}{% trans "Select a Playlist - a full screen Layout containing this Playlist will be created and scheduled in one step" %}{% endset %}
+                        {% set helpText %}{% trans "Choose a Playlist you want shown full screen" %}{% endset %}
                         {% set attributes = [
                             { name: "data-width", value: "100%" },
                             { name: "data-search-url", value: url_for("playlist.search") ~ "?fullScreenScheduleCheck=true" },
@@ -138,24 +138,24 @@
 
                         {{ forms.hidden('fullScreenCampaignId') }}
 
-                        {% set title %}{% trans "Duration in Loop" %}{% endset %}
-                        {% set helpText %}{% trans "For long should this Media be displayed in each loop? If left empty it will default to Media duration" %}{% endset %}
+                        {% set title %}{% trans "Duration in loop" %}{% endset %}
+                        {% set helpText %}{% trans "Set how long this item should be shown each time it appears in the schedule. Leave blank to use the Media Duration set in the Library" %}{% endset %}
                         {{ forms.number('layoutDuration', title, "", helpText, 'media-control no-full-screen-layout') }}
 
                         {% set title %}{% trans "Resolution" %}{% endset %}
-                        {% set helpText %}{% trans "Optionally select a Resolution for this Full screen Layout, if left empty it will default to existing resolution matching the Media size the closest" %}{% endset %}
+                        {% set helpText %}{% trans "Optionally select a Resolution to use for the selected Media. Leave blank to match with an existing Resolution closest in size to the selected media." %}{% endset %}
                         {% set attributes = [
                             { name: "data-search-url", value: url_for("resolution.search") },
                             { name: "data-search-term", value: "resolution" },
                             { name: "data-id-property", value: "resolutionId" },
                             { name: "data-text-property", value: "resolution" },
-                            { name: "data-trans-media-help-text", value: "Optionally select a Resolution for Full screen Layout containing selected Media, if left empty it will default to existing resolution closest in size to selected Media"|trans },
-                            { name: "data-trans-playlist-help-text", value: "Optionally select a Resolution for Full screen Layout containing this Playlist, if left empty it will default to 1080p Resolution"|trans },
+                            { name: "data-trans-media-help-text", value: "Optionally select a Resolution to use for the selected Media. Leave blank to match with an existing Resolution closest in size to the selected media."|trans },
+                            { name: "data-trans-playlist-help-text", value: "Optionally select a Resolution to use for the selected Playlist. Leave blank to default to a 1080p Resolution."|trans },
                         ] %}
                         {{ forms.dropdown("resolutionId", "single", title, "", null, "resolutionId", "resolution", helpText, "pagedSelect media-playlist-control resolution-control no-full-screen-layout", "", "", "", attributes) }}
 
                         {% set title %}{% trans "Background Colour" %}{% endset %}
-                        {% set helpText %}{% trans "Optionally use the colour picker to select the Layout background colour" %}{% endset %}
+                        {% set helpText %}{% trans "Optionally set a colour to use as a background for if the item selected does not fill the entire screen" %}{% endset %}
                         {{ forms.colorPicker("backgroundColor", title, '#000', helpText, 'media-playlist-control no-full-screen-layout') }}
                         <div class="form-group row preview-button-container">
                             <div class="offset-md-2 col-md-10">

--- a/views/schedule-form-now.twig
+++ b/views/schedule-form-now.twig
@@ -63,10 +63,10 @@
                 {{ forms.dropdown("campaignId", "single", title, campaign.campaignId, [campaign], "campaignId", "campaign", helpText, "layout-control", "", "", "", attributes) }}
 
                 {% set title %}{% trans "Media" %}{% endset %}
-                {% set helpText %}{% trans "Select a Media from Library - a full screen Layout containing this Media will be created and scheduled in one step" %}{% endset %}
+                {% set helpText %}{% trans "Choose a media item on the library you want shown full screen" %}{% endset %}
                 {% set attributes = [
                     { name: "data-width", value: "100%" },
-                    { name: "data-search-url", value: url_for("library.search") ~ "?fullScreenScheduleCheck=true" },
+                    { name: "data-search-url", value: url_for("library.search") ~ "?fullScreenScheduleCheck=true&types[]=image&types[]=video" },
                     { name: "data-search-term", value: "media" },
                     { name: "data-id-property", value: "mediaId" },
                     { name: "data-text-property", value: "name" },
@@ -77,7 +77,7 @@
                 {{ forms.dropdown("mediaId", "single", title, media.mediaId, [media], "mediaId", "name", helpText, "pagedSelect media-control", "", "", "", attributes) }}
 
                 {% set title %}{% trans "Playlist" %}{% endset %}
-                {% set helpText %}{% trans "Select a Playlist - a full screen Layout containing this Playlist will be created and scheduled in one step" %}{% endset %}
+                {% set helpText %}{% trans "Choose a Playlist you want shown full screen" %}{% endset %}
                 {% set attributes = [
                     { name: "data-width", value: "100%" },
                     { name: "data-search-url", value: url_for("playlist.search") ~ "?fullScreenScheduleCheck=true" },
@@ -92,24 +92,24 @@
 
                 {{ forms.hidden('fullScreenCampaignId') }}
 
-                {% set title %}{% trans "Duration in Loop" %}{% endset %}
-                {% set helpText %}{% trans "For long should this Media be displayed in each loop? If left empty it will default to Media duration" %}{% endset %}
+                {% set title %}{% trans "Duration in loop" %}{% endset %}
+                {% set helpText %}{% trans "Set how long this item should be shown each time it appears in the schedule. Leave blank to use the Media Duration set in the Library" %}{% endset %}
                 {{ forms.number('layoutDuration', title, "", helpText, 'media-control no-full-screen-layout') }}
 
                 {% set title %}{% trans "Resolution" %}{% endset %}
-                {% set helpText %}{% trans "Optionally select a Resolution for this Full screen Layout, if left empty it will default to existing resolution matching the Media size the closest" %}{% endset %}
+                {% set helpText %}{% trans "Optionally select a Resolution to use for the selected Media. Leave blank to match with an existing Resolution closest in size to the selected media." %}{% endset %}
                 {% set attributes = [
                     { name: "data-search-url", value: url_for("resolution.search") },
                     { name: "data-search-term", value: "resolution" },
                     { name: "data-id-property", value: "resolutionId" },
                     { name: "data-text-property", value: "resolution" },
-                    { name: "data-trans-media-help-text", value: "Optionally select a Resolution for Full screen Layout containing selected Media, if left empty it will default to existing resolution closest in size to selected Media"|trans },
-                    { name: "data-trans-playlist-help-text", value: "Optionally select a Resolution for Full screen Layout containing this Playlist, if left empty it will default to 1080p Resolution"|trans },
+                    { name: "data-trans-media-help-text", value: "Optionally select a Resolution to use for the selected Media. Leave blank to match with an existing Resolution closest in size to the selected media."|trans },
+                    { name: "data-trans-playlist-help-text", value: "Optionally select a Resolution to use for the selected Playlist. Leave blank to default to a 1080p Resolution."|trans },
                 ] %}
                 {{ forms.dropdown("resolutionId", "single", title, "", null, "resolutionId", "resolution", helpText, "pagedSelect media-playlist-control resolution-control no-full-screen-layout", "", "", "", attributes) }}
 
                 {% set title %}{% trans "Background Colour" %}{% endset %}
-                {% set helpText %}{% trans "Optionally use the colour picker to select the Layout background colour" %}{% endset %}
+                {% set helpText %}{% trans "Optionally set a colour to use as a background for if the item selected does not fill the entire screen" %}{% endset %}
                 {{ forms.colorPicker("backgroundColor", title, '#000', helpText, 'media-playlist-control no-full-screen-layout') }}
 
                 {% set title %}{% trans "Always?" %}{% endset %}

--- a/views/schedule-grid-page.twig
+++ b/views/schedule-grid-page.twig
@@ -26,7 +26,7 @@
                             {{ inline.dateTime("toDt", title, defaults.toDate, "", "", "", "") }}
 
                             {% set title %}{% trans 'Event Type' %}{% endset %}
-                            {{ inline.dropdown("filterEventTypeId", "single", title, "", [{id: null, value: ""}]|merge(eventTypes), "eventTypeId", "eventTypeName") }}
+                            {{ inline.dropdown("filterEventTypeId", "single", title, "", [{eventTypeId: null, eventTypeName: "All"}]|merge(eventTypes), "eventTypeId", "eventTypeName") }}
 
                             {% set attributes = [
                                 { name: "data-width", value: "200px" },
@@ -58,7 +58,7 @@
 
                             {% set title %}{% trans 'Geo Aware?' %}{% endset %}
                             {% set options = [
-                                { id: null, name: ""|trans },
+                                { id: null, name: "Both"|trans },
                                 { id: 0, name: "No"|trans },
                                 { id: 1, name: "Yes"|trans }
                             ] %}
@@ -66,7 +66,7 @@
 
                             {% set title %}{% trans 'Recurring?' %}{% endset %}
                             {% set options = [
-                                { id: null, name: "" },
+                                { id: null, name: "Both" },
                                 { id: 0, name: "No"|trans },
                                 { id: 1, name: "Yes"|trans }
                             ] %}
@@ -86,6 +86,7 @@
                             <th>{% trans 'Campaign ID' %}</th>
                             <th>{% trans 'Display Groups' %}</th>
                             <th>{% trans 'SoV' %}</th>
+                            <th>{% trans 'Max Plays per Hour' %}</th>
                             <th>{% trans 'Geo Aware?' %}</th>
                             <th>{% trans 'Recurring?' %}</th>
                             <th>{% trans 'Recurrence Type' %}</th>
@@ -191,6 +192,17 @@
               responsivePriority: 4,
             },
             {
+              name:'maxPlaysPerHour',
+              responsivePriority: 4,
+              data: function (data) {
+                if (data.maxPlaysPerHour === 0) {
+                  return translations.unlimited;
+                } else {
+                  return data.maxPlaysPerHour;
+                }
+              }
+            },
+            {
               data:'isGeoAware',
               responsivePriority: 4,
               "render": dataTableTickCrossColumn,
@@ -237,7 +249,7 @@
               name: 'recurrenceRange',
               responsivePriority: 4,
               data: function(data) {
-                if (data.recurringEvent) {
+                if (data.recurringEvent && data.recurrenceRange !== null) {
                   return moment(data.recurrenceRange, 'X').format(jsDateFormat)
                 } else {
                   return ''


### PR DESCRIPTION
- Various wording adjustments on schedule forms and grid
- Default some filters on Schedule grid to All/Both instead of an empty string
- Add Max plays per hour to the Schedule grid
- Fix `Invalid Date` in Recurrence End for Recurring event without end date
- Show only Image and Video in the Media selector on schedule grids for Full Screen schedule
- Fix PHP warning on schedule forms with no DisplayGroup selected
- Use SystemMessageInline instead of SystemMessage for errors during layout create/fetch for full screen schedule