### PR TITLE
Content sync : fixes and xmds test

### DIFF
--- a/lib/Controller/Schedule.php
+++ b/lib/Controller/Schedule.php
@@ -349,9 +349,10 @@ class Schedule extends Base
 
             // Event Title
             if ($this->isSyncEvent($row->eventTypeId)) {
-                $title = __(
-                    'Synchronised group %s',
-                    $row->getUnmatchedProperty('syncGroupName')
+                $title = sprintf(
+                    __('%s scheduled on sync group %s'),
+                    $row->getSyncTypeForEvent(),
+                    $row->getUnmatchedProperty('syncGroupName'),
                 );
             } else if ($row->campaignId == 0) {
                 // Command

--- a/lib/Controller/SyncGroup.php
+++ b/lib/Controller/SyncGroup.php
@@ -668,9 +668,18 @@ class SyncGroup extends Base
     {
         $syncGroup = $this->syncGroupFactory->getById($id);
         $params = $this->getSanitizer($request->getParams());
+        $displays = [];
 
         if (!empty($params->getInt('eventId'))) {
-            $displays = $syncGroup->getGroupMembersForEditForm($params->getInt('eventId'));
+            $syncGroupMembers = $syncGroup->getGroupMembersForForm();
+            foreach ($syncGroupMembers as $display) {
+                $layoutId = $syncGroup->getLayoutIdForDisplay(
+                    $params->getInt('eventId'),
+                    $display['displayId']
+                );
+                $display['layoutId'] = $layoutId;
+                $displays[] = $display;
+            }
         } else {
             $displays = $syncGroup->getGroupMembersForForm();
         }

--- a/lib/Entity/Schedule.php
+++ b/lib/Entity/Schedule.php
@@ -1787,8 +1787,8 @@ class Schedule implements \JsonSerializable
         );
 
         return (count(array_unique($layouts, SORT_REGULAR)) === 1)
-            ? __('Mirror')
-            : __('Wall');
+            ? __('Synchronised Mirrored Content')
+            : __('Synchronised Content');
     }
 
     /**

--- a/lib/Entity/SyncGroup.php
+++ b/lib/Entity/SyncGroup.php
@@ -173,11 +173,22 @@ class SyncGroup implements \JsonSerializable
         ]);
     }
 
-    public function getLayoutIdForDisplay($eventId)
+    public function getLayoutIdForDisplay(int $eventId, int $displayId)
     {
-        return $this->getStore()->select('SELECT `schedule_sync`.layoutId FROM `schedule_sync` WHERE `schedule_sync`.eventId = :eventId', [
-            'eventId' => $eventId
+        $layout = $this->getStore()->select('SELECT `schedule_sync`.layoutId 
+            FROM `display` 
+                INNER JOIN `schedule_sync` ON `schedule_sync`.displayId = `display`.displayId 
+            WHERE `display`.syncGroupId = :syncGroupId AND `schedule_sync`.eventId = :eventId AND `schedule_sync`.displayId = :displayId', [
+            'eventId' => $eventId,
+            'displayId' => $displayId,
+            'syncGroupId' => $this->syncGroupId
         ]);
+
+        if (count($layout) <= 0) {
+            return null;
+        }
+
+        return $layout[0]['layoutId'];
     }
 
     /**

--- a/tests/Xmds/SyncTest.php
+++ b/tests/Xmds/SyncTest.php
@@ -1,0 +1,140 @@
+<?php
+/*
+ * Copyright (C) 2023 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Xibo\Tests\Xmds;
+
+use DOMDocument;
+use DOMXPath;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Xibo\Tests\xmdsTestCase;
+
+/**
+ * @property string $scheduleXml
+ * @property string $registerXml
+ * @property string $registerLeadXml
+ */
+class SyncTest extends XmdsTestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->scheduleXml = '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:tns="urn:xmds" xmlns:types="urn:xmds/encodedTypes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <soap:Body soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+    <tns:Schedule>
+      <serverKey xsi:type="xsd:string">test</serverKey>
+      <hardwareKey xsi:type="xsd:string">phpunitsync</hardwareKey>
+    </tns:Schedule>
+  </soap:Body>
+</soap:Envelope>';
+
+        $this->registerXml = '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:tns="urn:xmds" xmlns:types="urn:xmds/encodedTypes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <soap:Body soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+    <tns:RegisterDisplay>
+      <serverKey xsi:type="xsd:string">test</serverKey>
+      <hardwareKey xsi:type="xsd:string">phpunitsync</hardwareKey>
+      <displayName xsi:type="xsd:string">PHPUnitSync</displayName>
+      <clientType xsi:type="xsd:string">android</clientType>
+      <clientVersion xsi:type="xsd:string">4</clientVersion>
+      <clientCode xsi:type="xsd:int">420</clientCode>
+      <macAddress xsi:type="xsd:string">CC:40:D0:46:3C:A8</macAddress>
+      <licenceResult xsi:type="xsd:string">licensed</licenceResult>
+    </tns:RegisterDisplay>
+  </soap:Body>
+</soap:Envelope>';
+
+        $this->registerLeadXml = '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:tns="urn:xmds" xmlns:types="urn:xmds/encodedTypes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <soap:Body soap:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
+    <tns:RegisterDisplay>
+      <serverKey xsi:type="xsd:string">test</serverKey>
+      <hardwareKey xsi:type="xsd:string">phpunit6</hardwareKey>
+      <displayName xsi:type="xsd:string">PHPUnit_v6</displayName>
+      <clientType xsi:type="xsd:string">android</clientType>
+      <clientVersion xsi:type="xsd:string">4</clientVersion>
+      <clientCode xsi:type="xsd:int">420</clientCode>
+      <macAddress xsi:type="xsd:string">CC:40:D0:46:3C:A8</macAddress>
+      <licenceResult xsi:type="xsd:string">licensed</licenceResult>
+    </tns:RegisterDisplay>
+  </soap:Body>
+</soap:Envelope>';
+    }
+
+    public static function registerSuccessCases(): array
+    {
+        return [
+            [7],
+            [6],
+        ];
+    }
+
+    public function testScheduleSyncEvent()
+    {
+        $request = $this->sendRequest('POST', $this->scheduleXml, 7);
+
+        $response = $request->getBody()->getContents();
+
+        $document = new DOMDocument();
+        $document->loadXML($response);
+
+        $xpath = new DOMXpath($document);
+        $result = $xpath->evaluate('string(//ScheduleXml)');
+        $innerDocument = new DOMDocument();
+        $innerDocument->loadXML($result);
+        $layouts = $innerDocument->documentElement->getElementsByTagName('layout');
+
+        foreach ($layouts as $layout) {
+            $this->assertSame('165', $layout->getAttribute('file'));
+            $this->assertSame('1', $layout->getAttribute('syncEvent'));
+            $this->assertSame('64', $layout->getAttribute('scheduleid'));
+        }
+    }
+
+    #[DataProvider('registerSuccessCases')]
+    public function testRegisterDisplay($version)
+    {
+        if ($version === 7) {
+            $xml = $this->registerXml;
+        } else {
+            $xml = $this->registerLeadXml;
+        }
+
+        $request = $this->sendRequest('POST', $xml, $version);
+        $response = $request->getBody()->getContents();
+
+        $document = new DOMDocument();
+        $document->loadXML($response);
+
+        $xpath = new DOMXpath($document);
+        $result = $xpath->evaluate('string(//ActivationMessage)');
+        $innerDocument = new DOMDocument();
+        $innerDocument->loadXML($result);
+
+        $this->assertSame('READY', $innerDocument->documentElement->getAttribute('code'));
+        $this->assertSame('Display is active and ready to start.', $innerDocument->documentElement->getAttribute('message'));
+
+        if ($version === 7) {
+            $this->assertSame('192.168.0.3', $innerDocument->documentElement->getAttribute('syncGroup'));
+        } else {
+            $this->assertSame('lead', $innerDocument->documentElement->getAttribute('syncGroup'));
+        }
+    }
+}

--- a/ui/src/core/xibo-calendar.js
+++ b/ui/src/core/xibo-calendar.js
@@ -1524,13 +1524,16 @@ var setupSelectForSchedule = function (dialog) {
     })
 
     $('#syncGroupId', dialog).on('select2:select', function(event) {
+        let eventId = dialog.find('form').data().eventSyncGroupId == $(this).select2('data')[0].id
+          ? dialog.find('form').data().eventId
+          : null
         $.ajax({
             type: 'GET',
             url: dialog.find('form').data().fetchSyncDisplays.replace(':id', $(this).select2('data')[0].id),
             cache: false,
             dataType: 'json',
             data: {
-                eventId : dialog.find('form').data().eventId
+                eventId : eventId
             }
         })
           .then(

--- a/views/schedule-form-sync-edit.twig
+++ b/views/schedule-form-sync-edit.twig
@@ -48,7 +48,7 @@
             {% set notDayPartMessage %}{% trans "Start and end time will be defined by the daypart's configuration for this day of the week. Use a repeating schedule to apply this event over multiple days" %}{% endset %}
             <form id="scheduleEditSyncForm" autocomplete="off" class="XiboForm form-horizontal" method="put" action="{{ url_for("schedule.edit" , {id: event.eventId}) }}"
                   data-full-screen-url="{{ url_for('layout.add.full.screen.schedule') }}" data-fetch-sync-displays="{{ url_for('syncgroup.fetch.displays', {id:':id'}) }}"
-                  data-event-id="{{ event.eventId }}" data-daypart-message="{{ dayPartMessage }}" data-not-daypart-message="{{ notDayPartMessage }}" data-default-lat="{{ defaultLat }}"
+                  data-event-sync-group-id="{{ event.syncGroupId }}" data-event-id="{{ event.eventId }}" data-daypart-message="{{ dayPartMessage }}" data-not-daypart-message="{{ notDayPartMessage }}" data-default-lat="{{ defaultLat }}"
                   data-default-long = "{{ defaultLong }}" data-event-start="{{ eventStart }}" data-event-end="{{ eventEnd }}"
             >
                 <div class="tab-content">

--- a/views/schedule-grid-page.twig
+++ b/views/schedule-grid-page.twig
@@ -7,7 +7,7 @@
     {% if currentUser.featureEnabled("schedule.add") %}
         <div class="widget-action-menu pull-right">
         {% if currentUser.featureEnabled("schedule.sync") %}
-            <button class="btn btn-success XiboFormButton btns" title="{% trans "Add a new Sync event" %}" href="{{ url_for("schedule.add.sync.form") }}"><span class="fa fa-plus"></span> {% trans "Add Synchronised Schedule" %}</button>
+            <button class="btn btn-white XiboFormButton btns" title="{% trans "Add a new Sync event" %}" href="{{ url_for("schedule.add.sync.form") }}"><span class="fa fa-plus"></span> {% trans "Add Synchronised Event" %}</button>
         {% endif %}
             <button class="btn btn-success XiboFormButton btns" title="{% trans "Add a new Scheduled event" %}" href="{{ url_for("schedule.add.form") }}"><span class="fa fa-plus"></span> {% trans "Add Event" %}</button>
         </div>

--- a/views/schedule-page.twig
+++ b/views/schedule-page.twig
@@ -169,7 +169,7 @@
                     <li class="event-interrupt"><span class="fa fa-hand-paper"></span> {% trans "Interrupt" %}</li>
                     <li class="event-geo-location"><span class="fa fa-map-marker"></span> {% trans "Geo Location" %}</li>
                     <li class="event-action"><span class="fa fa-paper-plane "></span> {% trans "Interactive Action" %}</li>
-                    <li class="event-sync"><span class="fa fa-refresh"></span> {% trans "Synchronised Schedule" %}</li>
+                    <li class="event-sync"><span class="fa fa-refresh"></span> {% trans "Synchronised" %}</li>
                 </ul>
             </div>
         </div>
@@ -325,6 +325,10 @@
 
                     if (event.event.eventTypeId == 6) {
                         eventIcon = "fa-paper-plane";
+                    }
+
+                    if (event.event.eventTypeId == 9) {
+                        eventIcon = "fa-refresh";
                     }
 
                     if (!event.editable) {


### PR DESCRIPTION
Relates to https://github.com/xibosignageltd/xibo-private/issues/268

- Various wording adjustments
- Fixed switching syncGroup on sync event edit form
- Fixed syncGroup members table on sync event edit form when member was added to the group AFTER the event was created (previously there would be no row for such Display in this case)
- XMDS test for sync group register/schedule output