### PR TITLE
Player test fixes

### DIFF
--- a/lib/Entity/Display.php
+++ b/lib/Entity/Display.php
@@ -841,12 +841,19 @@ class Display implements \JsonSerializable
     {
         $this->load();
 
-        // Delete incidential references
-        $this->getStore()->update('DELETE FROM `requiredfile` WHERE displayId = :displayId', ['displayId' => $this->displayId]);
+        // Delete references
+        $this->getStore()->update('DELETE FROM `display_media` WHERE displayId = :displayId', [
+            'displayId' => $this->displayId
+        ]);
+        $this->getStore()->update('DELETE FROM `requiredfile` WHERE displayId = :displayId', [
+            'displayId' => $this->displayId
+        ]);
+        $this->getStore()->update('DELETE FROM `player_faults` WHERE displayId = :displayId', [
+            'displayId' => $this->displayId
+        ]);
 
         // Remove our display from any groups it is assigned to
         foreach ($this->displayGroups as $displayGroup) {
-            /* @var DisplayGroup $displayGroup */
             $this->getDispatcher()->dispatch(new DisplayGroupLoadEvent($displayGroup), DisplayGroupLoadEvent::$NAME);
             $displayGroup->load();
             $displayGroup->unassignDisplay($this);
@@ -859,10 +866,14 @@ class Display implements \JsonSerializable
         $displayGroup->delete();
 
         // Delete the display
-        $this->getStore()->update('DELETE FROM `player_faults` WHERE displayId = :displayId', ['displayId' => $this->displayId]);
-        $this->getStore()->update('DELETE FROM `display` WHERE displayId = :displayId', ['displayId' => $this->displayId]);
+        $this->getStore()->update('DELETE FROM `display` WHERE displayId = :displayId', [
+            'displayId' => $this->displayId
+        ]);
 
-        $this->getLog()->audit('Display', $this->displayId, 'Display Deleted', ['displayId' => $this->displayId]);
+        $this->getLog()->audit('Display', $this->displayId, 'Display Deleted', [
+            'displayId' => $this->displayId,
+            'display' => $this->display,
+        ]);
     }
 
     /**

--- a/lib/Widget/Definition/Asset.php
+++ b/lib/Widget/Definition/Asset.php
@@ -122,6 +122,12 @@ class Asset implements \JsonSerializable
         }
     }
 
+    /**
+     * Get Legacy ID for this asset on older players
+     *  there is a risk that this ID will change as modules/templates with assets are added/removed in the system
+     *  however, we have mitigated by ensuring that only one instance of any required file is added to rf return
+     * @return int
+     */
     private function getLegacyId(): int
     {
         return (Dependency::LEGACY_ID_OFFSET_ASSET + $this->assetNo) * -1;

--- a/lib/Xmds/Soap.php
+++ b/lib/Xmds/Soap.php
@@ -2727,10 +2727,10 @@ class Soap
             ->createForGetDependency(
                 $this->display->displayId,
                 $dependency->fileType,
-                $dependency->legacyId,
+                $isSupportsDependency ? $dependency->id : $dependency->legacyId,
                 $dependency->id,
                 $dependencyBasePath,
-                false
+                $isSupportsDependency
             )
             ->save()->rfId;
 


### PR DESCRIPTION
Get legacyId works for assets as long as new modules/templates aren't added to the system - at that point the assetId changes and duplicates are added into the requiredfiles table. Duplicates are not added to rf.xml though, so the player still updates and marks itself as complete.

To improve this in v4 we can add the assetId to RF using the realId instead of the legacyId (legacyId isn't really used at that point). This means the asset only gets into the table once, even if its calculated legacyId changes.

I think this works!

----

I also fixed an issue with deleting displays that have display_media links, and tidied up the delete method.