### PR TITLE
Widget upgrade fix: Wrong legacy type on clock

### DIFF
--- a/modules/clock-analogue.xml
+++ b/modules/clock-analogue.xml
@@ -27,7 +27,7 @@
     <compatibilityClass>\Xibo\Widget\Compatibility\ClockWidgetCompatibility</compatibilityClass>
     <type>clock-analogue</type>
     <group id="clock" icon="clock">Clock</group>
-    <legacyType condition="clockTypeId==1">countdown</legacyType>
+    <legacyType condition="clockTypeId==1">clock</legacyType>
     <dataType></dataType>
     <schemaVersion>1</schemaVersion>
     <assignable>1</assignable>

--- a/modules/clock-digital.xml
+++ b/modules/clock-digital.xml
@@ -27,7 +27,7 @@
     <compatibilityClass>\Xibo\Widget\Compatibility\ClockWidgetCompatibility</compatibilityClass>
     <type>clock-digital</type>
     <group id="clock" icon="clock">Clock</group>
-    <legacyType condition="clockTypeId==2">countdown</legacyType>
+    <legacyType condition="clockTypeId==2">clock</legacyType>
     <dataType></dataType>
     <schemaVersion>1</schemaVersion>
     <assignable>1</assignable>

--- a/modules/clock-flip.xml
+++ b/modules/clock-flip.xml
@@ -27,7 +27,7 @@
     <compatibilityClass>\Xibo\Widget\Compatibility\ClockWidgetCompatibility</compatibilityClass>
     <type>clock-flip</type>
     <group id="clock" icon="clock">Clock</group>
-    <legacyType condition="clockTypeId==3">countdown</legacyType>
+    <legacyType condition="clockTypeId==3">clock</legacyType>
     <dataType></dataType>
     <schemaVersion>1</schemaVersion>
     <assignable>1</assignable>


### PR DESCRIPTION
- https://github.com/xibosignageltd/xibo-private/issues/209