### PR TITLE
Various v4 fixes

### DIFF
--- a/lib/Controller/Display.php
+++ b/lib/Controller/Display.php
@@ -1949,6 +1949,12 @@ class Display extends Base
             throw new AccessDeniedException();
         }
 
+        if ($display->isLead()) {
+            throw new InvalidArgumentException(
+                __('Cannot delete a Lead Display of a Sync Group'),
+            );
+        }
+
         $display->delete();
 
         // Return

--- a/lib/Controller/Folder.php
+++ b/lib/Controller/Folder.php
@@ -334,11 +334,23 @@ class Folder extends Base
             throw new AccessDeniedException();
         }
 
+        if ($folder->isHome()) {
+            throw new InvalidArgumentException(
+                __('Cannot remove Folder set as home Folder for a user'),
+                'folderId',
+                __('Change home Folder for Users using this Folder before deleting')
+            );
+        }
+
         try {
             $folder->delete();
         } catch (\Exception $exception) {
             $this->getLog()->debug('Folder delete failed with message: ' . $exception->getMessage());
-            throw new InvalidArgumentException(__('Cannot remove Folder with content'), 'folderId', __('Reassign objects from this Folder before deleting.'));
+            throw new InvalidArgumentException(
+                __('Cannot remove Folder with content'),
+                'folderId',
+                __('Reassign objects from this Folder before deleting.')
+            );
         }
 
         // Return

--- a/lib/Controller/SyncGroup.php
+++ b/lib/Controller/SyncGroup.php
@@ -134,6 +134,7 @@ class SyncGroup extends Base
             'name' => $parsedQueryParams->getString('name'),
             'folderId' => $parsedQueryParams->getInt('folderId'),
             'ownerId' => $parsedQueryParams->getInt('ownerId'),
+            'leadDisplayId' => $parsedQueryParams->getInt('leadDisplayId')
         ];
 
         $syncGroups = $this->syncGroupFactory->query(

--- a/lib/Entity/Display.php
+++ b/lib/Entity/Display.php
@@ -1389,4 +1389,18 @@ class Display implements \JsonSerializable
 
         return $this;
     }
+
+    /**
+     * Check if this Display is set as Lead Display on any Sync Group
+     * @return bool
+     */
+    public function isLead(): bool
+    {
+        $syncGroups = $this->getStore()->select(
+            'SELECT syncGroupId FROM `syncgroup` WHERE `syncgroup`.leadDisplayId = :displayId',
+            ['displayId' => $this->displayId]
+        );
+
+        return count($syncGroups) > 0;
+    }
 }

--- a/lib/Entity/Folder.php
+++ b/lib/Entity/Folder.php
@@ -455,4 +455,17 @@ class Folder
 
         return $found;
     }
+
+    /**
+     * Check if this folder is used as Home Folder for any existing Users
+     * @return bool
+     */
+    public function isHome(): bool
+    {
+        $userIds = $this->getStore()->select('SELECT userId FROM `user` WHERE `user`.homeFolderId = :folderId', [
+            'folderId' => $this->id
+        ]);
+
+        return count($userIds) > 0;
+    }
 }

--- a/lib/Factory/SyncGroupFactory.php
+++ b/lib/Factory/SyncGroupFactory.php
@@ -193,6 +193,11 @@ class SyncGroupFactory extends BaseFactory
             $params['folderId'] = $parsedBody->getInt('folderId');
         }
 
+        if ($parsedBody->getInt('leadDisplayId') !== null) {
+            $body .= ' AND `syncgroup`.leadDisplayId = :leadDisplayId ';
+            $params['leadDisplayId'] = $parsedBody->getInt('leadDisplayId');
+        }
+
         // View Permissions
         $this->viewPermissionSql(
             'Xibo\Entity\SyncGroup',

--- a/lib/Helper/XiboUploadHandler.php
+++ b/lib/Helper/XiboUploadHandler.php
@@ -408,6 +408,13 @@ class XiboUploadHandler extends BlueImpUploadHandler
                 // Get the Playlist
                 $playlist = $controller->getPlaylistFactory()->getById($this->options['playlistId']);
 
+                if (!$playlist->isEditable()) {
+                    throw new InvalidArgumentException(
+                        __('This Layout is not a Draft, please checkout.'),
+                        'layoutId'
+                    );
+                }
+
                 // Create a Widget and add it to our region
                 $widget = $controller->getWidgetFactory()->create(
                     $this->options['userId'],

--- a/lib/Service/DisplayNotifyService.php
+++ b/lib/Service/DisplayNotifyService.php
@@ -279,7 +279,7 @@ class DisplayNotifyService implements DisplayNotifyServiceInterface
                ) campaigns
                ON campaigns.campaignId = `schedule`.campaignId
              WHERE (
-                  (`schedule`.FromDT < :toDt AND IFNULL(`schedule`.toDt, `schedule`.fromDt) > :fromDt) 
+                  (`schedule`.FromDT < :toDt AND IFNULL(`schedule`.toDt, UNIX_TIMESTAMP()) > :fromDt) 
                   OR `schedule`.recurrence_range >= :fromDt 
                   OR (
                     IFNULL(`schedule`.recurrence_range, 0) = 0 AND IFNULL(`schedule`.recurrence_type, \'\') <> \'\' 
@@ -436,7 +436,7 @@ class DisplayNotifyService implements DisplayNotifyServiceInterface
                     AND `widgetoption`.option = \'dataSetId\'
                     AND `widgetoption`.value = :activeDataSetId
             WHERE (
-               (schedule.FromDT < :toDt AND IFNULL(`schedule`.toDt, `schedule`.fromDt) > :fromDt) 
+               (schedule.FromDT < :toDt AND IFNULL(`schedule`.toDt, UNIX_TIMESTAMP()) > :fromDt) 
                   OR `schedule`.recurrence_range >= :fromDt 
                   OR (
                     IFNULL(`schedule`.recurrence_range, 0) = 0 AND IFNULL(`schedule`.recurrence_type, \'\') <> \'\' 
@@ -588,7 +588,7 @@ class DisplayNotifyService implements DisplayNotifyServiceInterface
                ON `playlist`.regionId = `region`.regionId
              WHERE `playlist`.playlistId = :playlistId
               AND (
-                  (schedule.FromDT < :toDt AND IFNULL(`schedule`.toDt, `schedule`.fromDt) > :fromDt) 
+                  (schedule.FromDT < :toDt AND IFNULL(`schedule`.toDt, UNIX_TIMESTAMP()) > :fromDt) 
                   OR `schedule`.recurrence_range >= :fromDt 
                   OR (
                     IFNULL(`schedule`.recurrence_range, 0) = 0 AND IFNULL(`schedule`.recurrence_type, \'\') <> \'\' 
@@ -741,7 +741,7 @@ class DisplayNotifyService implements DisplayNotifyServiceInterface
                ) campaigns
                ON campaigns.campaignId = `schedule`.campaignId
              WHERE (
-                  (`schedule`.FromDT < :toDt AND IFNULL(`schedule`.toDt, `schedule`.fromDt) > :fromDt) 
+                  (`schedule`.FromDT < :toDt AND IFNULL(`schedule`.toDt, UNIX_TIMESTAMP()) > :fromDt) 
                   OR `schedule`.recurrence_range >= :fromDt 
                   OR (
                     IFNULL(`schedule`.recurrence_range, 0) = 0 AND IFNULL(`schedule`.recurrence_type, \'\') <> \'\' 
@@ -769,7 +769,7 @@ class DisplayNotifyService implements DisplayNotifyServiceInterface
                         ON lkdisplaydg.DisplayID = display.displayID
             WHERE schedule.actionLayoutCode = :code 
               AND (
-                  (`schedule`.FromDT < :toDt AND IFNULL(`schedule`.toDt, `schedule`.fromDt) > :fromDt)
+                  (`schedule`.FromDT < :toDt AND IFNULL(`schedule`.toDt, UNIX_TIMESTAMP()) > :fromDt)
                   OR `schedule`.recurrence_range >= :fromDt 
                   OR (
                     IFNULL(`schedule`.recurrence_range, 0) = 0 AND IFNULL(`schedule`.recurrence_type, \'\') <> \'\'

--- a/lib/routes.php
+++ b/lib/routes.php
@@ -50,7 +50,7 @@ if (file_exists(PROJECT_ROOT . '/lib/routes-cypress.php')) {
  *  description="Xibo CMS API.
        Using HTTP formData requests.
        All PUT requests require Content-Type:application/x-www-form-urlencoded header.",
- *  version="3.3",
+ *  version="4.0",
  *  termsOfService="https://xibosignage.com/legal",
  *  @SWG\License(
  *      name="AGPLv3 or later",

--- a/ui/src/core/xibo-cms.js
+++ b/ui/src/core/xibo-cms.js
@@ -3870,11 +3870,13 @@ function initJsTreeAjax(container, id, isForm, ttl, onReady = null, onSelected =
                             $('#container-folder-tree').jstree(true).refresh();
                         }
                     } else {
-                        toastr.error(translations.folderWithContent);
-                        console.log(data.message);
+                        if (data.message !== undefined) {
+                            toastr.error(data.message)
+                        } else {
+                            toastr.error(translations.folderWithContent);
+                        }
                         $(container).jstree(true).refresh();
                     }
-
                 }
             });
         }).bind("changed.jstree", function (e, data) {

--- a/views/syncgroup-page.twig
+++ b/views/syncgroup-page.twig
@@ -48,6 +48,9 @@
                             {% set title %}{% trans "Name" %}{% endset %}
                             {{ inline.inputNameGrid('name', title) }}
 
+                            {% set title %}{% trans "Lead Display ID" %}{% endset %}
+                            {{ inline.input("leadDisplayId", title) }}
+
                             {{ inline.hidden("folderId") }}
                         </form>
                     </div>


### PR DESCRIPTION
From 3.3.8
- Library Upload : We should check if the playlist provided with the upload is editable
- Folders : Catch and Throw specific error when attempting to delete a Folder that is set as a homeFolder for any existing user
- Schedule : Fix issues with notifying Displays after updating a Layout (or Playlist) if the Schedule was using a user created day part.

v4 specific
- API : set swagger api version to 4.0
- Display : Handle attempting to delete a Display set as lead display for a Sync Group