### PR TITLE
Widget: webpage modeid should be non camel case

### DIFF
--- a/modules/src/xibo-webpage-render.js
+++ b/modules/src/xibo-webpage-render.js
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2023 Xibo Signage Ltd
  *
- * Xibo - Digital Signage - http://www.xibo.org.uk
+ * Xibo - Digital Signage - https://xibosignage.com
  *
  * This file is part of Xibo.
  *
@@ -28,7 +28,7 @@ jQuery.fn.extend({
     // All we worry about is the item we have been working on ($(this))
     $(this).each(function(_idx, el) {
       // Mode
-      if (options.modeId == 1) {
+      if (options.modeid == 1) {
         // Open Natively
         // We shouldn't ever get here, because the
         // Layout Designer will not show a preview for mode 1, and
@@ -37,7 +37,7 @@ jQuery.fn.extend({
           width: options.originalWidth,
           height: options.originalHeight,
         });
-      } else if (options.modeId == 3) {
+      } else if (options.modeid == 3) {
         // Best fit, set the scale so that the web-page fits inside the region
 
         // If there is a preview width and height

--- a/modules/webpage.xml
+++ b/modules/webpage.xml
@@ -75,7 +75,7 @@
             <default></default>
             <visibility>
                 <test>
-                    <condition field="modeId" type="neq">1</condition>
+                    <condition field="modeid" type="neq">1</condition>
                 </test>
             </visibility>
         </property>
@@ -85,7 +85,7 @@
             <default></default>
             <visibility>
                 <test>
-                    <condition field="modeId" type="neq">1</condition>
+                    <condition field="modeid" type="neq">1</condition>
                 </test>
             </visibility>
         </property>
@@ -95,7 +95,7 @@
             <default></default>
             <visibility>
                 <test>
-                    <condition field="modeId" type="eq">2</condition>
+                    <condition field="modeid" type="eq">2</condition>
                 </test>
             </visibility>
         </property>
@@ -105,7 +105,7 @@
             <default></default>
             <visibility>
                 <test>
-                    <condition field="modeId" type="eq">2</condition>
+                    <condition field="modeid" type="eq">2</condition>
                 </test>
             </visibility>
         </property>
@@ -115,7 +115,7 @@
             <default></default>
             <visibility>
                 <test>
-                    <condition field="modeId" type="eq">2</condition>
+                    <condition field="modeid" type="eq">2</condition>
                 </test>
             </visibility>
         </property>
@@ -126,7 +126,7 @@
             <playerCompatibility android="v3 R303+" windows="v3 R302+" linux="TBC" webos="TBC" tizen="TBC">Fit supported from:</playerCompatibility>
             <visibility>
                 <test>
-                    <condition field="modeId" type="eq">1</condition>
+                    <condition field="modeid" type="eq">1</condition>
                 </test>
             </visibility>
         </property>

--- a/modules/webpage.xml
+++ b/modules/webpage.xml
@@ -54,7 +54,7 @@
             <helpText>Should this Widget be loaded entirely off screen so that it is ready when shown? Dynamic content will start running off screen.</helpText>
             <default></default>
         </property>
-        <property id="modeId" type="dropdown" mode="single">
+        <property id="modeid" type="dropdown" mode="single">
             <title>Options</title>
             <helpText>How should this web page be embedded?</helpText>
             <default>1</default>


### PR DESCRIPTION
In v3, although the form has `modeId`, the `setOption` is actually `modeId`, which means that all players have been looking for `modeid`.

fixes https://github.com/xibosignageltd/xibo-private/issues/382