### PR TITLE
Widgets: BE for automatically including assets/styles

### DIFF
--- a/lib/Factory/ModuleXmlTrait.php
+++ b/lib/Factory/ModuleXmlTrait.php
@@ -63,7 +63,9 @@ trait ModuleXmlTrait
                     $stencil->twig = $childNode->textContent;
                 } else if ($childNode->nodeName === 'hbs') {
                     $stencil->hbsId = $childNode->getAttribute('id');
-                    $stencil->hbs = $childNode->textContent;
+                    $stencil->hbs = trim($childNode->textContent);
+                } else if ($childNode->nodeName === 'style') {
+                    $stencil->style = trim($childNode->textContent);
                 } else if ($childNode->nodeName === 'elements') {
                     $stencil->elements = $this->parseElements($childNode->childNodes);
                 } else if ($childNode->nodeName === 'width') {
@@ -381,7 +383,7 @@ trait ModuleXmlTrait
                     $asset->path = $node->getAttribute('path');
                     $asset->mimeType = $node->getAttribute('mimeType');
                     $asset->type = $node->getAttribute('type');
-                    $asset->cmsOnly = $node->getAttribute('cmsOnly');
+                    $asset->cmsOnly = $node->getAttribute('cmsOnly') === 'true';
                     $asset->assetNo = count($this->assetCache) + 1;
                     $this->assetCache[$assetId] = $asset;
                 }

--- a/lib/Widget/Definition/Stencil.php
+++ b/lib/Widget/Definition/Stencil.php
@@ -38,6 +38,9 @@ class Stencil implements \JsonSerializable
     public $hbs;
 
     /** @var string|null */
+    public $style;
+
+    /** @var string|null */
     public $hbsId;
 
     /** @var double Optional positional information if contained as part of an element group */
@@ -55,6 +58,7 @@ class Stencil implements \JsonSerializable
         return [
             'hbsId' => $this->hbsId,
             'hbs' => $this->hbs,
+            'style' => $this->style,
             'width' => $this->width,
             'height' => $this->height,
             'gapBetweenHbs' => $this->gapBetweenHbs,

--- a/modules/forecastio.xml
+++ b/modules/forecastio.xml
@@ -100,10 +100,6 @@
     <preview></preview>
     <stencil>
         <twig><![CDATA[
-<link rel="stylesheet" href="[[assetId=weather-icons]]" media="screen">
-<link rel="stylesheet" href="[[assetId=font-awesome]]" media="screen">
-<link rel="stylesheet" href="[[assetId=animate]]" media="screen">
-
 <div class="error-message" style="display: none; padding: 8px; background-color: #f9f9f9; color: #333;">
     <strong>{% trans "No results returned, please configure Open Weather Map connector!" %}</strong>
 </div>

--- a/modules/templates/currency-static.xml
+++ b/modules/templates/currency-static.xml
@@ -81,8 +81,6 @@
   </div>
 </div>
 
-<link rel="stylesheet" href="[[assetId=flagsCSS]]" media="screen">
-
 <style>
 {{styleSheet|raw}}
 </style>
@@ -166,8 +164,6 @@ if (templateItems.length > 0) {
         </div>
     </div>
 </div>
-
-<link rel="stylesheet" href="[[assetId=flagsCSS]]" media="screen">
 
 <style>
 body {
@@ -347,8 +343,6 @@ if (templateItems.length > 0) {
   <div id="cycle-container" class="items-container">
   </div>
 </div>
-
-<link rel="stylesheet" href="[[assetId=flagsCSS]]" media="screen">
 
 <style>
 body {

--- a/modules/widget-html-render.twig
+++ b/modules/widget-html-render.twig
@@ -52,6 +52,20 @@
     {% for item in twig %}
         {{ item|raw }}
     {% endfor %}
+    {% for asset in assets %}
+        {% if asset.mimeType == 'text/css' %}
+        <link rel="stylesheet" media="screen" href="[[assetId={{ asset.id }}]]" />
+        {% elseif asset.mimeType == 'text/javascript' %}
+        <script id="{{ asset.id }}" type="text/javascript" src="[[assetId={{ asset.id }}]]"></script>
+        {% endif %}
+    {% endfor %}
+    {% if style|length > 0 %}
+        <style type="text/css">
+        {% for item in style %}
+            {{ item|raw }}
+        {% endfor %}
+        </style>
+    {% endif %}
     </body>
     <script type="text/javascript">
         window.globalOptions = {


### PR DESCRIPTION
 - auto-output css/js assets
 - remove manually output assets from static templates
 - add style xml node/parsing, output in HTML

 relates to xibosignageltd/xibo-private#329

Merge this after we've released alpha2