### PR TITLE
Elements with data: Prevent negative and empty results

### DIFF
--- a/ui/src/editor-core/element.js
+++ b/ui/src/editor-core/element.js
@@ -228,7 +228,9 @@ Element.prototype.getData = function() {
       const slot = self.slot ? self.slot : 0;
       parentWidget.getData().then((data) => {
         // Resolve the promise with the data
-        resolve(data[slot]);
+        // If slot is outside the data array
+        // restart from 0
+        resolve(data[slot % data.length]);
       });
     }
   });

--- a/ui/src/editor-core/properties-panel.js
+++ b/ui/src/editor-core/properties-panel.js
@@ -328,6 +328,7 @@ PropertiesPanel.prototype.render = function(
 ) {
   const self = this;
   const app = this.parent;
+  const minSlotValue = 1;
   let targetAux;
   let renderElements = false;
   let isElementGroup = false;
@@ -510,6 +511,7 @@ PropertiesPanel.prototype.render = function(
             title: propertiesPanelTrans.dataSlot,
             helpText: propertiesPanelTrans.dataSlotHelpText,
             value: Number(targetAux.slot) + 1,
+            min: minSlotValue,
             type: 'number',
             visibility: [],
           });
@@ -532,10 +534,17 @@ PropertiesPanel.prototype.render = function(
         ) {
           self.DOMObject.find('[name="slot"]')
             .on('change', function(ev) {
-              const sourceValue = $(ev.currentTarget).val();
+              let slotValue = $(ev.currentTarget).val();
+
+              // If value is lower than minSlotValue
+              // set it to minSlotValue
+              if (Number(slotValue) < minSlotValue) {
+                slotValue = minSlotValue;
+                $(ev.currentTarget).val(minSlotValue);
+              }
 
               // update slot for the group
-              targetAux.updateSlot(Number(sourceValue) - 1, true);
+              targetAux.updateSlot(Number(slotValue) - 1, true);
 
               // save elements
               target.saveElements();
@@ -621,6 +630,7 @@ PropertiesPanel.prototype.render = function(
                 title: propertiesPanelTrans.dataSlot,
                 helpText: propertiesPanelTrans.dataSlotHelpText,
                 value: Number(targetAux.slot) + 1,
+                min: minSlotValue,
                 type: 'number',
                 visibility: [],
               },
@@ -680,6 +690,13 @@ PropertiesPanel.prototype.render = function(
                 // If property is slot, set a value
                 // with -1 to match with the array
                 if (propertyName === 'slot') {
+                  // If value is lower than minSlotValue
+                  // set it to minSlotValue
+                  if (Number(value) < minSlotValue) {
+                    value = minSlotValue;
+                    $(ev.currentTarget).val(minSlotValue);
+                  }
+
                   value = Number(value) - 1;
                 }
 

--- a/ui/src/templates/forms/inputs/number.hbs
+++ b/ui/src/templates/forms/inputs/number.hbs
@@ -5,7 +5,7 @@
 >
     <label for="input_{{id}}" class="control-label"><strong>{{title}}</strong></label>
     <div class="input-info-container"></div>
-    <input type="number" class="form-control" {{#if step}}step="{{step}}"{{/if}} id="input_{{id}}" name="{{#if name}}{{name}}{{else}}{{id}}{{/if}}" value="{{value}}"
+    <input type="number" class="form-control" {{#if step}}step="{{step}}"{{/if}} id="input_{{id}}" name="{{#if name}}{{name}}{{else}}{{id}}{{/if}}" {{#if min}}min="{{min}}"{{/if}} value="{{value}}"
         {{#each customData}}
             data-{{this.name}}="{{this.value}}"
         {{/each}}


### PR DESCRIPTION
relates to xibosignageltd/xibo-private#251

- Slot input will force a positive input
- Viewer data render will start from 0 if slot is higher than data results length