### PR TITLE
Menu Boards: BE, admin and minor widget additions

### DIFF
--- a/db/migrations/20220330111440_modules_table_ver_four_migration.php
+++ b/db/migrations/20220330111440_modules_table_ver_four_migration.php
@@ -135,19 +135,12 @@ class ModulesTableVerFourMigration extends AbstractMigration
               (\'core-worldclock-digital-text\', '.$enabled.', '.$previewEnabled.', '.$defaultDuration.', \''.$settings.'\');
             ');
 
+            // Add new modules.
             $this->execute('
             INSERT INTO `module` (`moduleId`, `enabled`, `previewEnabled`, `defaultDuration`, `settings`) VALUES
-              (\'core-canvas\', \'1\', \'1\', \'60\', \'[]\');
-            ');
-
-            $this->execute('
-            INSERT INTO `module` (`moduleId`, `enabled`, `previewEnabled`, `defaultDuration`, `settings`) VALUES
-              (\'core-mastodon\', \'1\', \'1\', \'60\', \'[]\');
-            ');
-
-            $this->execute('
-            INSERT INTO `module` (`moduleId`, `enabled`, `previewEnabled`, `defaultDuration`, `settings`) VALUES
-              (\'core-countdown-custom\', \'1\', \'1\', \'60\', \'[]\');
+              (\'core-canvas\', \'1\', \'1\', \'60\', \'[]\'),
+              (\'core-mastodon\', \'1\', \'1\', \'60\', \'[]\'),
+              (\'core-countdown-custom\', \'1\', \'1\', \'60\', \'[]\')
             ');
         } catch (Exception $e) {
             // Keep the old module table around for diagnosis and just continue on.

--- a/db/migrations/20230727102500_menuboard_additional_fields_migration.php
+++ b/db/migrations/20230727102500_menuboard_additional_fields_migration.php
@@ -1,0 +1,73 @@
+<?php
+/*
+ * Copyright (C) 2023 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Add some additional fields to menu boards
+ * @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+ */
+class MenuboardAdditionalFieldsMigration extends AbstractMigration
+{
+    public function change(): void
+    {
+        // Before I do this I need to make sure that all products in this table have a numeric field in price
+        foreach ($this->fetchAll('SELECT `menuProductId`, `price` FROM `menu_product`') as $row) {
+            if (!empty($row['price'])) {
+                $this->execute('UPDATE `menu_product` SET `price` = :price WHERE menuProductId = :id', [
+                    'id' => $row['menuProductId'],
+                    'price' => preg_replace('/[^A-Za-z0-9 ]/', '', $row['price']),
+                ]);
+            }
+        }
+
+        $this->table('menu_product')
+            ->addColumn('calories', 'integer', [
+                'length' => \Phinx\Db\Adapter\MysqlAdapter::INT_SMALL,
+                'null' => true,
+                'default' => null,
+            ])
+            ->changeColumn('price', 'decimal', [
+                'precision' => 10,
+                'scale' => 4,
+                'default' => null,
+                'null' => true,
+            ])
+            ->save();
+
+        $this->table('menu_category')
+            ->addColumn('description', 'string', [
+                'length' => 254,
+                'null' => true,
+                'default' => null,
+            ])
+            ->save();
+
+        // Drop the old menu-board module entirely, and insert the new ones.
+        $this->execute('DELETE FROM `module` WHERE moduleId = \'core-menuboard\'');
+        $this->execute('
+            INSERT INTO `module` (`moduleId`, `enabled`, `previewEnabled`, `defaultDuration`, `settings`) VALUES
+              (\'core-menuboard-category\', \'1\', \'1\', \'60\', \'[]\'),
+              (\'core-menuboard-product\', \'1\', \'1\', \'60\', \'[]\');
+        ');
+    }
+}

--- a/db/migrations/20230727102500_menuboard_additional_fields_migration.php
+++ b/db/migrations/20230727102500_menuboard_additional_fields_migration.php
@@ -46,6 +46,11 @@ class MenuboardAdditionalFieldsMigration extends AbstractMigration
                 'null' => true,
                 'default' => null,
             ])
+            ->addColumn('displayOrder', 'integer', [
+                'length' => \Phinx\Db\Adapter\MysqlAdapter::INT_MEDIUM,
+                'null' => false,
+                'default' => 0,
+            ])
             ->changeColumn('price', 'decimal', [
                 'precision' => 10,
                 'scale' => 4,

--- a/lib/Controller/MenuBoard.php
+++ b/lib/Controller/MenuBoard.php
@@ -167,7 +167,7 @@ class MenuBoard extends Base
             $menuBoard->includeProperty('buttons');
             $menuBoard->buttons = [];
 
-            if ($this->getUser()->featureEnabled('menuboard.modify') && $this->getUser()->checkEditable($menuBoard)) {
+            if ($this->getUser()->featureEnabled('menuBoard.modify') && $this->getUser()->checkEditable($menuBoard)) {
                 $menuBoard->buttons[] = [
                     'id' => 'menuBoard_button_viewcategories',
                     'url' => $this->urlFor($request, 'menuBoard.category.view', ['id' => $menuBoard->menuId]),
@@ -203,7 +203,7 @@ class MenuBoard extends Base
                 }
             }
 
-            if ($this->getUser()->featureEnabled('menuboard.modify') && $this->getUser()->checkPermissionsModifyable($menuBoard)) {
+            if ($this->getUser()->featureEnabled('menuBoard.modify') && $this->getUser()->checkPermissionsModifyable($menuBoard)) {
                 $menuBoard->buttons[] = ['divider' => true];
 
                 // Share button
@@ -231,7 +231,7 @@ class MenuBoard extends Base
                 ];
             }
 
-            if ($this->getUser()->featureEnabled('menuboard.modify')
+            if ($this->getUser()->featureEnabled('menuBoard.modify')
                 && $this->getUser()->checkDeleteable($menuBoard)
             ) {
                 $menuBoard->buttons[] = ['divider' => true];

--- a/lib/Controller/MenuBoardCategory.php
+++ b/lib/Controller/MenuBoardCategory.php
@@ -274,6 +274,13 @@ class MenuBoardCategory extends Base
      *      type="string",
      *      required=false
      *   ),
+     *  @SWG\Parameter(
+     *      name="description",
+     *      in="formData",
+     *      description="Menu Board Category description",
+     *      type="string",
+     *      required=false
+     *   ),
      *  @SWG\Response(
      *      response=201,
      *      description="successful operation",
@@ -305,8 +312,9 @@ class MenuBoardCategory extends Base
         $name = $sanitizedParams->getString('name');
         $mediaId = $sanitizedParams->getInt('mediaId');
         $code = $sanitizedParams->getString('code');
+        $description = $sanitizedParams->getString('description');
 
-        $menuBoardCategory = $this->menuBoardCategoryFactory->create($id, $name, $mediaId, $code);
+        $menuBoardCategory = $this->menuBoardCategoryFactory->create($id, $name, $mediaId, $code, $description);
         $menuBoardCategory->save();
 
         // Return
@@ -384,6 +392,13 @@ class MenuBoardCategory extends Base
      *      type="string",
      *      required=false
      *   ),
+     *  @SWG\Parameter(
+     *      name="description",
+     *      in="formData",
+     *      description="Menu Board Category description",
+     *      type="string",
+     *      required=false
+     *   ),
      *  @SWG\Response(
      *      response=204,
      *      description="successful operation"
@@ -413,7 +428,7 @@ class MenuBoardCategory extends Base
         $menuBoardCategory->name = $sanitizedParams->getString('name');
         $menuBoardCategory->mediaId = $sanitizedParams->getInt('mediaId');
         $menuBoardCategory->code = $sanitizedParams->getString('code');
-
+        $menuBoardCategory->description = $sanitizedParams->getString('description');
         $menuBoardCategory->save();
 
         // Success

--- a/lib/Controller/MenuBoardCategory.php
+++ b/lib/Controller/MenuBoardCategory.php
@@ -1,8 +1,8 @@
 <?php
-/**
- * Copyright (C) 2021 Xibo Signage Ltd
+/*
+ * Copyright (C) 2023 Xibo Signage Ltd
  *
- * Xibo - Digital Signage - http://www.xibo.org.uk
+ * Xibo - Digital Signage - https://xibosignage.com
  *
  * This file is part of Xibo.
  *
@@ -162,18 +162,22 @@ class MenuBoardCategory extends Base
                 continue;
             }
 
-            $menuBoardCategory->thumbnail = '';
-
             if ($menuBoardCategory->mediaId != 0) {
-                $download = $this->urlFor($request, 'library.download', ['id' => $menuBoardCategory->mediaId], ['preview' => 1]);
-                $menuBoardCategory->thumbnail = '<a class="img-replace" data-toggle="lightbox" data-type="image" href="' . $download . '"><img src="' . $download . '&isThumb=1" /></i></a>';
-                $menuBoardCategory->thumbnailUrl = $download . '&isThumb=1';
+                $menuBoardCategory->setUnmatchedProperty(
+                    'thumbnail',
+                    $this->urlFor(
+                        $request,
+                        'library.download',
+                        ['id' => $menuBoardCategory->mediaId],
+                        ['preview' => 1],
+                    )
+                );
             }
 
             $menuBoardCategory->includeProperty('buttons');
             $menuBoardCategory->buttons = [];
 
-            if ($this->getUser()->featureEnabled('menuboard.modify') && $this->getUser()->checkEditable($menuBoard)) {
+            if ($this->getUser()->featureEnabled('menuBoard.modify') && $this->getUser()->checkEditable($menuBoard)) {
                 $menuBoardCategory->buttons[] = [
                     'id' => 'menuBoardCategory_button_viewproducts',
                     'url' => $this->urlFor($request, 'menuBoard.product.view', ['id' => $menuBoardCategory->menuCategoryId]),
@@ -188,7 +192,7 @@ class MenuBoardCategory extends Base
                 ];
             }
 
-            if ($this->getUser()->featureEnabled('menuboard.modify') && $this->getUser()->checkDeleteable($menuBoard)) {
+            if ($this->getUser()->featureEnabled('menuBoard.modify') && $this->getUser()->checkDeleteable($menuBoard)) {
                 $menuBoardCategory->buttons[] = ['divider' => true];
 
                 $menuBoardCategory->buttons[] = [

--- a/lib/Controller/MenuBoardProduct.php
+++ b/lib/Controller/MenuBoardProduct.php
@@ -1,8 +1,8 @@
 <?php
-/**
- * Copyright (C) 2021 Xibo Signage Ltd
+/*
+ * Copyright (C) 2023 Xibo Signage Ltd
  *
- * Xibo - Digital Signage - http://www.xibo.org.uk
+ * Xibo - Digital Signage - https://xibosignage.com
  *
  * This file is part of Xibo.
  *
@@ -174,17 +174,17 @@ class MenuBoardProduct extends Base
                 continue;
             }
 
-            $menuBoardProduct->thumbnail = '';
             $menuBoardProduct->includeProperty('buttons');
             $menuBoardProduct->buttons = [];
 
             if ($menuBoardProduct->mediaId != 0) {
-                $download = $this->urlFor($request, 'library.download', ['id' => $menuBoardProduct->mediaId], ['preview' => 1]);
-                $menuBoardProduct->thumbnail = '<a class="img-replace" data-toggle="lightbox" data-type="image" href="' . $download . '"><img src="' . $download . '&isThumb=1" /></i></a>';
-                $menuBoardProduct->thumbnailUrl = $download . '&isThumb=1';
+                $menuBoardProduct->setUnmatchedProperty(
+                    'thumbnail',
+                    $this->urlFor($request, 'library.download', ['id' => $menuBoardProduct->mediaId], ['preview' => 1]),
+                );
             }
 
-            if ($this->getUser()->featureEnabled('menuboard.modify') && $this->getUser()->checkEditable($menuBoard)) {
+            if ($this->getUser()->featureEnabled('menuBoard.modify') && $this->getUser()->checkEditable($menuBoard)) {
                 $menuBoardProduct->buttons[] = [
                     'id' => 'menuBoardProduct_edit_button',
                     'url' => $this->urlFor($request, 'menuBoard.product.edit.form', ['id' => $menuBoardProduct->menuProductId]),
@@ -192,7 +192,7 @@ class MenuBoardProduct extends Base
                 ];
             }
 
-            if ($this->getUser()->featureEnabled('menuboard.modify') && $this->getUser()->checkDeleteable($menuBoard)) {
+            if ($this->getUser()->featureEnabled('menuBoard.modify') && $this->getUser()->checkDeleteable($menuBoard)) {
                 $menuBoardProduct->buttons[] = ['divider' => true];
 
                 $menuBoardProduct->buttons[] = [

--- a/lib/Controller/MenuBoardProduct.php
+++ b/lib/Controller/MenuBoardProduct.php
@@ -322,6 +322,13 @@ class MenuBoardProduct extends Base
      *      required=false
      *   ),
      *  @SWG\Parameter(
+     *      name="displayOrder",
+     *      in="formData",
+     *      description="Menu Board Product Display Order, used for sorting",
+     *      type="integer",
+     *      required=true
+     *   ),
+     *  @SWG\Parameter(
      *      name="availability",
      *      in="formData",
      *      description="Menu Board Product availability",
@@ -393,10 +400,16 @@ class MenuBoardProduct extends Base
         $description = $sanitizedParams->getString('description');
         $allergyInfo = $sanitizedParams->getString('allergyInfo');
         $calories = $sanitizedParams->getInt('calories');
+        $displayOrder = $sanitizedParams->getInt('displayOrder');
         $availability = $sanitizedParams->getCheckbox('availability');
         $productOptions = $sanitizedParams->getArray('productOptions', ['default' => []]);
         $productValues = $sanitizedParams->getArray('productValues', ['default' => []]);
         $code = $sanitizedParams->getString('code');
+
+        // If the display order is empty, get the next highest one.
+        if ($displayOrder === null) {
+            $displayOrder = $this->menuBoardCategoryFactory->getNextDisplayOrder($menuBoardCategory->menuCategoryId);
+        }
 
         $menuBoardProduct = $this->menuBoardCategoryFactory->createProduct(
             $menuBoard->menuId,
@@ -406,6 +419,7 @@ class MenuBoardProduct extends Base
             $description,
             $allergyInfo,
             $calories,
+            $displayOrder,
             $availability,
             $mediaId,
             $code
@@ -516,6 +530,13 @@ class MenuBoardProduct extends Base
      *      required=false
      *   ),
      *  @SWG\Parameter(
+     *      name="displayOrder",
+     *      in="formData",
+     *      description="Menu Board Product Display Order, used for sorting",
+     *      type="integer",
+     *      required=true
+     *   ),
+     *  @SWG\Parameter(
      *      name="availability",
      *      in="formData",
      *      description="Menu Board Product availability",
@@ -583,6 +604,7 @@ class MenuBoardProduct extends Base
         $menuBoardProduct->price = $sanitizedParams->getDouble('price');
         $menuBoardProduct->allergyInfo = $sanitizedParams->getString('allergyInfo');
         $menuBoardProduct->calories = $sanitizedParams->getString('calories');
+        $menuBoardProduct->displayOrder = $sanitizedParams->getInt('displayOrder');
         $menuBoardProduct->availability = $sanitizedParams->getCheckbox('availability');
         $menuBoardProduct->mediaId = $sanitizedParams->getInt('mediaId');
         $menuBoardProduct->code = $sanitizedParams->getString('code');

--- a/lib/Controller/MenuBoardProduct.php
+++ b/lib/Controller/MenuBoardProduct.php
@@ -303,15 +303,22 @@ class MenuBoardProduct extends Base
      *  @SWG\Parameter(
      *      name="price",
      *      in="formData",
-     *      description="Menu Board Product price, including the currency symbol if needed",
-     *      type="string",
-     *      required=true
+     *      description="Menu Board Product price",
+     *      type="decimal",
+     *      required=false
      *   ),
      *  @SWG\Parameter(
      *      name="allergyInfo",
      *      in="formData",
      *      description="Menu Board Product allergyInfo",
      *      type="string",
+     *      required=false
+     *   ),
+     *  @SWG\Parameter(
+     *      name="calories",
+     *      in="formData",
+     *      description="Menu Board Product calories",
+     *      type="integer",
      *      required=false
      *   ),
      *  @SWG\Parameter(
@@ -382,9 +389,10 @@ class MenuBoardProduct extends Base
 
         $name = $sanitizedParams->getString('name');
         $mediaId = $sanitizedParams->getInt('mediaId');
-        $price = $sanitizedParams->getString('price');
+        $price = $sanitizedParams->getDouble('price');
         $description = $sanitizedParams->getString('description');
         $allergyInfo = $sanitizedParams->getString('allergyInfo');
+        $calories = $sanitizedParams->getInt('calories');
         $availability = $sanitizedParams->getCheckbox('availability');
         $productOptions = $sanitizedParams->getArray('productOptions', ['default' => []]);
         $productValues = $sanitizedParams->getArray('productValues', ['default' => []]);
@@ -397,6 +405,7 @@ class MenuBoardProduct extends Base
             $price,
             $description,
             $allergyInfo,
+            $calories,
             $availability,
             $mediaId,
             $code
@@ -488,15 +497,22 @@ class MenuBoardProduct extends Base
      *  @SWG\Parameter(
      *      name="price",
      *      in="formData",
-     *      description="Menu Board Product price, including the currency symbol if needed",
-     *      type="string",
-     *      required=true
+     *      description="Menu Board Product price",
+     *      type="decimal",
+     *      required=false
      *   ),
      *  @SWG\Parameter(
      *      name="allergyInfo",
      *      in="formData",
      *      description="Menu Board Product allergyInfo",
      *      type="string",
+     *      required=false
+     *   ),
+     *  @SWG\Parameter(
+     *      name="calories",
+     *      in="formData",
+     *      description="Menu Board Product calories",
+     *      type="integer",
      *      required=false
      *   ),
      *  @SWG\Parameter(
@@ -564,8 +580,9 @@ class MenuBoardProduct extends Base
 
         $menuBoardProduct->name = $sanitizedParams->getString('name');
         $menuBoardProduct->description = $sanitizedParams->getString('description');
-        $menuBoardProduct->price = $sanitizedParams->getString('price');
+        $menuBoardProduct->price = $sanitizedParams->getDouble('price');
         $menuBoardProduct->allergyInfo = $sanitizedParams->getString('allergyInfo');
+        $menuBoardProduct->calories = $sanitizedParams->getString('calories');
         $menuBoardProduct->availability = $sanitizedParams->getCheckbox('availability');
         $menuBoardProduct->mediaId = $sanitizedParams->getInt('mediaId');
         $menuBoardProduct->code = $sanitizedParams->getString('code');

--- a/lib/Controller/Widget.php
+++ b/lib/Controller/Widget.php
@@ -383,6 +383,11 @@ class Widget extends Base
         $widget->setOptionValue('name', 'attrib', $params->getString('name'));
         $widget->setOptionValue('enableStat', 'attrib', $params->getString('enableStat'));
 
+        // Handle special common properties for widgets with data
+        if ($module->isDataProviderExpected()) {
+            $widget->setOptionValue('isRepeatData', 'attrib', $params->getCheckbox('isRepeatData'));
+        }
+
         // Validate common parameters if we don't have a validator present.
         $widgetValidators = $module->getWidgetValidators();
         if (count($widgetValidators) <= 0 && $widget->duration < 0) {

--- a/lib/Entity/MenuBoardCategory.php
+++ b/lib/Entity/MenuBoardCategory.php
@@ -1,8 +1,8 @@
 <?php
 /*
- * Copyright (c) 2022 Xibo Signage Ltd
+ * Copyright (C) 2023 Xibo Signage Ltd
  *
- * Xibo - Digital Signage - http://www.xibo.org.uk
+ * Xibo - Digital Signage - https://xibosignage.com
  *
  * This file is part of Xibo.
  *
@@ -28,6 +28,7 @@ use Xibo\Service\LogServiceInterface;
 use Xibo\Storage\StorageServiceInterface;
 use Xibo\Support\Exception\InvalidArgumentException;
 use Xibo\Support\Exception\NotFoundException;
+use Xibo\Widget\DataType\ProductCategory;
 
 /**
  * @SWG\Definition()
@@ -102,6 +103,19 @@ class MenuBoardCategory implements \JsonSerializable
             $this->mediaId,
             $this->code
         );
+    }
+
+    /**
+     * Convert this to a product category
+     * @return ProductCategory
+     */
+    public function toProductCategory(): ProductCategory
+    {
+        $productCategory = new ProductCategory();
+        $productCategory->name = $this->name;
+        //$productCategory->description = $this->description;
+        $productCategory->image = $this->mediaId;
+        return $productCategory;
     }
 
     /**

--- a/lib/Entity/MenuBoardCategory.php
+++ b/lib/Entity/MenuBoardCategory.php
@@ -56,6 +56,12 @@ class MenuBoardCategory implements \JsonSerializable
     public $name;
 
     /**
+     * @SWG\Property(description="The Menu Board Category description")
+     * @var string
+     */
+    public $description;
+
+    /**
      * @SWG\Property(description="The Menu Board Category code identifier")
      * @var string
      */
@@ -113,7 +119,7 @@ class MenuBoardCategory implements \JsonSerializable
     {
         $productCategory = new ProductCategory();
         $productCategory->name = $this->name;
-        //$productCategory->description = $this->description;
+        $productCategory->description = $this->description;
         $productCategory->image = $this->mediaId;
         return $productCategory;
     }
@@ -210,30 +216,33 @@ class MenuBoardCategory implements \JsonSerializable
         }
     }
 
-    private function add()
+    private function add(): void
     {
-        $this->menuCategoryId = $this->getStore()->insert(
-            'INSERT INTO `menu_category` (name, menuId, mediaId, code) VALUES (:name, :menuId, :mediaId, :code)',
-            [
-                'name' => $this->name,
-                'mediaId' => $this->mediaId,
-                'menuId' => $this->menuId,
-                'code' => $this->code
-            ]
-        );
+        $this->menuCategoryId = $this->getStore()->insert('
+            INSERT INTO `menu_category` (`name`, `menuId`, `mediaId`, `code`, `description`)
+                VALUES (:name, :menuId, :mediaId, :code, :description)
+        ', [
+            'name' => $this->name,
+            'mediaId' => $this->mediaId,
+            'menuId' => $this->menuId,
+            'code' => $this->code,
+            'description' => $this->description,
+        ]);
     }
 
-    private function update()
+    private function update(): void
     {
-        $this->getStore()->update(
-            'UPDATE `menu_category` SET name = :name, mediaId = :mediaId, code = :code WHERE menuCategoryId = :menuCategoryId',
-            [
-                'menuCategoryId' => $this->menuCategoryId,
-                'name' => $this->name,
-                'mediaId' => $this->mediaId,
-                'code' => $this->code
-            ]
-        );
+        $this->getStore()->update('
+            UPDATE `menu_category` 
+                SET `name` = :name, `mediaId` = :mediaId, `code` = :code, `description` = :description
+             WHERE `menuCategoryId` = :menuCategoryId
+        ', [
+            'menuCategoryId' => $this->menuCategoryId,
+            'name' => $this->name,
+            'mediaId' => $this->mediaId,
+            'code' => $this->code,
+            'description' => $this->description,
+        ]);
     }
 
     /**

--- a/lib/Entity/MenuBoardProduct.php
+++ b/lib/Entity/MenuBoardProduct.php
@@ -62,7 +62,7 @@ class MenuBoardProduct implements \JsonSerializable
 
     /**
      * @SWG\Property(description="The Menu Board Product price")
-     * @var string
+     * @var double
      */
     public $price;
 
@@ -89,6 +89,12 @@ class MenuBoardProduct implements \JsonSerializable
      * @var string
      */
     public $allergyInfo;
+
+    /**
+     * @SWG\Property(description="The Menu Board Product allergy information")
+     * @var int
+     */
+    public $calories;
 
     /**
      * @SWG\Property(description="The Menu Board Product associated mediaId")
@@ -125,31 +131,18 @@ class MenuBoardProduct implements \JsonSerializable
      * Get the Id
      * @return int
      */
-    public function getId()
+    public function getId(): int
     {
         return $this->menuProductId;
     }
 
     /**
-     * Get the Id
-     * @return int
-     */
-    public function getCategoryId()
-    {
-        return $this->menuCategoryId;
-    }
-
-    /**
      * @throws InvalidArgumentException
      */
-    public function validate()
+    public function validate(): void
     {
         if (!v::stringType()->notEmpty()->validate($this->name)) {
             throw new InvalidArgumentException(__('Name cannot be empty'), 'name');
-        }
-
-        if (!v::stringType()->notEmpty()->validate($this->price)) {
-            throw new InvalidArgumentException(__('Price cannot be empty'), 'price');
         }
     }
 
@@ -158,7 +151,16 @@ class MenuBoardProduct implements \JsonSerializable
      */
     public function __toString()
     {
-        return sprintf('MenuProductId %d, MenuCategoryId %d, MenuId %d, Name %s, Price %s, Media %d, Code %s', $this->menuProductId, $this->menuCategoryId, $this->menuId, $this->name, $this->price, $this->mediaId, $this->code);
+        return sprintf(
+            'MenuProductId %d, MenuCategoryId %d, MenuId %d, Name %s, Price %s, Media %d, Code %s',
+            $this->menuProductId,
+            $this->menuCategoryId,
+            $this->menuId,
+            $this->name,
+            $this->price,
+            $this->mediaId,
+            $this->code
+        );
     }
 
     /**
@@ -173,6 +175,7 @@ class MenuBoardProduct implements \JsonSerializable
         $product->description = $this->description;
         $product->availability = $this->availability;
         $product->allergyInfo = $this->allergyInfo;
+        $product->calories = $this->calories;
         $product->image = $this->mediaId;
         foreach (($this->productOptions ?? []) as $productOption) {
             $product->productOptions[] = [
@@ -210,42 +213,73 @@ class MenuBoardProduct implements \JsonSerializable
     /**
      * Add Menu Board Product
      */
-    private function add()
+    private function add(): void
     {
-        $this->menuProductId = $this->getStore()->insert(
-            'INSERT INTO `menu_product` (menuCategoryId, menuId, name, price, description, mediaId, availability, allergyInfo, code) VALUES (:menuCategoryId, :menuId, :name, :price, :description, :mediaId, :availability, :allergyInfo, :code)',
-            [
-                'menuCategoryId' => $this->menuCategoryId,
-                'menuId' => $this->menuId,
-                'name' => $this->name,
-                'price' => $this->price,
-                'description' => $this->description,
-                'mediaId' => $this->mediaId,
-                'availability' => $this->availability,
-                'allergyInfo' => $this->allergyInfo,
-                'code' => $this->code
-            ]
-        );
+        $this->menuProductId = $this->getStore()->insert('
+            INSERT INTO `menu_product` (
+                `menuCategoryId`,
+                `menuId`,
+                `name`,
+                `price`,
+                `description`,
+                `mediaId`,
+                `availability`,
+                `allergyInfo`,
+                `calories`,
+                `code`
+            )
+            VALUES (
+                :menuCategoryId,
+                :menuId,
+                :name,
+                :price,
+                :description,
+                :mediaId,
+                :availability,
+                :allergyInfo,
+                :code
+            )
+        ', [
+            'menuCategoryId' => $this->menuCategoryId,
+            'menuId' => $this->menuId,
+            'name' => $this->name,
+            'price' => $this->price,
+            'description' => $this->description,
+            'mediaId' => $this->mediaId,
+            'availability' => $this->availability,
+            'allergyInfo' => $this->allergyInfo,
+            'calories' => $this->calories,
+            'code' => $this->code,
+        ]);
     }
 
     /**
      * Update Menu Board Product
      */
-    private function update()
+    private function update(): void
     {
-        $this->getStore()->update(
-            'UPDATE `menu_product` SET name = :name, price = :price, description = :description, mediaId = :mediaId, availability = :availability, allergyInfo = :allergyInfo, code = :code WHERE menuProductId = :menuProductId',
-            [
-                'name' => $this->name,
-                'price' => $this->price,
-                'description' => $this->description,
-                'mediaId' => $this->mediaId,
-                'availability' => $this->availability,
-                'allergyInfo' => $this->allergyInfo,
-                'code' => $this->code,
-                'menuProductId' => $this->menuProductId
-            ]
-        );
+        $this->getStore()->update('
+            UPDATE `menu_product` SET
+                `name` = :name,
+                `price` = :price,
+                `description` = :description,
+                `mediaId` = :mediaId,
+                `availability` = :availability,
+                `allergyInfo` = :allergyInfo,
+                `calories` = :calories,
+                `code` = :code
+             WHERE `menuProductId` = :menuProductId
+        ', [
+            'name' => $this->name,
+            'price' => $this->price,
+            'description' => $this->description,
+            'mediaId' => $this->mediaId,
+            'availability' => $this->availability,
+            'allergyInfo' => $this->allergyInfo,
+            'calories' => $this->calories,
+            'code' => $this->code,
+            'menuProductId' => $this->menuProductId
+        ]);
     }
 
     /**

--- a/lib/Entity/MenuBoardProduct.php
+++ b/lib/Entity/MenuBoardProduct.php
@@ -1,8 +1,8 @@
 <?php
 /*
- * Copyright (c) 2022 Xibo Signage Ltd
+ * Copyright (C) 2023 Xibo Signage Ltd
  *
- * Xibo - Digital Signage - http://www.xibo.org.uk
+ * Xibo - Digital Signage - https://xibosignage.com
  *
  * This file is part of Xibo.
  *
@@ -27,6 +27,7 @@ use Xibo\Factory\MenuBoardProductOptionFactory;
 use Xibo\Service\LogServiceInterface;
 use Xibo\Storage\StorageServiceInterface;
 use Xibo\Support\Exception\InvalidArgumentException;
+use Xibo\Widget\DataType\Product;
 
 /**
  * @SWG\Definition()
@@ -79,7 +80,7 @@ class MenuBoardProduct implements \JsonSerializable
 
     /**
      * @SWG\Property(description="The Menu Board Product availability")
-     * @var string
+     * @var int
      */
     public $availability;
 
@@ -97,7 +98,7 @@ class MenuBoardProduct implements \JsonSerializable
 
     /**
      * @SWG\Property(description="The Menu Board Product array of options", @SWG\Items(type="string"))
-     * @var array
+     * @var MenuBoardProductOption[]
      */
     public $productOptions;
 
@@ -158,6 +159,24 @@ class MenuBoardProduct implements \JsonSerializable
     public function __toString()
     {
         return sprintf('MenuProductId %d, MenuCategoryId %d, MenuId %d, Name %s, Price %s, Media %d, Code %s', $this->menuProductId, $this->menuCategoryId, $this->menuId, $this->name, $this->price, $this->mediaId, $this->code);
+    }
+
+    public function toProduct(): Product
+    {
+        $product = new Product();
+        $product->name = $this->name;
+        $product->price = $this->price;
+        $product->description = $this->description;
+        $product->availability = $this->availability;
+        $product->allergyInfo = $this->allergyInfo;
+        $product->mediaId = $this->mediaId;
+        foreach (($this->productOptions ?? []) as $productOption) {
+            $product->productOptions[] = [
+                'name' => $productOption->option,
+                'value' => $productOption->value,
+            ];
+        }
+        return $product;
     }
 
     /**

--- a/lib/Entity/MenuBoardProduct.php
+++ b/lib/Entity/MenuBoardProduct.php
@@ -79,6 +79,12 @@ class MenuBoardProduct implements \JsonSerializable
     public $code;
 
     /**
+     * @SWG\Property(description="The Menu Board Product display order, used for sorting")
+     * @var int
+     */
+    public $displayOrder;
+
+    /**
      * @SWG\Property(description="The Menu Board Product availability")
      * @var int
      */
@@ -223,6 +229,7 @@ class MenuBoardProduct implements \JsonSerializable
                 `price`,
                 `description`,
                 `mediaId`,
+                `displayOrder`,
                 `availability`,
                 `allergyInfo`,
                 `calories`,
@@ -235,8 +242,10 @@ class MenuBoardProduct implements \JsonSerializable
                 :price,
                 :description,
                 :mediaId,
+                :displayOrder,
                 :availability,
                 :allergyInfo,
+                :calories,
                 :code
             )
         ', [
@@ -246,6 +255,7 @@ class MenuBoardProduct implements \JsonSerializable
             'price' => $this->price,
             'description' => $this->description,
             'mediaId' => $this->mediaId,
+            'displayOrder' => $this->displayOrder,
             'availability' => $this->availability,
             'allergyInfo' => $this->allergyInfo,
             'calories' => $this->calories,
@@ -264,6 +274,7 @@ class MenuBoardProduct implements \JsonSerializable
                 `price` = :price,
                 `description` = :description,
                 `mediaId` = :mediaId,
+                `displayOrder` = :displayOrder,
                 `availability` = :availability,
                 `allergyInfo` = :allergyInfo,
                 `calories` = :calories,
@@ -274,6 +285,7 @@ class MenuBoardProduct implements \JsonSerializable
             'price' => $this->price,
             'description' => $this->description,
             'mediaId' => $this->mediaId,
+            'displayOrder' => $this->displayOrder,
             'availability' => $this->availability,
             'allergyInfo' => $this->allergyInfo,
             'calories' => $this->calories,

--- a/lib/Entity/MenuBoardProduct.php
+++ b/lib/Entity/MenuBoardProduct.php
@@ -161,6 +161,10 @@ class MenuBoardProduct implements \JsonSerializable
         return sprintf('MenuProductId %d, MenuCategoryId %d, MenuId %d, Name %s, Price %s, Media %d, Code %s', $this->menuProductId, $this->menuCategoryId, $this->menuId, $this->name, $this->price, $this->mediaId, $this->code);
     }
 
+    /**
+     * Convert this to a Product
+     * @return Product
+     */
     public function toProduct(): Product
     {
         $product = new Product();
@@ -169,7 +173,7 @@ class MenuBoardProduct implements \JsonSerializable
         $product->description = $this->description;
         $product->availability = $this->availability;
         $product->allergyInfo = $this->allergyInfo;
-        $product->mediaId = $this->mediaId;
+        $product->image = $this->mediaId;
         foreach (($this->productOptions ?? []) as $productOption) {
             $product->productOptions[] = [
                 'name' => $productOption->option,

--- a/lib/Event/MenuBoardCategoryRequest.php
+++ b/lib/Event/MenuBoardCategoryRequest.php
@@ -1,0 +1,50 @@
+<?php
+/*
+ * Copyright (C) 2023 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Xibo\Event;
+
+use Xibo\Widget\Provider\DataProviderInterface;
+
+/**
+ * Menu Board Category Request.
+ */
+class MenuBoardCategoryRequest extends Event
+{
+    public static $NAME = 'menuboard.category.request.event';
+
+    /** @var \Xibo\Widget\Provider\DataProviderInterface */
+    private DataProviderInterface $dataProvider;
+
+    public function __construct(DataProviderInterface $dataProvider)
+    {
+        $this->dataProvider = $dataProvider;
+    }
+
+    /**
+     * The data provider should be updated with data for its widget.
+     * @return \Xibo\Widget\Provider\DataProviderInterface
+     */
+    public function getDataProvider(): DataProviderInterface
+    {
+        return $this->dataProvider;
+    }
+}

--- a/lib/Event/MenuBoardProductRequest.php
+++ b/lib/Event/MenuBoardProductRequest.php
@@ -1,0 +1,50 @@
+<?php
+/*
+ * Copyright (C) 2023 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Xibo\Event;
+
+use Xibo\Widget\Provider\DataProviderInterface;
+
+/**
+ * Menu Board Product Request.
+ */
+class MenuBoardProductRequest extends Event
+{
+    public static $NAME = 'menuboard.product.request.event';
+
+    /** @var \Xibo\Widget\Provider\DataProviderInterface */
+    private DataProviderInterface $dataProvider;
+
+    public function __construct(DataProviderInterface $dataProvider)
+    {
+        $this->dataProvider = $dataProvider;
+    }
+
+    /**
+     * The data provider should be updated with data for its widget.
+     * @return \Xibo\Widget\Provider\DataProviderInterface
+     */
+    public function getDataProvider(): DataProviderInterface
+    {
+        return $this->dataProvider;
+    }
+}

--- a/lib/Factory/MenuBoardCategoryFactory.php
+++ b/lib/Factory/MenuBoardCategoryFactory.php
@@ -1,8 +1,8 @@
 <?php
 /*
- * Copyright (c) 2022 Xibo Signage Ltd
+ * Copyright (C) 2022-2023 Xibo Signage Ltd
  *
- * Xibo - Digital Signage - http://www.xibo.org.uk
+ * Xibo - Digital Signage - https://xibosignage.com
  *
  * This file is part of Xibo.
  *
@@ -76,14 +76,14 @@ class MenuBoardCategoryFactory extends BaseFactory
      * @param string $code
      * @return MenuBoardCategory
      */
-    public function create($menuId, $name, $mediaId, $code)
+    public function create($menuId, $name, $mediaId, $code, $description)
     {
         $menuBoardCategory = $this->createEmpty();
         $menuBoardCategory->menuId = $menuId;
         $menuBoardCategory->name = $name;
         $menuBoardCategory->mediaId = $mediaId;
         $menuBoardCategory->code = $code;
-
+        $menuBoardCategory->description = $description;
         return $menuBoardCategory;
     }
 
@@ -92,9 +92,10 @@ class MenuBoardCategoryFactory extends BaseFactory
      * @param int $menuId
      * @param int $menuCategoryId
      * @param string $name
-     * @param string $price
+     * @param float $price
      * @param string $description
      * @param string $allergyInfo
+     * @param int $calories
      * @param int $availability
      * @param int $mediaId
      * @param string $code
@@ -107,6 +108,7 @@ class MenuBoardCategoryFactory extends BaseFactory
         $price,
         $description,
         $allergyInfo,
+        $calories,
         $availability,
         $mediaId,
         $code
@@ -118,10 +120,10 @@ class MenuBoardCategoryFactory extends BaseFactory
         $menuBoardProduct->price = $price;
         $menuBoardProduct->description = $description;
         $menuBoardProduct->allergyInfo = $allergyInfo;
+        $menuBoardProduct->$calories = $$calories;
         $menuBoardProduct->availability = $availability;
         $menuBoardProduct->mediaId = $mediaId;
         $menuBoardProduct->code = $code;
-
         return $menuBoardProduct;
     }
 
@@ -198,11 +200,12 @@ class MenuBoardCategoryFactory extends BaseFactory
         $entries = [];
 
         $select = '
-            SELECT menu_category.menuCategoryId,
-               `menu_category`.menuId,
-               `menu_category`.name,
-               `menu_category`.code,
-               `menu_category`.mediaId
+            SELECT `menu_category`.`menuCategoryId`,
+               `menu_category`.`menuId`,
+               `menu_category`.`name`,
+               `menu_category`.`description`,
+               `menu_category`.`code`,
+               `menu_category`.`mediaId`
             ';
 
         $body = ' FROM menu_category WHERE 1 = 1 ';
@@ -293,6 +296,7 @@ class MenuBoardCategoryFactory extends BaseFactory
                `menu_product`.mediaId,
                `menu_product`.availability,
                `menu_product`.allergyInfo,
+               `menu_product`.`calories`,
                `menu_product`.code
             ';
 
@@ -354,7 +358,15 @@ class MenuBoardCategoryFactory extends BaseFactory
         $sql = $select . $body . $order . $limit;
 
         foreach ($this->getStore()->select($sql, $params) as $row) {
-            $menuProduct = $this->createEmptyProduct()->hydrate($row, ['intProperties' => ['availability']]);
+            $menuProduct = $this->createEmptyProduct()->hydrate($row, [
+                'intProperties' => [
+                    'availability',
+                    'calories',
+                ],
+                'doubleProperties' => [
+                    'price',
+                ]
+            ]);
             $entries[] = $menuProduct;
         }
 

--- a/lib/Helper/Environment.php
+++ b/lib/Helper/Environment.php
@@ -30,7 +30,7 @@ use Phinx\Wrapper\TextWrapper;
  */
 class Environment
 {
-    public static $WEBSITE_VERSION_NAME = '4.0.0-beta';
+    public static $WEBSITE_VERSION_NAME = '4.0.0-rc1';
     public static $XMDS_VERSION = '7';
     public static $XLF_VERSION = 3;
     public static $VERSION_REQUIRED = '8.1.0';

--- a/lib/Listener/MenuBoardProviderListener.php
+++ b/lib/Listener/MenuBoardProviderListener.php
@@ -1,0 +1,68 @@
+<?php
+/*
+ * Copyright (C) 2023 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Xibo\Listener;
+
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Xibo\Event\MenuBoardProductRequest;
+use Xibo\Factory\MenuBoardCategoryFactory;
+
+/**
+ * Listener for dealing with a menu board provider
+ */
+class MenuBoardProviderListener
+{
+    use ListenerLoggerTrait;
+
+    private MenuBoardCategoryFactory $menuBoardCategoryFactory;
+
+    public function __construct(MenuBoardCategoryFactory $menuBoardCategoryFactory)
+    {
+        $this->menuBoardCategoryFactory = $menuBoardCategoryFactory;
+    }
+
+    public function registerWithDispatcher(EventDispatcherInterface $dispatcher): MenuBoardProviderListener
+    {
+        $dispatcher->addListener(MenuBoardProductRequest::$NAME, [$this, 'onProductRequest']);
+        return $this;
+    }
+
+    public function onProductRequest(MenuBoardProductRequest $event): void
+    {
+        $this->getLogger()->debug('onProductRequest: data source is ' . $event->getDataProvider()->getDataSource());
+
+        $dataProvider = $event->getDataProvider();
+        $menuId = $dataProvider->getProperty('menuId', 0);
+        if (empty($menuId)) {
+            $this->getLogger()->debug('onDataRequest: no menuId.');
+            return;
+        }
+
+        $products = $this->menuBoardCategoryFactory->getProductData(null, ['menuId' => $menuId]);
+
+        foreach ($products as $product) {
+            $dataProvider->addItem($product->toProduct());
+        }
+
+        $dataProvider->setIsHandled();
+    }
+}

--- a/lib/Listener/MenuBoardProviderListener.php
+++ b/lib/Listener/MenuBoardProviderListener.php
@@ -60,7 +60,17 @@ class MenuBoardProviderListener
             return;
         }
 
-        $products = $this->menuBoardCategoryFactory->getProductData(null, ['menuId' => $menuId]);
+        // Build a filter
+        $filter = [
+            'menuId' => $menuId,
+        ];
+
+        // Show Unavailable?
+        if ($dataProvider->getProperty('showUnavailable', 0) === 0) {
+            $filter['availability'] = 0;
+        }
+
+        $products = $this->menuBoardCategoryFactory->getProductData(['name'], $filter);
 
         foreach ($products as $menuBoardProduct) {
             $product = $menuBoardProduct->toProduct();

--- a/lib/Middleware/ListenersMiddleware.php
+++ b/lib/Middleware/ListenersMiddleware.php
@@ -42,6 +42,7 @@ use Xibo\Listener\DataSetDataProviderListener;
 use Xibo\Listener\DisplayGroupListener;
 use Xibo\Listener\LayoutListener;
 use Xibo\Listener\MediaListener;
+use Xibo\Listener\MenuBoardProviderListener;
 use Xibo\Listener\NotificationDataProviderListener;
 use Xibo\Listener\PlaylistListener;
 use Xibo\Listener\SyncGroupListener;
@@ -351,6 +352,12 @@ class ListenersMiddleware implements MiddlewareInterface
             $c->get('widgetFactory'),
             $c->get('store'),
             $c->get('configService')
+        ))
+            ->useLogger($c->get('logger'))
+            ->registerWithDispatcher($dispatcher);
+
+        (new MenuBoardProviderListener(
+            $c->get('menuBoardCategoryFactory')
         ))
             ->useLogger($c->get('logger'))
             ->registerWithDispatcher($dispatcher);

--- a/lib/Middleware/Theme.php
+++ b/lib/Middleware/Theme.php
@@ -36,7 +36,6 @@ use Xibo\Helper\ByteFormatter;
 use Xibo\Helper\DateFormatHelper;
 use Xibo\Helper\Environment;
 use Xibo\Helper\Translate;
-use Xibo\Support\Exception\NotFoundException;
 
 /**
  * Class Theme
@@ -135,15 +134,6 @@ class Theme implements Middleware
             && isset($samlSettings['workflow']['slo'])
             && $samlSettings['workflow']['slo'] == false) {
             $view['hideLogout'] = true;
-        }
-
-        // Disable menu boards if the module isn't installed
-        try {
-            $menuBoard = $container->get('moduleFactory')->getByType('menuboard');
-            $view['hideMenuBoard'] = !$menuBoard->enabled;
-        } catch (NotFoundException $notFoundException) {
-            // Disable
-            $view['hideMenuBoard'] = true;
         }
     }
 }

--- a/lib/Widget/DataType/Product.php
+++ b/lib/Widget/DataType/Product.php
@@ -1,0 +1,67 @@
+<?php
+/*
+ * Copyright (C) 2023 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Xibo\Widget\DataType;
+
+use Xibo\Widget\Definition\DataType;
+
+/**
+ * Product DataType (primarily used for the Menu Board component)
+ */
+class Product implements \JsonSerializable, DataTypeInterface
+{
+    public $name;
+    public $price;
+    public $description;
+    public $availability;
+    public $allergyInfo;
+    public $mediaId;
+    public $productOptions;
+
+    public function getDefinition(): DataType
+    {
+        $dataType = new DataType();
+        $dataType->id = 'Product';
+        $dataType->name = __('Proudct');
+        $dataType->addField('name', 'Name', 'string');
+        $dataType->addField('price', 'Price', 'string');
+        $dataType->addField('description', 'Description', 'string');
+        $dataType->addField('availability', 'Availability', 'int');
+        $dataType->addField('allergyInfo', 'allergyInfo', 'string');
+        $dataType->addField('mediaId', 'mediaId', 'int');
+        $dataType->addField('productOptions', 'productOptions', 'array');
+        return $dataType;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'name' => $this->name,
+            'price' => $this->price,
+            'description' => $this->description,
+            'availability' => $this->availability,
+            'allergyInfo' => $this->allergyInfo,
+            'mediaId' => $this->mediaId,
+            'productOptions' => $this->productOptions,
+        ];
+    }
+}

--- a/lib/Widget/DataType/Product.php
+++ b/lib/Widget/DataType/Product.php
@@ -34,6 +34,7 @@ class Product implements \JsonSerializable, DataTypeInterface
     public $description;
     public $availability;
     public $allergyInfo;
+    public $calories;
     public $image;
     public $productOptions;
 
@@ -41,14 +42,15 @@ class Product implements \JsonSerializable, DataTypeInterface
     {
         $dataType = new DataType();
         $dataType->id = 'product';
-        $dataType->name = __('Proudct');
-        $dataType->addField('name', 'Name', 'string');
-        $dataType->addField('price', 'Price', 'string');
-        $dataType->addField('description', 'Description', 'string');
-        $dataType->addField('availability', 'Availability', 'int');
-        $dataType->addField('allergyInfo', 'allergyInfo', 'string');
-        $dataType->addField('image', 'image', 'int');
-        $dataType->addField('productOptions', 'productOptions', 'array');
+        $dataType->name = __('Product');
+        $dataType->addField('name', __('Name'), 'string');
+        $dataType->addField('price', __('Price'), 'decimal');
+        $dataType->addField('description', __('Description'), 'string');
+        $dataType->addField('availability', __('Availability'), 'int');
+        $dataType->addField('allergyInfo', __('Allergy Information'), 'string');
+        $dataType->addField('calories', __('Calories'), 'string');
+        $dataType->addField('image', __('Image'), 'int');
+        $dataType->addField('productOptions', __('Product Options'), 'array');
         return $dataType;
     }
 

--- a/lib/Widget/DataType/ProductCategory.php
+++ b/lib/Widget/DataType/ProductCategory.php
@@ -38,9 +38,9 @@ class ProductCategory implements \JsonSerializable, DataTypeInterface
         $dataType = new DataType();
         $dataType->id = 'product-category';
         $dataType->name = __('Product Category');
-        $dataType->addField('name', 'Name', 'string');
-        $dataType->addField('description', 'Description', 'string');
-        $dataType->addField('image', 'image', 'int');
+        $dataType->addField('name', __('Name'), 'string');
+        $dataType->addField('description', __('Description'), 'string');
+        $dataType->addField('image', __('Image'), 'int');
         return $dataType;
     }
 

--- a/lib/Widget/DataType/ProductCategory.php
+++ b/lib/Widget/DataType/ProductCategory.php
@@ -25,30 +25,22 @@ namespace Xibo\Widget\DataType;
 use Xibo\Widget\Definition\DataType;
 
 /**
- * Product DataType (primarily used for the Menu Board component)
+ * Product Category (primarily used for the Menu Board component)
  */
-class Product implements \JsonSerializable, DataTypeInterface
+class ProductCategory implements \JsonSerializable, DataTypeInterface
 {
     public $name;
-    public $price;
     public $description;
-    public $availability;
-    public $allergyInfo;
     public $image;
-    public $productOptions;
 
     public function getDefinition(): DataType
     {
         $dataType = new DataType();
-        $dataType->id = 'product';
-        $dataType->name = __('Proudct');
+        $dataType->id = 'product-category';
+        $dataType->name = __('Product Category');
         $dataType->addField('name', 'Name', 'string');
-        $dataType->addField('price', 'Price', 'string');
         $dataType->addField('description', 'Description', 'string');
-        $dataType->addField('availability', 'Availability', 'int');
-        $dataType->addField('allergyInfo', 'allergyInfo', 'string');
         $dataType->addField('image', 'image', 'int');
-        $dataType->addField('productOptions', 'productOptions', 'array');
         return $dataType;
     }
 
@@ -56,12 +48,8 @@ class Product implements \JsonSerializable, DataTypeInterface
     {
         return [
             'name' => $this->name,
-            'price' => $this->price,
             'description' => $this->description,
-            'availability' => $this->availability,
-            'allergyInfo' => $this->allergyInfo,
             'image' => $this->image,
-            'productOptions' => $this->productOptions,
         ];
     }
 }

--- a/lib/Widget/MenuBoardCategoryProvider.php
+++ b/lib/Widget/MenuBoardCategoryProvider.php
@@ -1,0 +1,60 @@
+<?php
+/*
+ * Copyright (C) 2023 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Xibo\Widget;
+
+use Carbon\Carbon;
+use Xibo\Event\MenuBoardCategoryRequest;
+use Xibo\Widget\Provider\DataProviderInterface;
+use Xibo\Widget\Provider\DurationProviderInterface;
+use Xibo\Widget\Provider\WidgetProviderInterface;
+use Xibo\Widget\Provider\WidgetProviderTrait;
+
+/**
+ * Menu Board Category Provider
+ */
+class MenuBoardCategoryProvider implements WidgetProviderInterface
+{
+    use WidgetProviderTrait;
+
+    public function fetchData(DataProviderInterface $dataProvider): WidgetProviderInterface
+    {
+        $this->getLog()->debug('fetchData: MenuBoardCategoryRequest passing to event');
+        $this->getDispatcher()->dispatch(new MenuBoardCategoryRequest($dataProvider), MenuBoardCategoryRequest::$NAME);
+        return $this;
+    }
+
+    public function fetchDuration(DurationProviderInterface $durationProvider): WidgetProviderInterface
+    {
+        return $this;
+    }
+
+    public function getDataCacheKey(DataProviderInterface $dataProvider): ?string
+    {
+        return null;
+    }
+
+    public function getDataModifiedDt(DataProviderInterface $dataProvider): ?Carbon
+    {
+        return null;
+    }
+}

--- a/lib/Widget/MenuBoardProductProvider.php
+++ b/lib/Widget/MenuBoardProductProvider.php
@@ -1,0 +1,60 @@
+<?php
+/*
+ * Copyright (C) 2023 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Xibo\Widget;
+
+use Carbon\Carbon;
+use Xibo\Event\MenuBoardProductRequest;
+use Xibo\Widget\Provider\DataProviderInterface;
+use Xibo\Widget\Provider\DurationProviderInterface;
+use Xibo\Widget\Provider\WidgetProviderInterface;
+use Xibo\Widget\Provider\WidgetProviderTrait;
+
+/**
+ * Menu Board Product Provider
+ */
+class MenuBoardProductProvider implements WidgetProviderInterface
+{
+    use WidgetProviderTrait;
+
+    public function fetchData(DataProviderInterface $dataProvider): WidgetProviderInterface
+    {
+        $this->getLog()->debug('fetchData: MenuBoardProductProvider passing to event');
+        $this->getDispatcher()->dispatch(new MenuBoardProductRequest($dataProvider), MenuBoardProductRequest::$NAME);
+        return $this;
+    }
+
+    public function fetchDuration(DurationProviderInterface $durationProvider): WidgetProviderInterface
+    {
+        return $this;
+    }
+
+    public function getDataCacheKey(DataProviderInterface $dataProvider): ?string
+    {
+        return null;
+    }
+
+    public function getDataModifiedDt(DataProviderInterface $dataProvider): ?Carbon
+    {
+        return null;
+    }
+}

--- a/lib/routes-web.php
+++ b/lib/routes-web.php
@@ -730,7 +730,7 @@ $app->group('', function (\Slim\Routing\RouteCollectorProxy $group) {
     $group->get('/menuboard/{id}/product/form/add', ['\Xibo\Controller\MenuBoardProduct', 'addForm'])->setName('menuBoard.product.add.form');
     $group->get('/menuboard/{id}/product/form/edit', ['\Xibo\Controller\MenuBoardProduct', 'editForm'])->setName('menuBoard.product.edit.form');
     $group->get('/menuboard/{id}/product/form/delete', ['\Xibo\Controller\MenuBoardProduct', 'deleteForm'])->setName('menuBoard.product.delete.form');
-})->addMiddleware(new FeatureAuth($app->getContainer(), ['menuBoard.view']));
+})->addMiddleware(new FeatureAuth($app->getContainer(), ['menuboard.view']));
 
 $app->group('', function (RouteCollectorProxy $group) {
     $group->get('/folders/form/{folderId}/move', ['\Xibo\Controller\Folder', 'moveForm'])->setName('folders.move.form');

--- a/lib/routes-web.php
+++ b/lib/routes-web.php
@@ -730,7 +730,7 @@ $app->group('', function (\Slim\Routing\RouteCollectorProxy $group) {
     $group->get('/menuboard/{id}/product/form/add', ['\Xibo\Controller\MenuBoardProduct', 'addForm'])->setName('menuBoard.product.add.form');
     $group->get('/menuboard/{id}/product/form/edit', ['\Xibo\Controller\MenuBoardProduct', 'editForm'])->setName('menuBoard.product.edit.form');
     $group->get('/menuboard/{id}/product/form/delete', ['\Xibo\Controller\MenuBoardProduct', 'deleteForm'])->setName('menuBoard.product.delete.form');
-})->addMiddleware(new FeatureAuth($app->getContainer(), ['menuboard.view']));
+})->addMiddleware(new FeatureAuth($app->getContainer(), ['menuBoard.view']));
 
 $app->group('', function (RouteCollectorProxy $group) {
     $group->get('/folders/form/{folderId}/move', ['\Xibo\Controller\Folder', 'moveForm'])->setName('folders.move.form');

--- a/modules/forecastio.xml
+++ b/modules/forecastio.xml
@@ -155,12 +155,13 @@ $content.empty();
 
 // Get current day (main) template and clone its contents
 var currentContainerHTML = $(target).find('.current-day-template').html();
+if (currentContainerHTML) {
+    // Make replacements [] with current day data
+    currentContainerHTML = makeReplacement(currentContainerHTML, items[0]);
 
-// Make replacements [] with current day data
-currentContainerHTML = makeReplacement(currentContainerHTML, items[0]);
-
-// Add current day (main) template to content container
-$content.append(currentContainerHTML);
+    // Add current day (main) template to content container
+    $content.append(currentContainerHTML);
+}
 
 // Make replacements if we have bg-div
 var bgDivHTML = $(target).find('.bg-div').prop('outerHTML');

--- a/modules/menuboard-category.xml
+++ b/modules/menuboard-category.xml
@@ -1,0 +1,47 @@
+<!--
+  ~ Copyright (C) 2023 Xibo Signage Ltd
+  ~
+  ~ Xibo - Digital Signage - https://xibosignage.com
+  ~
+  ~ This file is part of Xibo.
+  ~
+  ~ Xibo is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ any later version.
+  ~
+  ~ Xibo is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<module>
+    <id>core-menuboard-category</id>
+    <name>Menu Board: Category</name>
+    <author>Core</author>
+    <description>Display categories from a Menu Board</description>
+    <class>\Xibo\Widget\MenuBoardCategoryProvider</class>
+    <dataCacheKey>%menuId%</dataCacheKey>
+    <type>menuboard-category</type>
+    <dataType>product-category</dataType>
+    <schemaVersion>1</schemaVersion>
+    <assignable>1</assignable>
+    <regionSpecific>1</regionSpecific>
+    <renderAs>html</renderAs>
+    <defaultDuration>60</defaultDuration>
+    <settings></settings>
+    <properties>
+        <property id="menuId" type="number">
+            <title>Menu</title>
+            <helpText>Please select the Menu to use as a source of data for this template.</helpText>
+        </property>
+        <property id="categoryId" type="number">
+            <title>Category</title>
+            <helpText>Please select the Category to use as a source of data for this template.</helpText>
+        </property>
+    </properties>
+    <preview></preview>
+</module>

--- a/modules/menuboard-category.xml
+++ b/modules/menuboard-category.xml
@@ -37,10 +37,21 @@
         <property id="menuId" type="number">
             <title>Menu</title>
             <helpText>Please select the Menu to use as a source of data for this template.</helpText>
+            <rule>
+                <test type="and">
+                    <condition type="required"></condition>
+                    <condition type="uri"></condition>
+                </test>
+            </rule>
         </property>
         <property id="categoryId" type="number">
             <title>Category</title>
             <helpText>Please select the Category to use as a source of data for this template.</helpText>
+            <visibility>
+                <test>
+                    <condition field="menuId" type="neq"></condition>
+                </test>
+            </visibility>
         </property>
     </properties>
     <preview></preview>

--- a/modules/menuboard-product.xml
+++ b/modules/menuboard-product.xml
@@ -1,0 +1,43 @@
+<!--
+  ~ Copyright (C) 2023 Xibo Signage Ltd
+  ~
+  ~ Xibo - Digital Signage - https://xibosignage.com
+  ~
+  ~ This file is part of Xibo.
+  ~
+  ~ Xibo is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ any later version.
+  ~
+  ~ Xibo is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<module>
+    <id>core-menuboard-product</id>
+    <name>Menu Board: Products</name>
+    <author>Core</author>
+    <description>Display products from a Menu Board</description>
+    <class>\Xibo\Widget\MenuBoardProductProvider</class>
+    <dataCacheKey>%menuId%</dataCacheKey>
+    <type>menuboard-product</type>
+    <dataType>product</dataType>
+    <schemaVersion>1</schemaVersion>
+    <assignable>1</assignable>
+    <regionSpecific>1</regionSpecific>
+    <renderAs>html</renderAs>
+    <defaultDuration>60</defaultDuration>
+    <settings></settings>
+    <properties>
+        <property id="menuId" type="number">
+            <title>Menu</title>
+            <helpText>Please select the Menu to use as a source of data for this template.</helpText>
+        </property>
+    </properties>
+    <preview></preview>
+</module>

--- a/modules/menuboard-product.xml
+++ b/modules/menuboard-product.xml
@@ -24,7 +24,7 @@
     <author>Core</author>
     <description>Display products from a Menu Board</description>
     <class>\Xibo\Widget\MenuBoardProductProvider</class>
-    <dataCacheKey>%menuId%</dataCacheKey>
+    <dataCacheKey>%menuId%_%showUnavailable%</dataCacheKey>
     <type>menuboard-product</type>
     <dataType>product</dataType>
     <schemaVersion>1</schemaVersion>
@@ -37,6 +37,30 @@
         <property id="menuId" type="number">
             <title>Menu</title>
             <helpText>Please select the Menu to use as a source of data for this template.</helpText>
+        </property>
+        <property id="categoryId" type="number">
+            <title>Category</title>
+            <helpText>Filter by Category</helpText>
+            <visibility>
+                <test>
+                    <condition field="menuId" type="neq"></condition>
+                </test>
+            </visibility>
+        </property>
+        <property id="showUnavailable" type="checkbox">
+            <title>Show Unavailable Products?</title>
+            <helpText>Should the currently unavailable products appear in the menu?</helpText>
+            <default>0</default>
+        </property>
+        <property id="durationIsPerItem" type="checkbox">
+            <title>Duration is per item</title>
+            <helpText>The duration specified is per item otherwise it is per menu.</helpText>
+            <default>0</default>
+            <visibility>
+                <test>
+                    <condition field="dataSetId" type="neq"></condition>
+                </test>
+            </visibility>
         </property>
     </properties>
     <preview></preview>

--- a/modules/menuboard-product.xml
+++ b/modules/menuboard-product.xml
@@ -24,7 +24,7 @@
     <author>Core</author>
     <description>Display products from a Menu Board</description>
     <class>\Xibo\Widget\MenuBoardProductProvider</class>
-    <dataCacheKey>%menuId%_%showUnavailable%</dataCacheKey>
+    <dataCacheKey>%menuId%_%showUnavailable%_%sortField%_%sortDescending%_%lowerLimit%_%upperLimit%</dataCacheKey>
     <type>menuboard-product</type>
     <dataType>product</dataType>
     <schemaVersion>1</schemaVersion>
@@ -47,11 +47,6 @@
                 </test>
             </visibility>
         </property>
-        <property id="showUnavailable" type="checkbox">
-            <title>Show Unavailable Products?</title>
-            <helpText>Should the currently unavailable products appear in the menu?</helpText>
-            <default>0</default>
-        </property>
         <property id="durationIsPerItem" type="checkbox">
             <title>Duration is per item</title>
             <helpText>The duration specified is per item otherwise it is per menu.</helpText>
@@ -61,6 +56,52 @@
                     <condition field="dataSetId" type="neq"></condition>
                 </test>
             </visibility>
+        </property>
+        <property id="sortField" type="dropdown" mode="single">
+            <title>Sort by</title>
+            <helpText>How should we sort the menu items?</helpText>
+            <default>displayOrder</default>
+            <options>
+                <option name="displayOrder">Display Order</option>
+                <option name="name">Name</option>
+                <option name="price">Price</option>
+                <option name="id">ID</option>
+            </options>
+        </property>
+        <property id="sortDescending" type="checkbox">
+            <title>Sort descending?</title>
+            <default>0</default>
+        </property>
+        <property id="showUnavailable" type="checkbox">
+            <title>Show Unavailable Products?</title>
+            <helpText>Should the currently unavailable products appear in the menu?</helpText>
+            <default>0</default>
+        </property>
+        <property type="message">
+            <title>Row limits can be used to return a subset of menu items. For example if you wanted the 10th to the 20th item you could put 10 and 20.</title>
+        </property>
+        <property id="lowerLimit" type="number">
+            <title>Lower Row Limit</title>
+            <helpText>Optionally provide a Lower Row Limit (enter 0 for no limit).</helpText>
+            <default>0</default>
+            <rule>
+                <test message="Lower limit must be 0 or above">
+                    <condition type="gte">0</condition>
+                </test>
+                <test message="Lower limit must be lower than the upper limit">
+                    <condition field="upperLimit" type="lte"></condition>
+                </test>
+            </rule>
+        </property>
+        <property id="upperLimit" type="number">
+            <title>Upper Row Limit</title>
+            <helpText>Optionally provide an Upper Row Limit (enter 0 for no limit).</helpText>
+            <default>0</default>
+            <rule>
+                <test message="Upper limit must be 0 or above">
+                    <condition type="gte">0</condition>
+                </test>
+            </rule>
         </property>
     </properties>
     <preview></preview>

--- a/modules/src/player.js
+++ b/modules/src/player.js
@@ -533,6 +533,7 @@ $(function() {
                           if (onElementParseData) {
                             item[dataOverride] = onElementParseData(
                               item[extendDataWith],
+                              templateData,
                             );
                           }
                         }

--- a/modules/templates/product-category-elements.xml
+++ b/modules/templates/product-category-elements.xml
@@ -1,0 +1,37 @@
+<!--
+  ~ Copyright (C) 2023 Xibo Signage Ltd
+  ~
+  ~ Xibo - Digital Signage - https://xibosignage.com
+  ~
+  ~ This file is part of Xibo.
+  ~
+  ~ Xibo is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ any later version.
+  ~
+  ~ Xibo is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<templates>
+    <template>
+        <id>product_category_name</id>
+        <extends override="text" with="data.name">text</extends>
+        <title>Name</title>
+        <type>element</type>
+        <dataType>product-category</dataType>
+        <canRotate>true</canRotate>
+        <thumbnail>product-category-name</thumbnail>
+        <startWidth>500</startWidth>
+        <startHeight>100</startHeight>
+        <assets>
+            <!-- To replace -->
+            <asset id="product-category-name" type="path" cmsOnly="true" mimeType="image/png" path="/modules/assets/template-thumbnails/article/elements/article-title.png" />
+        </assets>
+    </template>
+</templates>

--- a/modules/templates/product-elements.xml
+++ b/modules/templates/product-elements.xml
@@ -18,7 +18,6 @@
   ~ You should have received a copy of the GNU Affero General Public License
   ~ along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
   -->
-
 <templates>
     <template>
         <id>product_name</id>
@@ -27,13 +26,15 @@
         <type>element</type>
         <dataType>product</dataType>
         <canRotate>true</canRotate>
-        <thumbnail>product-name</thumbnail>
         <startWidth>500</startWidth>
         <startHeight>100</startHeight>
-        <assets>
-            <!-- To replace -->
-            <asset id="product-name" type="path" cmsOnly="true" mimeType="image/png" path="/modules/assets/template-thumbnails/article/elements/article-title.png" />
-        </assets>
+        <properties>
+            <property id="effect" type="effectSelector" variant="all">
+                <title>Effect</title>
+                <helpText>Please select the effect that will be used to transition between items.</helpText>
+                <default>noTransition</default>
+            </property>
+        </properties>
     </template>
     <template>
         <id>product_price</id>
@@ -45,6 +46,11 @@
         <startWidth>500</startWidth>
         <startHeight>100</startHeight>
         <properties>
+            <property id="currencyCode" type="text">
+                <title>Currency Code</title>
+                <helpText>The 3 digit currency code to apply to the price, e.g. USD/GBP/EUR</helpText>
+                <default></default>
+            </property>
             <property id="prefix" type="text">
                 <title>Prefix</title>
                 <default></default>
@@ -52,6 +58,11 @@
             <property id="suffix" type="text">
                 <title>Suffix</title>
                 <default></default>
+            </property>
+            <property id="effect" type="effectSelector" variant="all">
+                <title>Effect</title>
+                <helpText>Please select the effect that will be used to transition between items.</helpText>
+                <default>noTransition</default>
             </property>
         </properties>
         <onElementParseData><![CDATA[
@@ -61,7 +72,13 @@ if (String(value).length === 0) {
     return '';
 }
 
-value = Intl.NumberFormat().format(value);
+var options = {};
+if (properties.currencyCode && properties.currencyCode !== '') {
+    options.style = 'currency';
+    options.currency = properties.currencyCode;
+}
+
+value = new Intl.NumberFormat(undefined, options).format(value);
 
 if (properties.prefix && properties.prefix !== '') {
     value = properties.prefix + '' + value;

--- a/modules/templates/product-elements.xml
+++ b/modules/templates/product-elements.xml
@@ -35,4 +35,43 @@
             <asset id="product-name" type="path" cmsOnly="true" mimeType="image/png" path="/modules/assets/template-thumbnails/article/elements/article-title.png" />
         </assets>
     </template>
+    <template>
+        <id>product_price</id>
+        <extends override="text" with="data.price">text</extends>
+        <title>Price</title>
+        <type>element</type>
+        <dataType>product</dataType>
+        <canRotate>true</canRotate>
+        <startWidth>500</startWidth>
+        <startHeight>100</startHeight>
+        <properties>
+            <property id="prefix" type="text">
+                <title>Prefix</title>
+                <default></default>
+            </property>
+            <property id="suffix" type="text">
+                <title>Suffix</title>
+                <default></default>
+            </property>
+        </properties>
+        <onElementParseData><![CDATA[
+// value - element to be parsed
+// properties
+if (String(value).length === 0) {
+    return '';
+}
+
+value = Intl.NumberFormat().format(value);
+
+if (properties.prefix && properties.prefix !== '') {
+    value = properties.prefix + '' + value;
+}
+
+if (properties.suffix && properties.suffix !== '') {
+    value = value + '' + properties.suffix;
+}
+
+return value;
+        ]]></onElementParseData>
+    </template>
 </templates>

--- a/modules/templates/product-elements.xml
+++ b/modules/templates/product-elements.xml
@@ -1,0 +1,38 @@
+<!--
+  ~ Copyright (C) 2023 Xibo Signage Ltd
+  ~
+  ~ Xibo - Digital Signage - https://xibosignage.com
+  ~
+  ~ This file is part of Xibo.
+  ~
+  ~ Xibo is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU Affero General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ any later version.
+  ~
+  ~ Xibo is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU Affero General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Affero General Public License
+  ~ along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<templates>
+    <template>
+        <id>product_name</id>
+        <extends override="text" with="data.name">text</extends>
+        <title>Name</title>
+        <type>element</type>
+        <dataType>product</dataType>
+        <canRotate>true</canRotate>
+        <thumbnail>product-name</thumbnail>
+        <startWidth>500</startWidth>
+        <startHeight>100</startHeight>
+        <assets>
+            <!-- To replace -->
+            <asset id="product-name" type="path" cmsOnly="true" mimeType="image/png" path="/modules/assets/template-thumbnails/article/elements/article-title.png" />
+        </assets>
+    </template>
+</templates>

--- a/modules/widget-html-render.twig
+++ b/modules/widget-html-render.twig
@@ -138,7 +138,7 @@
 {% endfor %}
 {% for templateId, parser in onElementParseData %}
     <script type="text/javascript" id="onElementParseData-{{ templateId }}">
-      function onElementParseData_{{ templateId }}(value) {
+      function onElementParseData_{{ templateId }}(value, properties) {
           {{ parser|raw  }}
       }
     </script>

--- a/ui/src/style/common.scss
+++ b/ui/src/style/common.scss
@@ -1,3 +1,24 @@
+/*!
+ * Copyright (C) 2023 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 // Imports
 @import "mixins";
 @import "variables";
@@ -42,7 +63,7 @@ $fa-font-path: "~font-awesome/fonts";
         @include border-radius(0);
         border: 1px solid $xibo-color-neutral-100 !important;
         padding: 5px 7px;
-    
+
         &:hover {
             color: $xibo-color-neutral-100;
             background-color: $xibo-color-primary !important;
@@ -370,6 +391,14 @@ $fa-font-path: "~font-awesome/fonts";
 
 .module-icon-zone {
     @extend .fas, .fa-border-none;
+}
+
+.module-icon-menuboard-product {
+    @extend .fa, .fa-hamburger;
+}
+
+.module-icon-menuboard-category {
+    @extend .fa, .fa-list-alt;
 }
 
 

--- a/ui/src/templates/viewer-element-content.hbs
+++ b/ui/src/templates/viewer-element-content.hbs
@@ -26,7 +26,7 @@
     {{/if}}
     {{#if onElementParseData}}
         <script type="text/javascript">
-            function onElementParseData_{{ ../element.id }}(value) {
+            function onElementParseData_{{ ../element.id }}(value, properties) {
                 {{{onElementParseData}}}
             }
         </script>

--- a/views/authed-sidebar.twig
+++ b/views/authed-sidebar.twig
@@ -45,7 +45,7 @@
                 <li class="sidebar-list"><a href="{{ url_for("dataset.view") }}">{% trans "DataSets" %}</a></li>
             {% endif %}
 
-            {% if currentUser.featureEnabled("menuboard.view") and not hideMenuBoard %}
+            {% if currentUser.featureEnabled("menuboard.view") %}
                 <li class="sidebar-list"><a href="{{ url_for("menuBoard.view") }}">{% trans "Menu Boards" %}</a></li>
             {% endif %}
         {% endif %}

--- a/views/authed-sidebar.twig
+++ b/views/authed-sidebar.twig
@@ -30,7 +30,7 @@
             {% endif %}
         {% endif %}
 
-        {% set countViewable = currentUser.featureEnabledCount(["library.view", "playlist.view", "dataset.view", "menuboard.view"]) %}
+        {% set countViewable = currentUser.featureEnabledCount(["library.view", "playlist.view", "dataset.view", "menuBoard.view"]) %}
         {% if countViewable > 0 %}
             <li class="sidebar-title"><a>{% trans "Library" %}</a></li>
             {% if currentUser.featureEnabled("playlist.view") %}
@@ -45,7 +45,7 @@
                 <li class="sidebar-list"><a href="{{ url_for("dataset.view") }}">{% trans "DataSets" %}</a></li>
             {% endif %}
 
-            {% if currentUser.featureEnabled("menuboard.view") %}
+            {% if currentUser.featureEnabled("menuBoard.view") %}
                 <li class="sidebar-list"><a href="{{ url_for("menuBoard.view") }}">{% trans "Menu Boards" %}</a></li>
             {% endif %}
         {% endif %}

--- a/views/authed-topbar.twig
+++ b/views/authed-topbar.twig
@@ -76,7 +76,7 @@
         </li>
     {% endif %}
 
-    {% set countViewable = currentUser.featureEnabledCount(["library.view", "playlist.view", "dataset.view", "menuboard.view"]) %}
+    {% set countViewable = currentUser.featureEnabledCount(["library.view", "playlist.view", "dataset.view", "menuBoard.view"]) %}
     {% set groupElementClass = (countViewable > 1) ? 'dropdown-item' : 'nav-link' %}
     {% if countViewable > 0 %}
         {% if countViewable > 1 %}
@@ -98,7 +98,7 @@
                 <a class="{{ groupElementClass }}" href="{{ url_for("dataset.view") }}">{% trans "DataSets" %}</a>
             {% endif %}
 
-            {% if currentUser.featureEnabled("menuboard.view") and not hideMenuBoard %}
+            {% if currentUser.featureEnabled("menuBoard.view") %}
                 <a class="{{ groupElementClass }}" href="{{ url_for("menuBoard.view") }}">{% trans "Menu Boards" %}</a>
             {% endif %}
         {% if countViewable > 1 %}

--- a/views/menuboard-category-form-add.twig
+++ b/views/menuboard-category-form-add.twig
@@ -44,6 +44,10 @@
                 {% set helpText %}{% trans "The Name for this Menu Board Category" %}{% endset %}
                 {{ forms.input("name", title, "", helpText) }}
 
+                {% set title %}{% trans "Description" %}{% endset %}
+                {% set helpText %}{% trans "The description for this Menu Board Category" %}{% endset %}
+                {{ forms.input("description", title, "", helpText) }}
+
                 {% set title %}{% trans "Code" %}{% endset %}
                 {% set helpText %}{% trans "The Code identifier for this Menu Board Category" %}{% endset %}
                 {{ forms.input("code", title, "", helpText) }}

--- a/views/menuboard-category-form-edit.twig
+++ b/views/menuboard-category-form-edit.twig
@@ -43,6 +43,10 @@
                 {% set helpText %}{% trans "The Name for this Menu Board Category" %}{% endset %}
                 {{ forms.input("name", title, menuBoardCategory.name, helpText) }}
 
+                {% set title %}{% trans "Description" %}{% endset %}
+                {% set helpText %}{% trans "The description for this Menu Board Category" %}{% endset %}
+                {{ forms.input("description", title, menuBoardCategory.description, helpText) }}
+
                 {% set title %}{% trans "Code" %}{% endset %}
                 {% set helpText %}{% trans "The Code identifier for this Menu Board Category" %}{% endset %}
                 {{ forms.input("code", title, menuBoardCategory.code, helpText) }}

--- a/views/menuboard-category-page.twig
+++ b/views/menuboard-category-page.twig
@@ -100,8 +100,9 @@
                           }
 
                           if (row.thumbnail && row.thumbnail !== '') {
-                            return '<a class="img-replace" data-toggle="lightbox" data-type="image" href="' +
-                              row.thumbnail + '>' + '<img src="' + row.thumbnail + '&isThumb=1" />';
+                            return '<a class="img-replace" data-toggle="lightbox" data-type="image"' +
+                              ' href="' + row.thumbnail + '">' +
+                              '<img src="' + row.thumbnail + '&isThumb=1" alt="Thumbnail" />';
                           } else {
                             return '';
                           }

--- a/views/menuboard-category-page.twig
+++ b/views/menuboard-category-page.twig
@@ -47,6 +47,7 @@
                             <th>{% trans "Name" %}</th>
                             <th>{% trans "Media" %}</th>
                             <th>{% trans "Code" %}</th>
+                            <th>{% trans "Description" %}</th>
                             <th class="rowMenu"></th>
                         </tr>
                         </thead>
@@ -108,6 +109,10 @@
                     },
                     {
                         "data": "code", responsivePriority: 3
+                    },
+                    {
+                      data: 'description',
+                      responsivePriority: 3,
                     },
                     {
                         "orderable": false,

--- a/views/menuboard-category-page.twig
+++ b/views/menuboard-category-page.twig
@@ -91,10 +91,20 @@
                         "render": dataTableSpacingPreformatted
                     },
                     {
-                        "name": "mediaId",
                         responsivePriority: 3,
-                        "data": null,
-                        "render": {"_": "thumbnail", "display": "thumbnail", "sort": "mediaId"}
+                        data: 'mediaId',
+                        render: function (data, type, row) {
+                          if (type !== 'display' || data === null || data === '') {
+                            return data;
+                          }
+
+                          if (row.thumbnail && row.thumbnail !== '') {
+                            return '<a class="img-replace" data-toggle="lightbox" data-type="image" href="' +
+                              row.thumbnail + '>' + '<img src="' + row.thumbnail + '&isThumb=1" />';
+                          } else {
+                            return '';
+                          }
+                        }
                     },
                     {
                         "data": "code", responsivePriority: 3

--- a/views/menuboard-form-add.twig
+++ b/views/menuboard-form-add.twig
@@ -49,9 +49,6 @@
                 {% endif %}
 
                 {% set title %}{% trans "Name" %}{% endset %}
-                {{ forms.message("This is a feature preview and should not be used in production"|trans, "alert alert-danger") }}
-
-                {% set title %}{% trans "Name" %}{% endset %}
                 {% set helpText %}{% trans "The Name for this Menu Board" %}{% endset %}
                 {{ forms.input("name", title, "", helpText) }}
 

--- a/views/menuboard-page.twig
+++ b/views/menuboard-page.twig
@@ -35,7 +35,7 @@
 
 {% block pageContent %}
     <div class="widget">
-        <div class="widget-title">{% trans "Menu Boards" %} | {{ "This is a feature preview and should not be used in production"|trans }}</div>
+        <div class="widget-title">{% trans "Menu Boards" %}</div>
         <div class="widget-body">
             <div class="XiboGrid" id="{{ random() }}" data-grid-type="menuBoard" data-grid-name="menuBoardView">
                 <div class="XiboFilter card mb-3 bg-light">

--- a/views/menuboard-product-form-add.twig
+++ b/views/menuboard-product-form-add.twig
@@ -64,8 +64,12 @@
                         {{ forms.input("allergyInfo", title, "", helpText) }}
 
                         {% set title %}{% trans "Calories" %}{% endset %}
-                        {% set helpText %}{% trans "How many calories are in this product>" %}{% endset %}
+                        {% set helpText %}{% trans "How many calories are in this product?" %}{% endset %}
                         {{ forms.input("calories", title, "", helpText) }}
+
+                        {% set title %}{% trans "Display Order" %}{% endset %}
+                        {% set helpText %}{% trans "Set a display order for this item to appear, leave empty to add to the end." %}{% endset %}
+                        {{ forms.number('displayOrder', title, null, helpText) }}
 
                         {% set title %}{% trans "Availability" %}{% endset %}
                         {% set helpText %}{% trans "Should this Product appear as available?" %}{% endset %}

--- a/views/menuboard-product-form-add.twig
+++ b/views/menuboard-product-form-add.twig
@@ -57,11 +57,15 @@
 
                         {% set title %}{% trans "Price" %}{% endset %}
                         {% set helpText %}{% trans "The Price for this Menu Board Product" %}{% endset %}
-                        {{ forms.input("price", title, "", helpText) }}
+                        {{ forms.number("price", title, "", helpText) }}
 
                         {% set title %}{% trans "Allergy Information" %}{% endset %}
                         {% set helpText %}{% trans "The Allergy Information for this Menu Board Product" %}{% endset %}
                         {{ forms.input("allergyInfo", title, "", helpText) }}
+
+                        {% set title %}{% trans "Calories" %}{% endset %}
+                        {% set helpText %}{% trans "How many calories are in this product>" %}{% endset %}
+                        {{ forms.input("calories", title, "", helpText) }}
 
                         {% set title %}{% trans "Availability" %}{% endset %}
                         {% set helpText %}{% trans "Should this Product appear as available?" %}{% endset %}

--- a/views/menuboard-product-form-add.twig
+++ b/views/menuboard-product-form-add.twig
@@ -65,7 +65,7 @@
 
                         {% set title %}{% trans "Availability" %}{% endset %}
                         {% set helpText %}{% trans "Should this Product appear as available?" %}{% endset %}
-                        {{ forms.switch('availability', title, "", helpText) }}
+                        {{ forms.switch('availability', title, 1, helpText) }}
 
                         {% set title %}{% trans "Code" %}{% endset %}
                         {% set helpText %}{% trans "The Code identifier for this Menu Board Product" %}{% endset %}

--- a/views/menuboard-product-form-edit.twig
+++ b/views/menuboard-product-form-edit.twig
@@ -64,8 +64,12 @@
                         {{ forms.input("allergyInfo", title, menuBoardProduct.allergyInfo, helpText) }}
 
                         {% set title %}{% trans "Calories" %}{% endset %}
-                        {% set helpText %}{% trans "How many calories are in this product>" %}{% endset %}
+                        {% set helpText %}{% trans "How many calories are in this product?" %}{% endset %}
                         {{ forms.input("calories", title, menuBoardProduct.calories, helpText) }}
+
+                        {% set title %}{% trans "Display Order" %}{% endset %}
+                        {% set helpText %}{% trans "Set a display order for this item to appear" %}{% endset %}
+                        {{ forms.number('displayOrder', title, menuBoardProduct.displayOrder, helpText) }}
 
                         {% set title %}{% trans "Availability" %}{% endset %}
                         {% set helpText %}{% trans "Should this Product appear as available?" %}{% endset %}

--- a/views/menuboard-product-form-edit.twig
+++ b/views/menuboard-product-form-edit.twig
@@ -57,11 +57,15 @@
 
                         {% set title %}{% trans "Price" %}{% endset %}
                         {% set helpText %}{% trans "The Price for this Menu Board Product" %}{% endset %}
-                        {{ forms.input("price", title, menuBoardProduct.price, helpText) }}
+                        {{ forms.number("price", title, menuBoardProduct.price, helpText) }}
 
                         {% set title %}{% trans "Allergy Information" %}{% endset %}
                         {% set helpText %}{% trans "The Allergy Information for this Menu Board Product" %}{% endset %}
                         {{ forms.input("allergyInfo", title, menuBoardProduct.allergyInfo, helpText) }}
+
+                        {% set title %}{% trans "Calories" %}{% endset %}
+                        {% set helpText %}{% trans "How many calories are in this product>" %}{% endset %}
+                        {{ forms.input("calories", title, menuBoardProduct.calories, helpText) }}
 
                         {% set title %}{% trans "Availability" %}{% endset %}
                         {% set helpText %}{% trans "Should this Product appear as available?" %}{% endset %}

--- a/views/menuboard-product-page.twig
+++ b/views/menuboard-product-page.twig
@@ -60,6 +60,7 @@
                             <th>{% trans "Media" %}</th>
                             <th>{% trans "Availability" %}</th>
                             <th>{% trans "Allergy Information" %}</th>
+                            <th>{% trans "Calories" %}</th>
                             <th>{% trans "Code" %}</th>
                             <th class="rowMenu"></th>
                         </tr>
@@ -147,6 +148,10 @@
                     },
                     {
                         "data": "allergyInfo",
+                        responsivePriority: 2
+                    },
+                    {
+                        data: 'calories',
                         responsivePriority: 2
                     },
                     {

--- a/views/menuboard-product-page.twig
+++ b/views/menuboard-product-page.twig
@@ -58,6 +58,7 @@
                             <th>{% trans "Description" %}</th>
                             <th>{% trans "Price" %}</th>
                             <th>{% trans "Media" %}</th>
+                            <th>{% trans "Display Order" %}</th>
                             <th>{% trans "Availability" %}</th>
                             <th>{% trans "Allergy Information" %}</th>
                             <th>{% trans "Calories" %}</th>
@@ -91,7 +92,7 @@
                 filter: false,
                 searchDelay: 3000,
                 dataType: 'json',
-                "order": [[1, "asc"]],
+                "order": [[5, "asc"]],
                 ajax: {
                     url: "{{ url_for("menuBoard.product.search", {id: menuBoardCategory.menuCategoryId}) }}",
                     "data": function (d) {
@@ -129,6 +130,10 @@
                             return '';
                           }
                         }
+                    },
+                    {
+                        data: 'displayOrder',
+                        responsivePriority: 2,
                     },
                     {
                         "data": "availability",

--- a/views/menuboard-product-page.twig
+++ b/views/menuboard-product-page.twig
@@ -113,10 +113,20 @@
                         responsivePriority: 2
                     },
                     {
-                        "name": "mediaId",
                         responsivePriority: 3,
-                        "data": null,
-                        "render": {"_": "thumbnail", "display": "thumbnail", "sort": "mediaId"}
+                        data: 'mediaId',
+                        render: function (data, type, row) {
+                          if (type !== 'display' || data === null || data === '') {
+                            return data;
+                          }
+
+                          if (row.thumbnail && row.thumbnail !== '') {
+                            return '<a class="img-replace" data-toggle="lightbox" data-type="image" href="' +
+                              row.thumbnail + '>' + '<img src="' + row.thumbnail + '&isThumb=1" />';
+                          } else {
+                            return '';
+                          }
+                        }
                     },
                     {
                         "data": "availability",

--- a/views/menuboard-product-page.twig
+++ b/views/menuboard-product-page.twig
@@ -122,8 +122,9 @@
                           }
 
                           if (row.thumbnail && row.thumbnail !== '') {
-                            return '<a class="img-replace" data-toggle="lightbox" data-type="image" href="' +
-                              row.thumbnail + '>' + '<img src="' + row.thumbnail + '&isThumb=1" />';
+                            return '<a class="img-replace" data-toggle="lightbox" data-type="image"' +
+                              ' href="' + row.thumbnail + '">' +
+                              '<img src="' + row.thumbnail + '&isThumb=1" alt="Thumbnail" />';
                           } else {
                             return '';
                           }


### PR DESCRIPTION
This PR is in preparation for adding more elements/stencils to the menu board functionality. In this PR I have:
 - re-enabled admin UI
 - fix feature checking
 - fix thumbnail columns/unmatched properties
 - add product data type
 - add menu board product widget
 - add calories, display order to product
 - add description to category
 - convert price to decimal
 - translate datatypes
 - install modules by default
 - add price element

Preview:
 - pass properties into `onElementParseData`

Weather:
 - fix issue with element rendering in preview