### PR TITLE
Schedule : full screen media and playlist schedules and schedule page adjustments

### DIFF
--- a/lib/Controller/Library.php
+++ b/lib/Controller/Library.php
@@ -758,6 +758,7 @@ class Library extends Base
 
             // Schedule Now
             if ($this->getUser()->featureEnabled('schedule.now')
+                && in_array($media->mediaType, ['image', 'video'])
                 && ($this->getUser()->checkEditable($media)
                     || $this->getConfig()->getSetting('SCHEDULE_WITH_VIEW_PERMISSION') == 1)
             ) {

--- a/ui/src/style/forms.scss
+++ b/ui/src/style/forms.scss
@@ -1,3 +1,24 @@
+/*!
+ * Copyright (C) 2023 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 @import "variables";
 @import "mixins";
 
@@ -296,4 +317,19 @@
     p {
         margin-bottom: 0;
     }
+}
+
+// make select2 set as readonly to actually be readonly.
+select[readonly].select2-hidden-accessible + .select2-container {
+    pointer-events: none;
+    touch-action: none;
+}
+
+select[readonly].select2-hidden-accessible + .select2-container .select2-selection {
+    background: #eee;
+    box-shadow: none;
+}
+
+select[readonly].select2-hidden-accessible + .select2-container .select2-selection__arrow, select[readonly].select2-hidden-accessible + .select2-container .select2-selection__clear {
+    display: none;
 }

--- a/ui/src/vendor/calendar/js/calendar.js
+++ b/ui/src/vendor/calendar/js/calendar.js
@@ -1222,7 +1222,7 @@ if(!String.prototype.formatNum) {
 			self.view(view);
 			$('#range').val(view)
 		});
-		$('.cal-cell').on('click', function() {
+		$('.cal-cell').dblclick(function() {
 			var view = $('[data-cal-date]', this).data('cal-view');
 			self.options.day = $('[data-cal-date]', this).data('cal-date');
 			// Add event to the picker to update the calendar
@@ -1348,6 +1348,8 @@ if(!String.prototype.formatNum) {
 				downbox.hide();
 			})
 			.on('click', function(event) {
+				self.options.day = $('[data-cal-date]', this).data('cal-date');
+				updateDatePicker($('#dateInput'), self.options.day, jsDateOnlyFormat);
 				if($('.events-list', this).length == 0) {
 					return;
 				}

--- a/views/forms.twig
+++ b/views/forms.twig
@@ -191,11 +191,11 @@
     </div>
 {% endmacro %}
 
-{% macro dropdown(name, type, title, value, options, optionId, optionValue, helpText, groupClass, validation, accessKey, callBack, dataAttributes, optionGroups, optionImageValue, optionFilter) %}
+{% macro dropdown(name, type, title, value, options, optionId, optionValue, helpText, groupClass, validation, accessKey, callBack, dataAttributes, optionGroups, optionImageValue, optionFilter, readonly) %}
     <div class="form-group row {{ groupClass }}">
         <label class="col-sm-2 control-label" for="{{ name }}" accesskey="{{ accessKey }}">{{ title }}</label>
         <div class="col-sm-10">
-            <select class="form-control" {% if type == "dropdownmulti" %}multiple{% endif %} name="{{ name }}" id="{{ name }}" {{ callBack }}
+            <select class="form-control" {% if type == "dropdownmulti" %}multiple{% endif %} name="{{ name }}" id="{{ name }}" {{ callBack }} {% if readonly %}readonly{% endif %}
                 {% if dataAttributes|length > 0 %}
                     {% for attribute in dataAttributes %}
                         {{ attribute.name }}="{{ attribute.value }}"
@@ -363,6 +363,26 @@
                         <option value="OR" {% if logicalOperatorValue != "AND" %}selected{% endif %}>OR</option>
                         <option value="AND" {% if logicalOperatorValue == "AND" %}selected{% endif %}>AND</option>
                 </select>
+            </div>
+            <small class="form-text text-muted">{{ helpText }}</small>
+        </div>
+    </div>
+{% endmacro %}
+
+{% macro inputFullScreenSchedule(name, title, value, helpText, groupClass, idValue, validation, accessKey) %}
+    <div class="form-group row input-full-screen-layout {{ groupClass }}">
+        <label class="col-sm-2 control-label" for="{{ name }}" accesskey="{{ accessKey }}">{{ title }}</label>
+        <div class="col-sm-10">
+            <div class="input-group">
+                <input class="form-control" type="text" id="{{ name }}" value="{{ value }}" {{ validation }} readonly />
+                <input type="hidden" id="{{ name }}Id" value="{{ idValue }}"/>
+                <div class="input-group-append input-group-addon">
+                    <button class="btn btn-outline-secondary full-screen-layout-form" type="button"
+                            data-toggle="modal" data-target="#full-screen-schedule-modal" id="fullScreenControl_{{ name }}"
+                            data-no-layout="{% trans "Choose" %}" data-has-layout="{% trans "Change" %}">
+                        {% if idValue %}{% trans "Change" %}{% else %}{% trans "Choose" %}{% endif %}
+                    </button>
+                </div>
             </div>
             <small class="form-text text-muted">{{ helpText }}</small>
         </div>

--- a/views/schedule-form-add.twig
+++ b/views/schedule-form-add.twig
@@ -47,7 +47,13 @@
             </ul>
             {% set dayPartMessage %}{% trans "Select the start time for this event" %}{% endset %}
             {% set notDayPartMessage %}{% trans "Start and end time will be defined by the daypart's configuration for this day of the week. Use a repeating schedule to apply this event over multiple days" %}{% endset %}
-            <form id="scheduleAddForm" autocomplete="off" class="form-horizontal" method="post" action="{{ url_for("schedule.add") }}" data-full-screen-url="{{ url_for('layout.add.full.screen.schedule') }}" data-daypart-message="{{ dayPartMessage }}" data-not-daypart-message="{{ notDayPartMessage }}" data-default-lat="{{ defaultLat }}" data-default-long = "{{ defaultLong }}">
+            <form id="scheduleAddForm" autocomplete="off" class="form-horizontal" method="post" action="{{ url_for("schedule.add") }}"
+                  data-daypart-message="{{ dayPartMessage }}"
+                  data-not-daypart-message="{{ notDayPartMessage }}"
+                  data-default-lat="{{ defaultLat }}"
+                  data-default-long = "{{ defaultLong }}"
+                  data-library-get-url="{{ url_for("library.search") }}"
+                  data-playlist-get-url="{{ url_for("playlist.search") }}">
                 <div class="tab-content">
                     <div class="tab-pane active" id="general">
 
@@ -103,52 +109,14 @@
                         {% set helpText %}{% trans "Please select a Layout for this Event to show" %}{% endset %}
                         {{ forms.dropdown("campaignId", "single", title, "", null, "id", "value", helpText, "layout-control", "", "", "", attributes) }}
 
-
                         {% set title %}{% trans "Media" %}{% endset %}
                         {% set helpText %}{% trans "Select a Media file from the Library to use. The selected file will be shown full screen for this event." %}{% endset %}
-                        {% set attributes = [
-                            { name: "data-width", value: "100%" },
-                            { name: "data-search-url", value: url_for("library.search") ~ "?fullScreenScheduleCheck=true&types[]=image&types[]=video" },
-                            { name: "data-search-term", value: "media" },
-                            { name: "data-id-property", value: "mediaId" },
-                            { name: "data-text-property", value: "name" },
-                            { name: "data-additional-property", value: "hasFullScreenLayout" }
-                        ] %}
-                        {{ forms.dropdown("mediaId", "single", title, "", null, "mediaId", "name", helpText, "pagedSelect media-control", "", "", "", attributes) }}
+                        {{ forms.inputFullScreenSchedule('media', title, "", helpText, "media-control full-screen-control") }}
 
                         {% set title %}{% trans "Playlist" %}{% endset %}
                         {% set helpText %}{% trans "Select a Playlist to use. The selected playlist will be shown full screen for this event." %}{% endset %}
-                        {% set attributes = [
-                            { name: "data-width", value: "100%" },
-                            { name: "data-search-url", value: url_for("playlist.search") ~ "?fullScreenScheduleCheck=true" },
-                            { name: "data-search-term", value: "name" },
-                            { name: "data-id-property", value: "playlistId" },
-                            { name: "data-text-property", value: "name" },
-                            { name: "data-additional-property", value: "hasFullScreenLayout" }
-                        ] %}
-                        {{ forms.dropdown("playlistId", "single", title, "", null, "playlistId", "name", helpText, "pagedSelect playlist-control", "", "", "", attributes) }}
-
+                        {{ forms.inputFullScreenSchedule('playlist', title, "", helpText, "playlist-control full-screen-control") }}
                         {{ forms.hidden('fullScreenCampaignId') }}
-
-                        {% set title %}{% trans "Duration in loop" %}{% endset %}
-                        {% set helpText %}{% trans "Set how long this item should be shown each time it appears in the schedule. Leave blank to use the Media Duration set in the Library" %}{% endset %}
-                        {{ forms.number('layoutDuration', title, "", helpText, 'media-control no-full-screen-layout') }}
-
-                        {% set title %}{% trans "Resolution" %}{% endset %}
-                        {% set helpText %}{% trans "Optionally select a Resolution to use for the selected Media. Leave blank to match with an existing Resolution closest in size to the selected media." %}{% endset %}
-                        {% set attributes = [
-                            { name: "data-search-url", value: url_for("resolution.search") },
-                            { name: "data-search-term", value: "resolution" },
-                            { name: "data-id-property", value: "resolutionId" },
-                            { name: "data-text-property", value: "resolution" },
-                            { name: "data-trans-media-help-text", value: "Optionally select a Resolution to use for the selected Media. Leave blank to match with an existing Resolution closest in size to the selected media."|trans },
-                            { name: "data-trans-playlist-help-text", value: "Optionally select a Resolution to use for the selected Playlist. Leave blank to default to a 1080p Resolution"|trans },
-                        ] %}
-                        {{ forms.dropdown("resolutionId", "single", title, "", null, "resolutionId", "resolution", helpText, "pagedSelect media-playlist-control resolution-control no-full-screen-layout", "", "", "", attributes) }}
-
-                        {% set title %}{% trans "Background Colour" %}{% endset %}
-                        {% set helpText %}{% trans "Optionally set a colour to use as a background for if the item selected does not fill the entire screen" %}{% endset %}
-                        {{ forms.colorPicker("backgroundColor", title, '#000', helpText, 'media-playlist-control no-full-screen-layout') }}
 
                         <div class="form-group row preview-button-container">
                             <div class="offset-md-2 col-md-10">

--- a/views/schedule-form-edit.twig
+++ b/views/schedule-form-edit.twig
@@ -53,7 +53,8 @@
                   data-duplicated-message="{% trans "Duplicate form loaded, make adjustments and press save." %}"
                   data-default-lat="{{ defaultLat }}"
                   data-default-long="{{ defaultLong }}"
-                  data-full-screen-url="{{ url_for('layout.add.full.screen.schedule') }}">
+                  data-library-get-url="{{ url_for("library.search") }}"
+                  data-playlist-get-url="{{ url_for("playlist.search") }}">
                 <div class="tab-content">
                     <div class="tab-pane active" id="general">
                         {% set title %}{% trans "Event Type" %}{% endset %}
@@ -110,53 +111,14 @@
 
                         {% set title %}{% trans "Media" %}{% endset %}
                         {% set helpText %}{% trans "Select a Media file from the Library to use. The selected file will be shown full screen for this event." %}{% endset %}
-                        {% set attributes = [
-                            { name: "data-width", value: "100%" },
-                            { name: "data-search-url", value: url_for("library.search") ~ "?fullScreenScheduleCheck=true&types[]=image&types[]=video" },
-                            { name: "data-search-term", value: "media" },
-                            { name: "data-id-property", value: "mediaId" },
-                            { name: "data-text-property", value: "name" },
-                            { name: "data-additional-property", value: "hasFullScreenLayout" },
-                            { name: "data-initial-key", value: "mediaId"},
-                            { name: "data-initial-value", value: event.getUnmatchedProperty("mediaId")}
-                        ] %}
-                        {{ forms.dropdown("mediaId", "single", title, "", null, "mediaId", "name", helpText, "pagedSelect media-control", "", "", "", attributes) }}
+                        {{ forms.inputFullScreenSchedule('media', title, "", helpText, "media-control full-screen-control", event.getUnmatchedProperty("mediaId")) }}
 
                         {% set title %}{% trans "Playlist" %}{% endset %}
                         {% set helpText %}{% trans "Select a Playlist to use. The selected playlist will be shown full screen for this event." %}{% endset %}
-                        {% set attributes = [
-                            { name: "data-width", value: "100%" },
-                            { name: "data-search-url", value: url_for("playlist.search") ~ "?fullScreenScheduleCheck=true" },
-                            { name: "data-search-term", value: "name" },
-                            { name: "data-id-property", value: "playlistId" },
-                            { name: "data-text-property", value: "name" },
-                            { name: "data-additional-property", value: "hasFullScreenLayout" },
-                            { name: "data-initial-key", value: "playlistId"},
-                            { name: "data-initial-value", value: event.getUnmatchedProperty("playlistId")}
-                        ] %}
-                        {{ forms.dropdown("playlistId", "single", title, "", null, "playlistId", "name", helpText, "pagedSelect playlist-control", "", "", "", attributes) }}
+                        {{ forms.inputFullScreenSchedule('playlist', title, "", helpText, "playlist-control full-screen-control", event.getUnmatchedProperty("playlistId")) }}
 
-                        {{ forms.hidden('fullScreenCampaignId') }}
+                        {{ forms.hidden('fullScreenCampaignId', event.getUnmatchedProperty("fullScreenCampaignId")) }}
 
-                        {% set title %}{% trans "Duration in loop" %}{% endset %}
-                        {% set helpText %}{% trans "Set how long this item should be shown each time it appears in the schedule. Leave blank to use the Media Duration set in the Library" %}{% endset %}
-                        {{ forms.number('layoutDuration', title, "", helpText, 'media-control no-full-screen-layout') }}
-
-                        {% set title %}{% trans "Resolution" %}{% endset %}
-                        {% set helpText %}{% trans "Optionally select a Resolution to use for the selected Media. Leave blank to match with an existing Resolution closest in size to the selected media." %}{% endset %}
-                        {% set attributes = [
-                            { name: "data-search-url", value: url_for("resolution.search") },
-                            { name: "data-search-term", value: "resolution" },
-                            { name: "data-id-property", value: "resolutionId" },
-                            { name: "data-text-property", value: "resolution" },
-                            { name: "data-trans-media-help-text", value: "Optionally select a Resolution to use for the selected Media. Leave blank to match with an existing Resolution closest in size to the selected media."|trans },
-                            { name: "data-trans-playlist-help-text", value: "Optionally select a Resolution to use for the selected Playlist. Leave blank to default to a 1080p Resolution."|trans },
-                        ] %}
-                        {{ forms.dropdown("resolutionId", "single", title, "", null, "resolutionId", "resolution", helpText, "pagedSelect media-playlist-control resolution-control no-full-screen-layout", "", "", "", attributes) }}
-
-                        {% set title %}{% trans "Background Colour" %}{% endset %}
-                        {% set helpText %}{% trans "Optionally set a colour to use as a background for if the item selected does not fill the entire screen" %}{% endset %}
-                        {{ forms.colorPicker("backgroundColor", title, '#000', helpText, 'media-playlist-control no-full-screen-layout') }}
                         <div class="form-group row preview-button-container">
                             <div class="offset-md-2 col-md-10">
                                 <a id="previewButton" class="btn btn-success" target="_blank" data-url="{{ url_for("campaign.preview", {id: ':id'}) }}">{% trans "Preview" %} <span class="fa fa-tablet"></span></a>

--- a/views/schedule-form-now.twig
+++ b/views/schedule-form-now.twig
@@ -31,7 +31,7 @@
 {% block formButtons %}
     {% trans "Help" %}, XiboHelpRender("{{ help }}")
     {% trans "Cancel" %}, XiboDialogClose()
-    {% trans "Save" %}, beforeSubmitScheduleForm($("#scheduleNowForm"))
+    {% trans "Save" %}, scheduleNowFormSubmit($("#scheduleNowForm"))
 {% endblock %}
 
 {% block callBack %}setupScheduleNowForm{% endblock %}
@@ -47,6 +47,7 @@
                 {{ forms.hidden("fromDt", "") }}
                 {{ forms.hidden("toDt", "") }}
                 {{ forms.hidden("syncTimezone", "1") }}
+                {{ forms.hidden("fullScreenCampaignId") }}
 
                 {# Campaign / Layout list. We want to build two arrays for us to use. #}
                 {% set attributes = [
@@ -59,11 +60,11 @@
                 ] %}
 
                 {% set title %}{% trans "Layout" %}{% endset %}
-                {% set helpText %}{% trans "Please select a Layout for this Event to show" %}{% endset %}
-                {{ forms.dropdown("campaignId", "single", title, campaign.campaignId, [campaign], "campaignId", "campaign", helpText, "layout-control", "", "", "", attributes) }}
+                {% set helpText %}{% trans "Layout for this Event to show" %}{% endset %}
+                {{ forms.dropdown("campaignId", "single", title, campaign.campaignId, [campaign], "campaignId", "campaign", helpText, "layout-control", "", "", "", attributes, "", "", "", readonlySelect) }}
 
                 {% set title %}{% trans "Media" %}{% endset %}
-                {% set helpText %}{% trans "Select a Media file from the Library to use. The selected file will be shown full screen for this event." %}{% endset %}
+                {% set helpText %}{% trans "Media file from the Library, selected file will be shown full screen for this event." %}{% endset %}
                 {% set attributes = [
                     { name: "data-width", value: "100%" },
                     { name: "data-search-url", value: url_for("library.search") ~ "?fullScreenScheduleCheck=true&types[]=image&types[]=video" },
@@ -74,10 +75,10 @@
                     { name: "data-initial-key", value: "mediaId"},
                     { name: "data-initial-value", value: mediaId}
                 ] %}
-                {{ forms.dropdown("mediaId", "single", title, "", null, "mediaId", "name", helpText, "pagedSelect media-control", "", "", "", attributes) }}
+                {{ forms.dropdown("mediaId", "single", title, "", null, "mediaId", "name", helpText, "pagedSelect media-control", "", "", "", attributes, "", "", "", readonlySelect) }}
 
                 {% set title %}{% trans "Playlist" %}{% endset %}
-                {% set helpText %}{% trans "Select a Playlist to use. The selected playlist will be shown full screen for this event." %}{% endset %}
+                {% set helpText %}{% trans "Playlist to use. The selected playlist will be shown full screen for this event." %}{% endset %}
                 {% set attributes = [
                     { name: "data-width", value: "100%" },
                     { name: "data-search-url", value: url_for("playlist.search") ~ "?fullScreenScheduleCheck=true" },
@@ -88,23 +89,24 @@
                     { name: "data-initial-key", value: "playlistId"},
                     { name: "data-initial-value", value: playlistId}
                 ] %}
-                {{ forms.dropdown("playlistId", "single", title, "", null, "playlistId", "name", helpText, "pagedSelect playlist-control", "", "", "", attributes) }}
-
-                {{ forms.hidden('fullScreenCampaignId') }}
+                {{ forms.dropdown("playlistId", "single", title, "", null, "playlistId", "name", helpText, "pagedSelect playlist-control", "", "", "", attributes, "", "", "", readonlySelect) }}
 
                 {% set title %}{% trans "Duration in loop" %}{% endset %}
                 {% set helpText %}{% trans "Set how long this item should be shown each time it appears in the schedule. Leave blank to use the Media Duration set in the Library" %}{% endset %}
                 {{ forms.number('layoutDuration', title, "", helpText, 'media-control no-full-screen-layout') }}
 
                 {% set title %}{% trans "Resolution" %}{% endset %}
-                {% set helpText %}{% trans "Optionally select a Resolution to use for the selected Media. Leave blank to match with an existing Resolution closest in size to the selected media." %}{% endset %}
+                {% if eventTypeId == 7 %}
+                    {% set helpText %}{% trans "Optionally select a Resolution to use for the selected Media. Leave blank to match with an existing Resolution closest in size to the selected media." %}{% endset %}
+                {% else %}
+                    {% set helpText %}{% trans "Optionally select a Resolution to use for the selected Playlist. Leave blank to default to a 1080p Resolution." %}{% endset %}
+                {% endif %}
+
                 {% set attributes = [
                     { name: "data-search-url", value: url_for("resolution.search") },
                     { name: "data-search-term", value: "resolution" },
                     { name: "data-id-property", value: "resolutionId" },
                     { name: "data-text-property", value: "resolution" },
-                    { name: "data-trans-media-help-text", value: "Optionally select a Resolution to use for the selected Media. Leave blank to match with an existing Resolution closest in size to the selected media."|trans },
-                    { name: "data-trans-playlist-help-text", value: "Optionally select a Resolution to use for the selected Playlist. Leave blank to default to a 1080p Resolution."|trans },
                 ] %}
                 {{ forms.dropdown("resolutionId", "single", title, "", null, "resolutionId", "resolution", helpText, "pagedSelect media-playlist-control resolution-control no-full-screen-layout", "", "", "", attributes) }}
 

--- a/views/schedule-page.twig
+++ b/views/schedule-page.twig
@@ -22,6 +22,7 @@
 #}
 {% extends "authed.twig" %}
 {% import "inline.twig" as inline %}
+{% import "forms.twig" as forms %}
 
 {% block title %}{{ "Schedule"|trans }} | {% endblock %}
 
@@ -88,7 +89,7 @@
                             <div class="form-group mr-1 mb-1 non-agenda-filter">
                                 <label class="control-label mr-1" for="campaignId" title=""
                                        accesskey="">{{ title }}</label>
-                                <select name="campaignId" id="campaignId" class="form-control"
+                                <select name="campaignId" id="campaignIdFilter" class="form-control"
                                         data-search-url="{{ url_for("campaign.search") }}"
                                         data-trans-campaigns="{% trans "Campaigns" %}"
                                         data-trans-layouts="{% trans "Layouts" %}"
@@ -102,17 +103,40 @@
                             </div>
 
                             {% set title %}{% trans "Displays" %}{% endset %}
-                            <div class="form-group mr-1 mb-1">
+                            <div class="form-group mr-1 mb-1 pagedSelect" style="min-width: 200px">
                                 <label class="control-label mr-1" for="DisplayList" title=""
                                        accesskey="">{{ title }}</label>
                                 <select id="DisplayList" class="form-control" name="displayGroupIds[]"
-                                        data-placeholder="{% trans "Displays" %}"
-                                        data-search-url="{{ url_for("displayGroup.search") }}"
-                                        data-trans-groups="{% trans "Groups" %}"
-                                        data-trans-display="{% trans "Display" %}"
-                                        data-allow-clear="true"
                                         data-width="100%"
-                                        data-placeholder="{% trans "Select Displays" %}" multiple>
+                                        data-placeholder="{% trans "Displays" %}"
+                                        data-search-url="{{ url_for("display.search") }}"
+                                        data-search-term="display"
+                                        data-id-property="displayGroupId"
+                                        data-text-property="display"
+                                        data-additional-property="displayGroupId"
+                                        data-allow-clear="true"
+                                        multiple>
+                                    {% for option in displaySpecificDisplayGroups %}
+                                        {% set itemOptionId = attribute(option, "displayGroupId") %}
+                                        {% set itemOptionValue = attribute(option, "displayGroup") %}
+                                        <option value="{{ itemOptionId }}" selected>{{ itemOptionValue }}</option>
+                                    {% endfor %}
+                                </select>
+                            </div>
+
+                            {% set title %}{% trans "Display Groups" %}{% endset %}
+                            <div class="form-group mr-1 mb-1 pagedSelect" style="min-width: 200px">
+                                <label class="control-label mr-1" for="DisplayGroupList" title=""
+                                       accesskey="">{{ title }}</label>
+                                <select id="DisplayGroupList" class="form-control" name="displayGroupIds[]"
+                                        data-width="100%"
+                                        data-placeholder="{% trans "Display Groups" %}"
+                                        data-search-url="{{ url_for("displayGroup.search") }}"
+                                        data-search-term="displayGroup"
+                                        data-id-property="displayGroupId"
+                                        data-text-property="displayGroup"
+                                        data-allow-clear="true"
+                                        multiple>
                                     {% for option in displayGroups %}
                                         {% set itemOptionId = attribute(option, "displayGroupId") %}
                                         {% set itemOptionValue = attribute(option, "displayGroup") %}
@@ -190,6 +214,9 @@
                     </div>
                     <div class="tab-pane" id="calendar-view">
                         <div class="row">
+                            <div class="text-center text-danger col-lg-12" id="calendar-error-message">
+                                <span>{% trans "Please select a Display or Display Group to view the calendar" %}</span>
+                            </div>
                             <div class="xibo-calendar-controls-container align-content-start justify-content-end col-xl-12 pl-0 form-inline text-right">
                                 <div class="btn-group xibo-calendar-controls xibo-agenda-calendar-controls">
                                     <button type="button" class="btn btn-primary" data-calendar-nav="prev"><span
@@ -212,7 +239,7 @@
                                     {% if currentUser.featureEnabled("schedule.agenda") %}
                                         <button type="button" id="btn-agenda-view" class="btn btn-outline-info" data-calendar-view="agenda">{% trans "Agenda" %}</button>
                                     {% endif %}
-                                    <button type="button" id="btn-month-view" class="btn btn-outline-info" data-calendar-view="month">{% trans "Month" %}</button>
+                                    <button type="button" id="btn-month-view" class="btn btn-outline-info" data-calendar-view="month">{% trans "Back" %}</button>
                                 </div>
                             </div>
                             <div class="text-center col-xl-12">
@@ -1121,8 +1148,87 @@
             </tr>
         {{/each}}
         </script>
-
         {% endverbatim %}
+
+
+    <script type="text/x-handlebars-template" id="full-screen-schedule-template">
+            <!-- Modal -->
+            <div id="full-screen-schedule-modal" class="modal fade inner-modal" role="dialog">
+                <div class="modal-dialog modal-md modal-dialog-centered">
+                    <!-- Modal content-->
+                    <div class="modal-content">
+                        <div class="modal-header bg-light">
+                            <h4 class="modal-title">{% verbatim %}{{#eq type "Media"}}{% endverbatim %}{% trans "Select Media"%}{% verbatim %}{{/eq}}{{#eq type "Playlist"}}{% endverbatim %} {% trans "Select Playlist" %}{% verbatim %}{{/eq}}{%endverbatim%}</h4>
+                            <button type="button" class="close" data-dismiss="modal">&times;</button>
+                        </div>
+                        <div class="modal-body">
+                            <form id="scheduleFullScreenForm" autocomplete="off" class="form-horizontal" method="post" action="{{ url_for('layout.add.full.screen.schedule') }}" data-full-screen-url="{{ url_for('layout.add.full.screen.schedule') }}">
+                            {% verbatim %}
+                                <input type="hidden" id="eventTypeId" value="{{ eventTypeId }}">
+                            {{#eq type "Media"}}
+                            {% endverbatim %}
+                                {% set title %}{% trans "Media" %}{% endset %}
+                                {% set helpText %}{% trans "Select a Media file from the Library to use. The selected file will be shown full screen for this event." %}{% endset %}
+                                {% set attributes = [
+                                    { name: "data-width", value: "100%" },
+                                    { name: "data-search-url", value: url_for("library.search") ~ "?fullScreenScheduleCheck=true&types[]=image&types[]=video" },
+                                    { name: "data-search-term", value: "media" },
+                                    { name: "data-id-property", value: "mediaId" },
+                                    { name: "data-text-property", value: "name" },
+                                    { name: "data-additional-property", value: "hasFullScreenLayout" },
+                                    { name: "data-initial-key", value: "mediaId"},
+                                    { name: "data-initial-value", value: mediaId}
+                                ] %}
+                                {{ forms.dropdown("mediaId", "single", title, "", null, "mediaId", "name", helpText, "pagedSelect media-control", "", "", "", attributes) }}
+                                {% verbatim %}
+                                 {{/eq}}
+                                 {{#eq type "Playlist"}}
+                                 {% endverbatim %}
+                                {% set title %}{% trans "Playlist" %}{% endset %}
+                                {% set helpText %}{% trans "Select a Playlist to use. The selected playlist will be shown full screen for this event." %}{% endset %}
+                                {% set attributes = [
+                                    { name: "data-width", value: "100%" },
+                                    { name: "data-search-url", value: url_for("playlist.search") ~ "?fullScreenScheduleCheck=true" },
+                                    { name: "data-search-term", value: "name" },
+                                    { name: "data-id-property", value: "playlistId" },
+                                    { name: "data-text-property", value: "name" },
+                                    { name: "data-additional-property", value: "hasFullScreenLayout" },
+                                    { name: "data-initial-key", value: "playlistId"},
+                                    { name: "data-initial-value", value: playlistId}
+                                ] %}
+                                {{ forms.dropdown("playlistId", "single", title, "", null, "playlistId", "name", helpText, "pagedSelect playlist-control", "", "", "", attributes) }}
+                                {% verbatim %}
+                                {{/eq}}
+                                {% endverbatim %}
+
+                                {% set title %}{% trans "Duration in loop" %}{% endset %}
+                                {% set helpText %}{% trans "Set how long this item should be shown each time it appears in the schedule. Leave blank to use the Media Duration set in the Library" %}{% endset %}
+                                {{ forms.number('layoutDuration', title, "", helpText, 'media-control no-full-screen-layout') }}
+
+                                {% set title %}{% trans "Resolution" %}{% endset %}
+                                {% set helpText %}{% trans "Optionally select a Resolution to use for the selected Media. Leave blank to match with an existing Resolution closest in size to the selected media." %}{% endset %}
+                                {% set attributes = [
+                                    { name: "data-search-url", value: url_for("resolution.search") },
+                                    { name: "data-search-term", value: "resolution" },
+                                    { name: "data-id-property", value: "resolutionId" },
+                                    { name: "data-text-property", value: "resolution" },
+                                    { name: "data-trans-media-help-text", value: "Optionally select a Resolution to use for the selected Media. Leave blank to match with an existing Resolution closest in size to the selected media."|trans },
+                                    { name: "data-trans-playlist-help-text", value: "Optionally select a Resolution to use for the selected Playlist. Leave blank to default to a 1080p Resolution"|trans },
+                                ] %}
+                                {{ forms.dropdown("resolutionId", "single", title, "", null, "resolutionId", "resolution", helpText, "pagedSelect media-playlist-control resolution-control no-full-screen-layout", "", "", "", attributes) }}
+
+                                {% set title %}{% trans "Background Colour" %}{% endset %}
+                                {% set helpText %}{% trans "Optionally set a colour to use as a background for if the item selected does not fill the entire screen" %}{% endset %}
+                                {{ forms.colorPicker("backgroundColor", title, '#000', helpText, 'media-playlist-control no-full-screen-layout') }}
+                            </form>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-outline-primary" id="btnFullScreenLayoutConfirm">{% trans "Save" %}</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </script>
 {% endblock %}
 
 {% block javaScript %}
@@ -1147,7 +1253,7 @@
         // Select lists
         var dialog = 'body';
 
-        var $campaignSelect = $('#schedule-filter #campaignId');
+        var $campaignSelect = $('#schedule-filter #campaignIdFilter');
         $campaignSelect.select2({
           dropdownParent: $(dialog),
           ajax: {
@@ -1242,97 +1348,11 @@
             setTimeout(calendar.view(), 1000);
           });
 
-        var $displaySelect = $('#DisplayList', dialog);
-        $displaySelect.select2({
-          dropdownParent: $(dialog),
-          dropdownAutoWidth: true,
-          ajax: {
-            url: $displaySelect.data("searchUrl"),
-            dataType: "json",
-            data: function (params) {
-              var query = {
-                isDisplaySpecific: -1,
-                forSchedule: 1,
-                displayGroup: params.term,
-                start: 0,
-                length: 10,
-                columns: [
-                  {
-                    data: 'isDisplaySpecific'
-                  },
-                  {
-                    data: 'displayGroup'
-                  }
-                ],
-                order: [
-                  {
-                    column: 0,
-                    dir: 'asc'
-                  },
-                  {
-                    column: 1,
-                    dir: 'asc'
-                  }
-                ]
-              };
-              // Set the start parameter based on the page number
-              if (params.page != null) {
-                query.start = (params.page - 1) * 10;
-              }
-              return query;
-            },
-            processResults: function (data, params) {
-              var groups = [];
-              var displays = [];
-              $.each(data.data, function (index, element) {
-                if (element.isDisplaySpecific === 1) {
-                  displays.push({
-                    id: element.displayGroupId,
-                    text: element.displayGroup
-                  });
-                } else {
-                  groups.push({
-                    id: element.displayGroupId,
-                    text: element.displayGroup
-                  });
-                }
-              });
-              var page = params.page || 1;
-              page = (page > 1) ? page - 1 : page;
-              return {
-                results: [
-                  {
-                    text: $displaySelect.data('transGroups'),
-                    children: groups
-                  }, {
-                    text: $displaySelect.data('transDisplay'),
-                    children: displays
-                  }
-                ],
-                pagination: {
-                  more: (page * 10 < data.recordsTotal)
-                }
-              }
-            }
-          }
-        }).on('select2:unselecting', function () {
-          // Prevent the ajax request when we deselect an option ( change will still be called )
-          var opts = $(this).data('select2').options;
-          opts.set('disabled', true);
-
-          setTimeout(function () {
-            opts.set('disabled', false);
-          }, 100);
-        })
-          .on('change', function (e) {
-            // Refresh the calendar view
+        // Set up our show all selector control
+        $('#showAll, #eventTypeId, #recurring, #geoAware, #DisplayList, #DisplayGroupList', dialog)
+          .on('change', function () {
             setTimeout(calendar.view(), 1000);
           });
-
-        // Set up our show all selector control
-        $('#showAll, #eventTypeId, #recurring, #geoAware', dialog).on('change', function () {
-          setTimeout(calendar.view(), 1000);
-        });
       });
 
       const table = $('#schedule-grid').DataTable({


### PR DESCRIPTION
- New control for full screen media/playlist instead of select2
On button click opens a new small modal with required fields, on submit creates/fetches the relevant layout and add its layout specific campaignId to the main add/edit schedule form for further editing/submit.
- Schedule Now : readonly select2 dropdowns where needed, on submit with Media/Playlist it will first call the endpoint to create/fetch full screen layout and then submit the form
- Schedule grid/calendar : 
-- separate display/displaygroup filters
-- notice/alert if no display/displaygroup selected (this is required to see events in the calendar)
-- closing swiper/drawer on monthly view should no longer switch to agenda view (double click on the calendar cell will)
-- going back to grid tab from agenda view will switch the view/range filter to today to make it easier to understand
-- the `Month` button while on agenda view renamed to `Back`