### PR TITLE
XMDS PHPUnit tests and other fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ openooh/specification.json
 
 # PHPStorm config
 tests/http-client.private.env.json
+/.phpunit.result.cache

--- a/lib/Controller/Library.php
+++ b/lib/Controller/Library.php
@@ -1146,7 +1146,7 @@ class Library extends Base
         // Get Valid Extensions
         if ($parsedBody->getInt('oldMediaId', ['default' => $options['oldMediaId']]) !== null) {
             $media = $this->mediaFactory->getById($parsedBody->getInt('oldMediaId', ['default' => $options['oldMediaId']]));
-            $oldFolderId = $media->folderId;
+            $folderId = $media->folderId;
             $validExt = $this->moduleFactory->getValidExtensions(['type' => $media->mediaType, 'allowMediaTypeChange' => $options['allowMediaTypeChange']]);
         } else {
             $validExt = $this->moduleFactory->getValidExtensions();

--- a/lib/Controller/UserGroup.php
+++ b/lib/Controller/UserGroup.php
@@ -24,7 +24,6 @@ namespace Xibo\Controller;
 use Slim\Http\Response as Response;
 use Slim\Http\ServerRequest as Request;
 use Xibo\Entity\Permission;
-use Xibo\Entity\User;
 use Xibo\Factory\PermissionFactory;
 use Xibo\Factory\UserFactory;
 use Xibo\Factory\UserGroupFactory;
@@ -137,7 +136,10 @@ class UserGroup extends Base
         foreach ($groups as $group) {
             /* @var \Xibo\Entity\UserGroup $group */
 
-            $group->libraryQuotaFormatted = ByteFormatter::format($group->libraryQuota * 1024);
+            $group->setUnmatchedProperty(
+                'libraryQuotaFormatted',
+                ByteFormatter::format($group->libraryQuota * 1024)
+            );
 
             if ($this->isApi($request)) {
                 continue;

--- a/lib/Entity/Layout.php
+++ b/lib/Entity/Layout.php
@@ -1653,8 +1653,10 @@ class Layout implements \JsonSerializable
                             continue;
                         }
 
-                        $optionNode = $document->createElement($property->id, $property->value ?? '');
-                        $optionsNode->appendChild($optionNode);
+                        if (!empty($property->id)) {
+                            $optionNode = $document->createElement($property->id, $property->value ?? '');
+                            $optionsNode->appendChild($optionNode);
+                        }
                     }
 
                     if ($property->id === 'updateInterval') {

--- a/lib/Factory/TagFactory.php
+++ b/lib/Factory/TagFactory.php
@@ -69,7 +69,7 @@ class TagFactory extends BaseFactory
         $tagLink = $this->createEmptyLink();
         $tagLink->tag = trim($tag);
         $tagLink->tagId = $tagId;
-        $tagLink->value = trim($value);
+        $tagLink->value = trim($value ?? '');
 
         return $tagLink;
     }

--- a/lib/XTR/MaintenanceRegularTask.php
+++ b/lib/XTR/MaintenanceRegularTask.php
@@ -431,7 +431,9 @@ class MaintenanceRegularTask implements TaskInterface
         if (count($layouts) > 0) {
             foreach ($layouts as $layout) {
                 // check if the layout should be published now according to the date
-                if (Carbon::createFromTimestamp($layout->publishedDate)->format('U') < Carbon::now()->format('U')) {
+                if (Carbon::createFromFormat(DateFormatHelper::getSystemFormat(), $layout->publishedDate)
+                    ->isBefore(Carbon::now()->format(DateFormatHelper::getSystemFormat()))
+                ) {
                     try {
                         // publish the layout
                         $layout = $this->layoutFactory->concurrentRequestLock($layout, true);

--- a/lib/Xmds/Soap.php
+++ b/lib/Xmds/Soap.php
@@ -379,6 +379,11 @@ class Soap
                             'media' => 'M',
                             default => 'P',
                         };
+
+                        if ($node->getAttribute('id') < 0 && $type === 'M') {
+                            $type = 'P';
+                        }
+
                         $newUrl = $this->generateRequiredFileDownloadPath(
                             $type,
                             $node->getAttribute('id'),
@@ -2755,6 +2760,7 @@ class Soap
                 $file->setAttribute('path', $dependencyBasePath);
             }
             $file->setAttribute('id', $dependency->legacyId);
+            $file->setAttribute('fileType', 'media');
         }
 
         // Add our node

--- a/lib/Xmds/Soap5.php
+++ b/lib/Xmds/Soap5.php
@@ -424,6 +424,8 @@ class Soap5 extends Soap4
             }
 
             $display->commercialLicence = $commercialLicence;
+            $node = $return->createElement('commercialLicence', $commercialLicenceString);
+            $displayElement->appendChild($node);
         }
 
         // commercial licence not applicable for Windows and Linux players.

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,8 +1,26 @@
+<!--
+  ~ Copyright (C) 2023 Xibo Signage Ltd
+  ~
+  ~ Xibo - Digital Signage - https://xibosignage.com
+  ~
+  ~ This file is part of Xibo.
+  ~
+  ~ Xibo is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ any later version.
+  ~
+  ~ Xibo is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
 <phpunit bootstrap="tests/Bootstrap.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true">
+         colors="true">
       <testsuites>
         <testsuite name="Xibo Integration Test Suite">
             <directory suffix="Test.php">tests/integration/</directory>
@@ -12,19 +30,22 @@
         <testsuite name="Xibo Unit-Test Suite">
             <directory suffix="Test.php">tests/Widget/</directory>
         </testsuite>
+        <testsuite name="Xibo XMDS Test Suite">
+            <directory suffix="Test.php">tests/xmds/</directory>
+        </testsuite>
       </testsuites>
     <groups>
       <exclude>
         <group>broken</group>
       </exclude>
     </groups>
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>lib</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
     <logging>
-        <log type="junit" target="results.xml" logIncompleteSkipped="true"/>
+        <junit outputFile="results.xml"/>
     </logging>
     <php>
         <ini name="memory_limit" value="-1" />

--- a/tests/Bootstrap.php
+++ b/tests/Bootstrap.php
@@ -1,9 +1,10 @@
 <?php
 /*
- * Xibo - Digital Signage - http://www.xibo.org.uk
- * Copyright (C) 2015 Spring Signage Ltd
+ * Copyright (C) 2023 Xibo Signage Ltd
  *
- * This file (UserFactory.php) is part of Xibo.
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
  *
  * Xibo is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as published by
@@ -27,6 +28,7 @@ define('PROJECT_ROOT', realpath(__DIR__ . '/..'));
 
 require_once PROJECT_ROOT . '/vendor/autoload.php';
 require_once PROJECT_ROOT . '/tests/LocalWebTestCase.php';
+require_once PROJECT_ROOT . '/tests/xmdsTestCase.php';
 
 if (!file_exists(PROJECT_ROOT . '/web/settings.php'))
     die('Not configured');

--- a/tests/LocalWebTestCase.php
+++ b/tests/LocalWebTestCase.php
@@ -1,8 +1,8 @@
 <?php
 /*
- * Copyright (c) 2022 Xibo Signage Ltd
+ * Copyright (C) 2022-2023 Xibo Signage Ltd
  *
- * Xibo - Digital Signage - http://www.xibo.org.uk
+ * Xibo - Digital Signage - https://xibosignage.com
  *
  * This file is part of Xibo.
  *
@@ -226,7 +226,7 @@ class LocalWebTestCase extends PHPUnit_TestCase
      * Create a global container for all tests to share.
      * @throws \Exception
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 
@@ -516,7 +516,7 @@ class LocalWebTestCase extends PHPUnit_TestCase
      * @inheritDoc
      * @throws \Exception
      */
-    public function setUp()
+    public function setUp(): void
     {
         self::getLogger()->debug('LocalWebTestCase: setUp');
         parent::setUp();
@@ -529,7 +529,7 @@ class LocalWebTestCase extends PHPUnit_TestCase
      * @inheritDoc
      * @throws \Exception
      */
-    public function tearDown()
+    public function tearDown(): void
     {
         self::getLogger()->debug('LocalWebTestCase: tearDown');
 

--- a/tests/Xmds/GetDataTest.php
+++ b/tests/Xmds/GetDataTest.php
@@ -1,0 +1,136 @@
+<?php
+/*
+ * Copyright (C) 2023 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Xibo\Tests\Xmds;
+
+use DOMDocument;
+use DOMXPath;
+use Xibo\Tests\xmdsTestCase;
+
+/**
+ * @property string $dataSetXml
+ * @property string $requiredFilesXml
+ * @property string $requiredFilesXmlv6
+ */
+class GetDataTest extends xmdsTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $registerXml = '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:tns="urn:xmds" xmlns:types="urn:xmds/encodedTypes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <soap:Body soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+    <tns:RegisterDisplay>
+      <serverKey xsi:type="xsd:string">test</serverKey>
+      <hardwareKey xsi:type="xsd:string">phpstorm</hardwareKey>
+      <displayName xsi:type="xsd:string">PHPStorm</displayName>
+      <clientType xsi:type="xsd:string">windows</clientType>
+      <clientVersion xsi:type="xsd:string">4</clientVersion>
+      <clientCode xsi:type="xsd:int">420</clientCode>
+      <macAddress xsi:type="xsd:string">CC:40:D0:46:3C:A8</macAddress>
+    </tns:RegisterDisplay>
+  </soap:Body>
+</soap:Envelope>';
+
+        // to make sure Display is logged in, otherwise WidgetSyncTask will not sync data.
+        $this->sendRequest('POST', $registerXml, 7);
+
+        $this->dataSetXml = '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+    xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
+    xmlns:tns="urn:xmds" xmlns:types="urn:xmds/encodedTypes"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <soap:Body soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+    <tns:GetData>
+      <serverKey xsi:type="xsd:string">test</serverKey>
+      <hardwareKey xsi:type="xsd:string">phpstorm</hardwareKey>
+      <widgetId xsi:type="xsd:int">112</widgetId>
+    </tns:GetData>
+  </soap:Body>
+</soap:Envelope>';
+
+
+        $this->requiredFilesXml = '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+    xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
+    xmlns:tns="urn:xmds" xmlns:types="urn:xmds/encodedTypes"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <soap:Body soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+    <tns:RequiredFiles>
+      <serverKey xsi:type="xsd:string">test</serverKey>
+      <hardwareKey xsi:type="xsd:string">phpstorm</hardwareKey>
+    </tns:RequiredFiles>
+  </soap:Body>
+</soap:Envelope>';
+    }
+    public function testGetData()
+    {
+        // Fresh RF
+        $this->sendRequest('POST', $this->requiredFilesXml, 7);
+
+        // Execute Widget Sync task so we can have data for our Widget
+        exec('cd /var/www/cms; php bin/run.php 9');
+
+        // XMDS GetData with our dataSet Widget
+        $response = $this->sendRequest('POST', $this->dataSetXml);
+        $content = $response->getBody()->getContents();
+
+        // expect GetDataResponse
+        $this->assertStringContainsString(
+            '<ns1:GetDataResponse><data xsi:type="xsd:string">',
+            $content,
+            'GetData received incorrect response'
+        );
+
+        $document = new DOMDocument();
+        $document->loadXML($content);
+        $xpath = new DOMXpath($document);
+        $result = $xpath->evaluate('string(//data)');
+
+        $array = json_decode($result, true);
+
+        // go through GetData response and see what we have
+        foreach ($array as $key => $item) {
+            // data and meta expected to not be empty
+            if ($key === 'data' || $key === 'meta') {
+                $this->assertNotEmpty($item);
+                $this->assertNotEmpty($key);
+            }
+
+            if ($key === 'data') {
+                $i = 0;
+                // go through the expected 2 rows in our dataSet data and see if the column/value matches
+                foreach ($item as $row) {
+                    $this->assertNotEmpty($row);
+                    if ($i === 0) {
+                        $this->assertSame('Example text value', $row['Text']);
+                        $this->assertSame(1, $row['Number']);
+                    } else if ($i === 1) {
+                        $this->assertSame('PHPUnit text', $row['Text']);
+                        $this->assertSame(2, $row['Number']);
+                    }
+                    $i++;
+                }
+            }
+        }
+    }
+}

--- a/tests/Xmds/GetDependencyTest.php
+++ b/tests/Xmds/GetDependencyTest.php
@@ -1,0 +1,259 @@
+<?php
+/*
+ * Copyright (C) 2023 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Xibo\Tests\Xmds;
+
+use DOMDocument;
+use DOMXPath;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Xibo\Tests\xmdsTestCase;
+
+/**
+ * @property string $requiredFilesXml
+ * @property string $requiredFilesXmlv6
+ */
+class GetDependencyTest extends xmdsTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->requiredFilesXml = '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+    xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
+    xmlns:tns="urn:xmds" xmlns:types="urn:xmds/encodedTypes"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <soap:Body soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+    <tns:RequiredFiles>
+      <serverKey xsi:type="xsd:string">test</serverKey>
+      <hardwareKey xsi:type="xsd:string">phpstorm</hardwareKey>
+    </tns:RequiredFiles>
+  </soap:Body>
+</soap:Envelope>';
+        
+        $this->requiredFilesXmlv6 = '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+    xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
+    xmlns:tns="urn:xmds" xmlns:types="urn:xmds/encodedTypes"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <soap:Body soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+    <tns:RequiredFiles>
+      <serverKey xsi:type="xsd:string">test</serverKey>
+      <hardwareKey xsi:type="xsd:string">phpunit6</hardwareKey>
+    </tns:RequiredFiles>
+  </soap:Body>
+</soap:Envelope>';
+    }
+
+    public static function successCasesBundle(): array
+    {
+        return [
+            [7],
+        ];
+    }
+
+    public static function successCasesFont(): array
+    {
+        return [
+            [7],
+            [6],
+            [5],
+            [4],
+        ];
+    }
+
+    public static function successCasesBundleOld(): array
+    {
+        return [
+            [6],
+            [5],
+            [4],
+        ];
+    }
+
+    #[DataProvider('successCasesFont')]
+    public function testGetFont($version)
+    {
+        if ($version === 7) {
+            $rf = $this->sendRequest('POST', $this->requiredFilesXml, $version);
+        } else {
+            $rf = $this->sendRequest('POST', $this->requiredFilesXmlv6, $version);
+        }
+
+        $response = $rf->getBody()->getContents();
+        $path = null;
+
+        $document = new DOMDocument();
+        $document->loadXML($response);
+        $xpath = new DOMXpath($document);
+        $result = $xpath->evaluate('string(//RequiredFilesXml)');
+        $array = json_decode(json_encode(simplexml_load_string($result)), true);
+
+        foreach ($array as $item) {
+            foreach ($item as $file) {
+                if (!empty($file['@attributes'])) {
+                    if ($file['@attributes']['saveAs'] === 'Aileron-Heavy.otf') {
+                        if ($version === 7) {
+                            $this->assertSame('dependency', $file['@attributes']['type']);
+                        } else {
+                            $this->assertSame('media', $file['@attributes']['type']);
+                        }
+
+                        $path = strstr($file['@attributes']['path'], '?');
+                    }
+                }
+            }
+        }
+
+        $this->assertNotEmpty($path);
+
+        // Font dependency is still http download, try to get it here
+        $getFile = $this->getFile($path);
+        $this->assertSame(200, $getFile->getStatusCode());
+        $this->assertNotEmpty($getFile->getBody()->getContents());
+    }
+
+    #[DataProvider('successCasesBundle')]
+    public function testGetBundlev7($version)
+    {
+        $rf = $this->sendRequest('POST', $this->requiredFilesXml, $version);
+        $response = $rf->getBody()->getContents();
+        $size = null;
+        $id = null;
+        $type = null;
+
+        $document = new DOMDocument();
+        $document->loadXML($response);
+        $xpath = new DOMXpath($document);
+        $result = $xpath->evaluate('string(//RequiredFilesXml)');
+        $array = json_decode(json_encode(simplexml_load_string($result)), true);
+
+        foreach ($array as $item) {
+            foreach ($item as $file) {
+                if (!empty($file['@attributes'])) {
+                    if ($file['@attributes']['saveAs'] === 'bundle.min.js') {
+                        $size = $file['@attributes']['size'];
+                        $type = $file['@attributes']['fileType'];
+                        $id = $file['@attributes']['id'];
+                    }
+                }
+
+            }
+        }
+
+        $this->assertNotEmpty($size);
+        $this->assertNotEmpty($type);
+        $this->assertNotEmpty($id);
+
+        // construct the xml for GetDependency wsdl request
+        $bundleXml = '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+    xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/"
+    xmlns:tns="urn:xmds" xmlns:types="urn:xmds/encodedTypes"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <soap:Body soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+    <tns:GetDependency>
+      <serverKey xsi:type="xsd:string">test</serverKey>
+      <hardwareKey xsi:type="xsd:string">phpstorm</hardwareKey>
+      <fileType xsi:type="xsd:string">'. $type .'</fileType>
+      <id xsi:type="xsd:string">'. $id .'</id>
+      <chunkOffset xsi:type="xsd:double">0</chunkOffset>
+      <chunkSize xsi:type="xsd:double">'. $size .'</chunkSize>
+    </tns:GetDependency>
+  </soap:Body>
+</soap:Envelope>';
+
+        // try to call GetDependency with our xml
+        $getBundle = $this->sendRequest('POST', $bundleXml, $version);
+        $getBundleResponse = $getBundle->getBody()->getContents();
+        // expect success
+        $this->assertSame(200, $getBundle->getStatusCode());
+        // expect not empty body
+        $this->assertNotEmpty($getBundleResponse);
+        // expect response format
+        $this->assertStringContainsString(
+            '<ns1:GetDependencyResponse><file xsi:type="xsd:base64Binary">',
+            $getBundleResponse,
+            'GetDependency getBundle received incorrect response'
+        );
+    }
+
+    #[DataProvider('successCasesBundleOld')]
+    public function testGetBundlev6($version)
+    {
+        $rf = $this->sendRequest('POST', $this->requiredFilesXmlv6, $version);
+        $response = $rf->getBody()->getContents();
+        $size = null;
+        $id = null;
+        $type = null;
+
+        $document = new DOMDocument();
+        $document->loadXML($response);
+        $xpath = new DOMXpath($document);
+        $result = $xpath->evaluate('string(//RequiredFilesXml)');
+        $array = json_decode(json_encode(simplexml_load_string($result)), true);
+
+        foreach ($array as $item) {
+            foreach ($item as $file) {
+                if (!empty($file['@attributes'])) {
+                    if ($file['@attributes']['saveAs'] === 'bundle.min.js') {
+                        $size = $file['@attributes']['size'];
+                        $type = $file['@attributes']['type'];
+                        $id = $file['@attributes']['id'];
+                    }
+                }
+            }
+        }
+
+        $this->assertNotEmpty($size);
+        $this->assertNotEmpty($type);
+        $this->assertNotEmpty($id);
+
+        // construct the xml for GetDependency wsdl request
+        $bundleXml = '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:tns="urn:xmds" xmlns:types="urn:xmds/encodedTypes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <soap:Body soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+    <tns:GetFile>
+      <serverKey xsi:type="xsd:string">test</serverKey>
+      <hardwareKey xsi:type="xsd:string">phpunit6</hardwareKey>
+      <fileId xsi:type="xsd:string">'. $id .'</fileId>
+      <fileType xsi:type="xsd:string">'. $type .'</fileType>
+      <chunkOffset xsi:type="xsd:double">0</chunkOffset>
+      <chuckSize xsi:type="xsd:double">'. $size .'</chuckSize>
+    </tns:GetFile>
+  </soap:Body>
+</soap:Envelope>';
+
+        // try to call GetFile with our xml
+        $getBundle = $this->sendRequest('POST', $bundleXml, $version);
+        $getBundleResponse = $getBundle->getBody()->getContents();
+        // expect success
+        $this->assertSame(200, $getBundle->getStatusCode());
+        // expect not empty body
+        $this->assertNotEmpty($getBundleResponse);
+        // expect response format
+        $this->assertStringContainsString(
+            '<ns1:GetFileResponse><file xsi:type="xsd:base64Binary">',
+            $getBundleResponse,
+            'GetDependency getBundle received incorrect response'
+        );
+    }
+}

--- a/tests/Xmds/NotifyStatusTest.php
+++ b/tests/Xmds/NotifyStatusTest.php
@@ -1,0 +1,215 @@
+<?php
+/*
+ * Copyright (C) 2023 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Xibo\Tests\Xmds;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Xibo\Tests\xmdsTestCase;
+
+/**
+ * @property string $currentLayoutXml
+ * @property string $geoLocationXml
+ * @property string $orientationXml
+ */
+final class NotifyStatusTest extends xmdsTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->currentLayoutXml = '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:tns="urn:xmds" xmlns:types="urn:xmds/encodedTypes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <soap:Body soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+    <tns:NotifyStatus>
+      <serverKey xsi:type="xsd:string">test</serverKey>
+      <hardwareKey xsi:type="xsd:string">phpstorm</hardwareKey>
+      <status xsi:type-="xsd:string">{"currentLayoutId":1}</status>
+    </tns:NotifyStatus>
+  </soap:Body>
+</soap:Envelope>';
+
+        $this->geoLocationXml = '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:tns="urn:xmds" xmlns:types="urn:xmds/encodedTypes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <soap:Body soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+    <tns:NotifyStatus>
+      <serverKey xsi:type="xsd:string">test</serverKey>
+      <hardwareKey xsi:type="xsd:string">phpstorm</hardwareKey>
+      <status xsi:type-="xsd:string">{"latitude":52.3676, "longitude":4.9041}</status>
+    </tns:NotifyStatus>
+  </soap:Body>
+</soap:Envelope>';
+
+        $this->orientationXml = '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:tns="urn:xmds" xmlns:types="urn:xmds/encodedTypes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <soap:Body soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+    <tns:NotifyStatus>
+      <serverKey xsi:type="xsd:string">test</serverKey>
+      <hardwareKey xsi:type="xsd:string">phpstorm</hardwareKey>
+      <status xsi:type-="xsd:string">{"width":7680, "height":4320}</status>
+    </tns:NotifyStatus>
+  </soap:Body>
+</soap:Envelope>';
+    }
+
+    public static function successCases(): array
+    {
+        return [
+            [7],
+            [6],
+            [5],
+            [4],
+        ];
+    }
+
+    public static function failureCases(): array
+    {
+        return [
+            [3],
+        ];
+    }
+
+    #[DataProvider('successCases')]
+    public function testCurrentLayout(int $version)
+    {
+        $request = $this->sendRequest('POST', $this->currentLayoutXml, $version);
+
+        $this->assertStringContainsString(
+            '<ns1:NotifyStatusResponse><success xsi:type="xsd:boolean">true</success></ns1:NotifyStatusResponse>',
+            $request->getBody()->getContents(),
+            'Notify Current Layout received incorrect response'
+        );
+    }
+
+    #[DataProvider('failureCases')]
+    public function testCurrentLayoutFailure(int $version)
+    {
+        // disable exception on http_error in guzzle, so we can still check the response
+        $request = $this->sendRequest('POST', $this->currentLayoutXml, $version, false);
+
+        $this->assertSame(500, $request->getStatusCode());
+        // check the fault code
+        $this->assertStringContainsString(
+            '<faultcode>SOAP-ENV:Server</faultcode>',
+            $request->getBody(),
+            'Notify Current Layout received incorrect response'
+        );
+
+        // check the fault string
+        $this->assertStringContainsString(
+            '<faultstring>Procedure \'NotifyStatus\' not present</faultstring>',
+            $request->getBody(),
+            'Notify Current Layout received incorrect response'
+        );
+    }
+
+    #[DataProvider('failureCases')]
+    public function testCurrentLayoutExceptionFailure(int $version)
+    {
+        // we are expecting 500 Server Exception here for xmds 3
+        $this->expectException('GuzzleHttp\Exception\ServerException');
+        $this->expectExceptionCode(500);
+        $this->sendRequest('POST', $this->currentLayoutXml, $version);
+    }
+
+    #[DataProvider('successCases')]
+    public function testGeoLocation($version)
+    {
+        $request = $this->sendRequest('POST', $this->geoLocationXml, $version);
+
+        $this->assertStringContainsString(
+            '<ns1:NotifyStatusResponse><success xsi:type="xsd:boolean">true</success></ns1:NotifyStatusResponse>',
+            $request->getBody()->getContents(),
+            'Notify Geo Location received incorrect response'
+        );
+    }
+
+    #[DataProvider('failureCases')]
+    public function testGeoLocationFailure(int $version)
+    {
+        // disable exception on http_error in guzzle, so we can still check the response
+        $request = $this->sendRequest('POST', $this->geoLocationXml, $version, false);
+
+        $this->assertSame(500, $request->getStatusCode());
+        // check the fault code
+        $this->assertStringContainsString(
+            '<faultcode>SOAP-ENV:Server</faultcode>',
+            $request->getBody(),
+            'Notify Geo Location received incorrect response'
+        );
+
+        // check the fault string
+        $this->assertStringContainsString(
+            '<faultstring>Procedure \'NotifyStatus\' not present</faultstring>',
+            $request->getBody(),
+            'Notify Geo Location received incorrect response'
+        );
+    }
+
+    #[DataProvider('failureCases')]
+    public function testGeoLocationExceptionFailure(int $version)
+    {
+        // we are expecting 500 Server Exception here for xmds 3
+        $this->expectException('GuzzleHttp\Exception\ServerException');
+        $this->expectExceptionCode(500);
+        $this->sendRequest('POST', $this->geoLocationXml, $version);
+    }
+
+    #[DataProvider('successCases')]
+    public function testOrientation(int $version)
+    {
+        $request = $this->sendRequest('POST', $this->orientationXml, $version);
+
+        $this->assertStringContainsString(
+            '<ns1:NotifyStatusResponse><success xsi:type="xsd:boolean">true</success></ns1:NotifyStatusResponse>',
+            $request->getBody()->getContents(),
+            'Notify Orientation received incorrect response'
+        );
+    }
+
+    #[DataProvider('failureCases')]
+    public function testOrientationFailure(int $version)
+    {
+        // disable exception on http_error in guzzle, so we can still check the response
+        $request = $this->sendRequest('POST', $this->orientationXml, $version, false);
+
+        $this->assertSame(500, $request->getStatusCode());
+        // check the fault code
+        $this->assertStringContainsString(
+            '<faultcode>SOAP-ENV:Server</faultcode>',
+            $request->getBody(),
+            'Notify Orientation received incorrect response'
+        );
+
+        // check the fault string
+        $this->assertStringContainsString(
+            '<faultstring>Procedure \'NotifyStatus\' not present</faultstring>',
+            $request->getBody(),
+            'Notify Orientation received incorrect response'
+        );
+    }
+
+    #[DataProvider('failureCases')]
+    public function testOrientationExceptionFailure(int $version)
+    {
+        // we are expecting 500 Server Exception here for xmds 3
+        $this->expectException('GuzzleHttp\Exception\ServerException');
+        $this->expectExceptionCode(500);
+        $this->sendRequest('POST', $this->orientationXml, $version);
+    }
+}

--- a/tests/Xmds/RegisterDisplayTest.php
+++ b/tests/Xmds/RegisterDisplayTest.php
@@ -1,0 +1,114 @@
+<?php
+/*
+ * Copyright (C) 2023 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Xibo\Tests\Xmds;
+
+use DOMDocument;
+use DOMXPath;
+use Xibo\Tests\xmdsTestCase;
+
+/**
+ * @property string $registerWindowsXml
+ * @property string $registerAndroidXml
+ */
+class RegisterDisplayTest extends xmdsTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registerWindowsXml = '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:tns="urn:xmds" xmlns:types="urn:xmds/encodedTypes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <soap:Body soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+    <tns:RegisterDisplay>
+      <serverKey xsi:type="xsd:string">test</serverKey>
+      <hardwareKey xsi:type="xsd:string">phpstorm</hardwareKey>
+      <displayName xsi:type="xsd:string">PHPStorm</displayName>
+      <clientType xsi:type="xsd:string">windows</clientType>
+      <clientVersion xsi:type="xsd:string">4</clientVersion>
+      <clientCode xsi:type="xsd:int">420</clientCode>
+      <macAddress xsi:type="xsd:string">CC:40:D0:46:3C:A8</macAddress>
+    </tns:RegisterDisplay>
+  </soap:Body>
+</soap:Envelope>';
+
+        $this->registerAndroidXml = '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:tns="urn:xmds" xmlns:types="urn:xmds/encodedTypes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <soap:Body soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+    <tns:RegisterDisplay>
+      <serverKey xsi:type="xsd:string">test</serverKey>
+      <hardwareKey xsi:type="xsd:string">PHPUnitWaiting</hardwareKey>
+      <displayName xsi:type="xsd:string">phpunitwaiting</displayName>
+      <clientType xsi:type="xsd:string">android</clientType>
+      <clientVersion xsi:type="xsd:string">4</clientVersion>
+      <clientCode xsi:type="xsd:int">420</clientCode>
+      <macAddress xsi:type="xsd:string">CC:40:D0:46:3C:A8</macAddress>
+      <licenceResult xsi:type="xsd:string">trial</licenceResult>
+    </tns:RegisterDisplay>
+  </soap:Body>
+</soap:Envelope>';
+    }
+
+    public function testRegisterDisplayAuthed()
+    {
+        $request = $this->sendRequest('POST', $this->registerWindowsXml, 7);
+        $response = $request->getBody()->getContents();
+
+        $document = new DOMDocument();
+        $document->loadXML($response);
+
+        $xpath = new DOMXpath($document);
+        $result = $xpath->evaluate('string(//ActivationMessage)');
+        $innerDocument = new DOMDocument();
+        $innerDocument->loadXML($result);
+
+        $this->assertSame('READY', $innerDocument->documentElement->getAttribute('code'));
+        $this->assertSame('Display is active and ready to start.', $innerDocument->documentElement->getAttribute('message'));
+    }
+
+    public function testRegisterDisplayNoAuth()
+    {
+        $request = $this->sendRequest('POST', $this->registerAndroidXml, 7);
+        $response = $request->getBody()->getContents();
+
+        $document = new DOMDocument();
+        $document->loadXML($response);
+
+        $xpath = new DOMXpath($document);
+        $result = $xpath->evaluate('string(//ActivationMessage)');
+        $innerDocument = new DOMDocument();
+        $innerDocument->loadXML($result);
+
+        $this->assertSame('WAITING', $innerDocument->documentElement->getAttribute('code'));
+        $this->assertSame(
+            'Display is Registered and awaiting Authorisation from an Administrator in the CMS',
+            $innerDocument->documentElement->getAttribute('message')
+        );
+
+        $array = json_decode(json_encode(simplexml_load_string($result)), true);
+
+        foreach ($array as $key => $value) {
+            // $this->getLogger()->debug($key . ' -> ' . json_encode($value));
+            if ($key === 'commercialLicence') {
+                $this->assertSame('trial', $value);
+            }
+        }
+    }
+}

--- a/tests/Xmds/ReportFaultsTest.php
+++ b/tests/Xmds/ReportFaultsTest.php
@@ -1,0 +1,106 @@
+<?php
+/*
+ * Copyright (C) 2023 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Xibo\Tests\Xmds;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Xibo\Tests\xmdsTestCase;
+
+/**
+ * @property string $xmlRequest
+ */
+final class ReportFaultsTest extends xmdsTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->xmlRequest = '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:tns="urn:xmds" xmlns:types="urn:xmds/encodedTypes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+          <soap:Body soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+            <tns:ReportFaults>
+              <serverKey xsi:type="xsd:string">test</serverKey>
+              <hardwareKey xsi:type="xsd:string">phpstorm</hardwareKey>
+              <fault xsi:type="xsd:string">[{date:"2023-04-20 17:03:52",expires:"2023-04-21 17:03:52",code:00001,reason:"Test",scheduleId:0,layoutId:0,regionId:0,mediaId:0,widgetId:0}]</fault>
+            </tns:ReportFaults>
+          </soap:Body>
+        </soap:Envelope>';
+    }
+
+    public static function successCases(): array
+    {
+        return [
+            [7],
+            [6],
+        ];
+    }
+
+    public static function failureCases(): array
+    {
+        return [
+            [5],
+            [4],
+            [3],
+        ];
+    }
+
+    #[DataProvider('successCases')]
+    public function testSendFaultSuccess(int $version)
+    {
+        $request = $this->sendRequest('POST', $this->xmlRequest, $version);
+
+        $this->assertStringContainsString(
+            '<ns1:ReportFaultsResponse><success xsi:type="xsd:boolean">true</success>',
+            $request->getBody()->getContents(),
+            'Send fault received incorrect response'
+        );
+    }
+
+    #[DataProvider('failureCases')]
+    public function testSendFaultFailure(int $version)
+    {
+        // disable exception on http_error in guzzle, so we can still check the response
+        $request = $this->sendRequest('POST', $this->xmlRequest, $version, false);
+
+        // check the fault code
+        $this->assertStringContainsString(
+            '<faultcode>SOAP-ENV:Server</faultcode>',
+            $request->getBody(),
+            'Send fault received incorrect response'
+        );
+
+        // check the fault string
+        $this->assertStringContainsString(
+            '<faultstring>Procedure \'ReportFaults\' not present</faultstring>',
+            $request->getBody(),
+            'Send fault received incorrect response'
+        );
+    }
+
+    #[DataProvider('failureCases')]
+    public function testSendFaultExceptionFailure(int $version)
+    {
+        // we are expecting 500 Server Exception here for xmds 3,4 and 5
+        $this->expectException('GuzzleHttp\Exception\ServerException');
+        $this->expectExceptionCode(500);
+        $this->sendRequest('POST', $this->xmlRequest, $version);
+    }
+}

--- a/tests/xmdsTestCase.php
+++ b/tests/xmdsTestCase.php
@@ -1,0 +1,196 @@
+<?php
+/*
+ * Copyright (C) 2023 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Xibo\Tests;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Stash\Driver\Composite;
+use Stash\Interfaces\PoolInterface;
+use Stash\Pool;
+
+class xmdsTestCase extends TestCase
+{
+    /** @var  ContainerInterface */
+    public static $container;
+
+    /** @var LoggerInterface */
+    public static $logger;
+
+    /** @var Client */
+    public $client;
+
+    /**
+     * @inheritDoc
+     */
+    public function getGuzzleClient(array $requestOptions = []): Client
+    {
+        if ($this->client === null) {
+            $this->client = new Client($requestOptions);
+        }
+
+        return $this->client;
+    }
+
+    public function getPool() : PoolInterface
+    {
+        $drivers[] = new \Stash\Driver\FileSystem(['path' => '/var/www/cms/library/cache']);
+        // Create a composite driver
+        $composite = new Composite(['drivers' => $drivers]);
+
+        $pool = new Pool($composite);
+        $pool->setLogger($this->getLogger());
+        $pool->setNamespace('Xibo');
+
+        return $pool;
+    }
+
+    /**
+     * @param string $method
+     * @param string $body
+     * @param string $path
+     * @param array $headers
+     * @return ResponseInterface
+     * @throws GuzzleException
+     */
+    protected function sendRequest(
+        string $method = 'POST',
+        string $body = '',
+        string $version = '7',
+        bool $httpErrors = true,
+        string $path = 'http://localhost/xmds.php?v=',
+        array $headers = ['HTTP_ACCEPT'=>'text/xml']
+    ): ResponseInterface {
+        // Create a request for tests
+        return $this->client->request($method, $path . $version, [
+            'headers' => $headers,
+            'body' => $body,
+            'http_errors' => $httpErrors
+        ]);
+    }
+
+    protected function getFile(
+        string $fileQuery = '',
+        string $method = 'GET',
+        string $basePath = 'http://localhost/xmds.php',
+    ): ResponseInterface {
+        // Create a request for tests
+        return $this->client->request($method, $basePath . $fileQuery);
+    }
+
+    /**
+     * Create a global container for all tests to share.
+     * @throws \Exception
+     */
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+    }
+
+    /**
+     * Convenience function to skip a test with a reason and close output buffers nicely.
+     * @param string $reason
+     */
+    public function skipTest(string $reason): void
+    {
+        $this->markTestSkipped($reason);
+    }
+
+    /**
+     * @return Logger|NullLogger|LoggerInterface
+     */
+    public static function getLogger(): Logger|NullLogger|LoggerInterface
+    {
+        // Create if necessary
+        if (self::$logger === null) {
+            if (isset($_SERVER['PHPUNIT_LOG_TO_CONSOLE']) && $_SERVER['PHPUNIT_LOG_TO_CONSOLE']) {
+                self::$logger = new Logger('TESTS', [new StreamHandler(STDERR, Logger::DEBUG)]);
+            } else {
+                self::$logger = new NullLogger();
+            }
+        }
+
+        return self::$logger;
+    }
+
+    /**
+     * @inheritDoc
+     * @throws \Exception
+     */
+    public function setUp(): void
+    {
+        self::getLogger()->debug('xmdsTestCase: setUp');
+        parent::setUp();
+
+        // Establish a local reference to the Slim app object
+        $this->client = $this->getGuzzleClient();
+    }
+
+    /**
+     * @inheritDoc
+     * @throws \Exception
+     */
+    public function tearDown(): void
+    {
+        self::getLogger()->debug('xmdsTestCase: tearDown');
+
+        // Close and tidy up the app
+        $this->client = null;
+
+        parent::tearDown();
+    }
+
+    /**
+     * Set the _SERVER vars for the suite
+     * @param array $userSettings
+     */
+    public static function setEnvironment(array $userSettings = []): void
+    {
+        $defaults = [
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI' => '/',
+            'SCRIPT_NAME' => '',
+            'PATH_INFO' => '/',
+            'QUERY_STRING' => '',
+            'SERVER_NAME' => 'local.dev',
+            'SERVER_PORT' => 80,
+            'HTTP_ACCEPT' => 'text/xml,text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+            'HTTP_ACCEPT_LANGUAGE' => 'en-US,en;q=0.8',
+            'HTTP_ACCEPT_CHARSET' => 'ISO-8859-1,utf-8;q=0.7,*;q=0.3',
+            'USER_AGENT' => 'Slim Framework',
+            'REMOTE_ADDR' => '127.0.0.1',
+        ];
+
+        $environmentSettings = array_merge($userSettings, $defaults);
+
+        foreach ($environmentSettings as $key => $value) {
+            $_SERVER[$key] = $value;
+        }
+    }
+}


### PR DESCRIPTION
## XMDS tests
- Couple new XMDS tests (GetData, GetDependency etc), this is still WIP, there are more tests to be added etc
- New xmdsTestCase - streamlined testCase we only need Guzzle client
- Adjusted phpunit.xml for phpunit 10+
- LocalWebTestCase : Fix return values for functions (phpunit 10+), as it is still included in Bootstrap it will throw fatal error without that.

### Other fixes
- Players : Fix downloading "dependencies" (bundle, fonts, assets etc) on older players (pre xmds 7)
- Layout Build : Do not attempt to include module properties without id in the xlf
- Layout Publish : Fix publishing a Layout with future date (Regular Maintenance)
- Library : set folderId from oldMedia on replace
- Tag Factory : Fix php warning about null in trim for tagValue
- User Group : Fix dynamic property libraryQuotaFormatted