### PR TITLE
Layout: renaming from inside the editor doesn't refresh the name

### DIFF
--- a/views/layout-designer-page.twig
+++ b/views/layout-designer-page.twig
@@ -378,7 +378,10 @@
             }
 
             function layoutEditFormSaved() {
-              lD.reloadData(lD.layout.layoutId, true);
+              lD.reloadData(lD.layout,
+                {
+                  refreshEditor: true,
+                });
             }
         </script>
 


### PR DESCRIPTION
relates to xibosignageltd/xibo-private#444