### PR TITLE
Widgets: world clock - template not found saving properties form

### DIFF
--- a/lib/Widget/Compatibility/WorldClockWidgetCompatibility.php
+++ b/lib/Widget/Compatibility/WorldClockWidgetCompatibility.php
@@ -87,6 +87,9 @@ class WorldClockWidgetCompatibility implements WidgetCompatibilityInterface
             $widget->setOptionValue('widgetDesignHeight', 'attrib', $widget->getOptionValue('widgetOriginalHeight', '250'));
         }
 
+        // Always remove template id from world clock
+        $widget->removeOption('templateId');
+
         return $upgraded;
     }
 

--- a/modules/worldclock-analogue.xml
+++ b/modules/worldclock-analogue.xml
@@ -314,9 +314,15 @@
         ]]></hbs>
         <twig><![CDATA[
 <style>
-.analogue-clock {
+body {
     {% if bgColor %}
         background: {{bgColor}};
+    {% endif %}
+}
+
+.analogue-clock {
+    {% if faceColor %}
+        background: {{faceColor}};
     {% endif %}
     position: relative;
     text-align: center;
@@ -532,7 +538,7 @@
 moment.locale(globalOptions.locale);
 
 Handlebars.registerHelper('eq', function (v1, v2, opts) {
-  if (v1 === v2) {
+  if (v1 == v2) {
     return opts.fn(this);
   } else {
     return opts.inverse(this);

--- a/modules/worldclock-digital-custom.xml
+++ b/modules/worldclock-digital-custom.xml
@@ -43,7 +43,7 @@
             <title>Clocks</title>
         </property>
         <property id="worldClocks" type="worldClock"></property>
-        <property id="template_html" allowLibraryRefs="true" variant="html">
+        <property id="template_html" type="code" allowLibraryRefs="true" variant="html">
             <title>Template - HTML</title>
             <helpText>Enter text or HTML in the box below. Use squared brackets for elements to be replaced (e.g. [HH:mm] for time, or [label] to show the timezone name</helpText>
             <default><![CDATA[

--- a/ui/src/editor-core/toolbar.js
+++ b/ui/src/editor-core/toolbar.js
@@ -1030,7 +1030,7 @@ Toolbar.prototype.openMenu = function(
 
     if (app.mainObjectType != 'playlist') {
       // Refresh main containers
-      app.viewer.update();
+      app.viewer.render(true);
     }
   }
 


### PR DESCRIPTION
relates to xibosignageltd/xibo-private#311

 -  Digital clock template input fix
 - Viewer render after moving toolbar fix