### PR TITLE
Widget data: handle 3 difference cases for when there is data/not.

### DIFF
--- a/lib/Widget/Render/WidgetHtmlRenderer.php
+++ b/lib/Widget/Render/WidgetHtmlRenderer.php
@@ -327,11 +327,9 @@ class WidgetHtmlRenderer
             } else if ($match === 'ViewPortWidth') {
                 // Player does this itself.
                 continue;
-            } else if ($match === 'Data') {
-                $output = str_replace('[[Data]]', json_encode($data), $output);
             } else if (Str::startsWith($match, 'dataUrl')) {
                 $value = explode('=', $match);
-                $replace = $isSupportsDataUrl ? $value[1] . '.json' : $value[1] . '.htm';
+                $replace = $isSupportsDataUrl ? $value[1] . '.json' : 'null';
                 $output = str_replace('[[' . $match . ']]', $replace, $output);
             } else if (Str::startsWith($match, 'data=')) {
                 $value = explode('=', $match);
@@ -448,8 +446,6 @@ class WidgetHtmlRenderer
             // Output some sample data and a data url.
             $widgetData = [
                 'widgetId' => $widget->widgetId,
-                'url' => '[[dataUrl=' . $widget->widgetId . ']]',
-                'data' => '[[data=' . $widget->widgetId . ']]',
                 'templateId' => $templateId,
                 'sample' => $module->sampleData,
                 'properties' => $module->getPropertyValues(),
@@ -457,6 +453,15 @@ class WidgetHtmlRenderer
                 'duration' => $widget->duration,
                 'calculatedDuration' => $widget->calculatedDuration,
             ];
+
+            // Should we expect data?
+            if ($module->isDataProviderExpected() || $module->isWidgetProviderAvailable()) {
+                $widgetData['url'] = '[[dataUrl=' . $widget->widgetId . ']]';
+                $widgetData['data'] = '[[data=' . $widget->widgetId . ']]';
+            } else {
+                $widgetData['url'] = null;
+                $widgetData['data'] = null;
+            }
 
             // Do we have a library file with this module?
             if ($module->regionSpecific == 0) {

--- a/modules/src/player.js
+++ b/modules/src/player.js
@@ -150,7 +150,7 @@ $(function() {
       // if (!isPreview) {
       if (widget.data?.data !== undefined) {
         resolve(widget.data);
-      } else {
+      } else if (widget.url) {
         // else get data from widget.url,
         // this will be either getData for preview
         // or new json file for v4 players
@@ -162,6 +162,8 @@ $(function() {
         }).fail(function(jqXHR, textStatus, errorThrown) {
           console.log(jqXHR, textStatus, errorThrown);
         });
+      } else {
+        resolve(null);
       }
     });
   }


### PR DESCRIPTION
This tries to handle 3 cases:
 - v4 player: widget where data is expected and can be requested via a separate URL
 - v4 player: widget where we do not expect data
 - v3 player: widget where data is expected and injected into the HTML (player does not support separate data)

@rubenpingol-xibo I made a workaround to player.js in this PR - please can you see if it will meet all of the above 3 requirements?

---------

@PeterMis I think this also finally fixes having duplicate assets in the RF table/xml 😅 