### PR TITLE
Dashboards: no data being returned/requested by the player

### DIFF
--- a/lib/Connector/ConnectorTrait.php
+++ b/lib/Connector/ConnectorTrait.php
@@ -2,7 +2,7 @@
 /*
  * Copyright (C) 2023 Xibo Signage Ltd
  *
- * Xibo - Digital Signage - http://www.xibo.org.uk
+ * Xibo - Digital Signage - https://xibosignage.com
  *
  * This file is part of Xibo.
  *
@@ -174,7 +174,13 @@ trait ConnectorTrait
         return new Client($this->httpOptions);
     }
 
-    public function getLayoutPreviewUrl($token)
+    /**
+     * Return a layout preview URL for the provided connector token
+     *  this can be used in a data request and is decorated by the previewing function.
+     * @param string $token
+     * @return string
+     */
+    public function getTokenUrl(string $token): string
     {
         return '[[connector='.$token.']]';
     }

--- a/lib/Connector/XiboDashboardConnector.php
+++ b/lib/Connector/XiboDashboardConnector.php
@@ -33,7 +33,6 @@ use Xibo\Support\Exception\GeneralException;
 use Xibo\Support\Exception\InvalidArgumentException;
 use Xibo\Support\Exception\NotFoundException;
 use Xibo\Support\Sanitizer\SanitizerInterface;
-use Xibo\Xmds\Wsdl;
 
 /**
  * Xibo Dashboard Service connector.
@@ -532,16 +531,9 @@ class XiboDashboardConnector implements ConnectorInterface
             return;
         }
 
-        if ($event->getDataProvider()->isPreview()) {
-            $url = $this->getLayoutPreviewUrl($token);
-        } else {
-            // This is fallback HTML for the player.
-            // so output a link to the XMDS file request.
-            $url = Wsdl::getRoot() . '?connector=true&token=' . $token;
-        }
-
+        // We return a single data item which contains our URL, token and whether we're a preview
         $item = [];
-        $item['url'] = $url;
+        $item['url'] = $this->getTokenUrl($token);
         $item['token'] = $token;
         $item['isPreview'] = $event->getDataProvider()->isPreview();
 

--- a/lib/Controller/Widget.php
+++ b/lib/Controller/Widget.php
@@ -1061,6 +1061,7 @@ class Widget extends Base
             $this->getConfig()->getSetting('DEFAULT_LAT'),
             $this->getConfig()->getSetting('DEFAULT_LONG')
         );
+        $dataProvider->setIsPreview(true);
 
         $widgetInterface = $module->getWidgetProviderOrNull();
         $widgetDataProviderCache = $this->moduleFactory->createWidgetDataProviderCache();

--- a/lib/Factory/ModuleFactory.php
+++ b/lib/Factory/ModuleFactory.php
@@ -153,10 +153,12 @@ class ModuleFactory extends BaseFactory
             // Determinthe cache key from the setting in XML.
             if (empty($module->dataCacheKey)) {
                 // Best we can do here is a cache per widget, but we should log this as an error.
-                $this->getLog()->debug('getData: module without dataCacheKey: ' . $module->moduleId);
+                $this->getLog()->debug('determineCacheKey: module without dataCacheKey: ' . $module->moduleId);
                 $cacheKey = $widget->widgetId;
             } else {
                 // Start with the one provided
+                $this->getLog()->debug('determineCacheKey: module dataCacheKey: ' . $module->dataCacheKey);
+
                 $cacheKey = $module->dataCacheKey;
 
                 // Properties
@@ -182,6 +184,8 @@ class ModuleFactory extends BaseFactory
                 }
             }
         }
+
+        $this->getLog()->debug('determineCacheKey: cache key is : ' . $cacheKey);
 
         return $cacheKey;
     }

--- a/lib/Widget/DashboardProvider.php
+++ b/lib/Widget/DashboardProvider.php
@@ -2,7 +2,7 @@
 /*
  * Copyright (C) 2023 Xibo Signage Ltd
  *
- * Xibo - Digital Signage - http://www.xibo.org.uk
+ * Xibo - Digital Signage - https://xibosignage.com
  *
  * This file is part of Xibo.
  *
@@ -50,7 +50,7 @@ class DashboardProvider implements WidgetProviderInterface
 
     public function getDataCacheKey(DataProviderInterface $dataProvider): ?string
     {
-        return $dataProvider->getWidgetId() . '_' . $dataProvider->getDisplayId();
+        return null;
     }
 
     public function getDataModifiedDt(DataProviderInterface $dataProvider): ?Carbon

--- a/lib/Widget/Provider/DataProvider.php
+++ b/lib/Widget/Provider/DataProvider.php
@@ -69,6 +69,9 @@ class DataProvider implements DataProviderInterface
     /** @var float the display longitude */
     private $longitude;
 
+    /** @var bool Is this data provider in preview mode? */
+    private $isPreview = false;
+
     /** @var \GuzzleHttp\Client */
     private $client;
 
@@ -122,6 +125,17 @@ class DataProvider implements DataProviderInterface
     }
 
     /**
+     * Set whether this data provider is in preview mode
+     * @param bool $isPreview
+     * @return DataProviderInterface
+     */
+    public function setIsPreview(bool $isPreview): DataProviderInterface
+    {
+        $this->isPreview = $isPreview;
+        return $this;
+    }
+
+    /**
      * @inheritDoc
      */
     public function getDataSource(): string
@@ -166,7 +180,7 @@ class DataProvider implements DataProviderInterface
      */
     public function isPreview(): bool
     {
-        return empty($this->displayId);
+        return $this->isPreview;
     }
 
     /**

--- a/lib/Widget/Render/WidgetDataProviderCache.php
+++ b/lib/Widget/Render/WidgetDataProviderCache.php
@@ -34,6 +34,7 @@ use Xibo\Helper\ObjectVars;
 use Xibo\Support\Exception\GeneralException;
 use Xibo\Widget\Provider\DataProvider;
 use Xibo\Widget\Provider\DataProviderInterface;
+use Xibo\Xmds\Wsdl;
 
 /**
  * Acts as a cache for the Widget data cache.
@@ -288,6 +289,8 @@ class WidgetDataProviderCache
         array $data,
         array $storedAs
     ): array {
+        $this->getLog()->debug('decorateForPlayer');
+
         foreach ($data as $row => $item) {
             // Each data item can be an array or an object
             if (is_array($item)) {
@@ -329,6 +332,14 @@ class WidgetDataProviderCache
                 } else {
                     $data = str_replace('[[' . $match . ']]', '', $data);
                 }
+            } else if (Str::startsWith($match, 'connector')) {
+                // We have WSDL here because this is only called from XMDS.
+                $value = explode('=', $match);
+                $data = str_replace(
+                    '[[' . $match . ']]',
+                    Wsdl::getRoot() . '?connector=true&token=' . $value[1],
+                    $data
+                );
             }
         }
         return $data;

--- a/lib/XTR/WidgetSyncTask.php
+++ b/lib/XTR/WidgetSyncTask.php
@@ -184,6 +184,8 @@ class WidgetSyncTask implements TaskInterface
         ?WidgetProviderInterface $widgetInterface,
         ?int $displayId
     ): array {
+        $this->getLogger()->debug('cache: ' . $widget->widgetId . ' for display: ' . ($displayId ?? 0));
+
         $mediaIds = [];
 
         // Each time we call this we use a new provider

--- a/lib/Xmds/Soap.php
+++ b/lib/Xmds/Soap.php
@@ -886,7 +886,9 @@ class Soap
                             // Does this also have an associated data file?
                             // we add this for < XMDS v7 as well, because the record is used by the widget sync task
                             // the player shouldn't receive it.
-                            if ($modules[$widget->type]->isDataProviderExpected()) {
+                            if ($modules[$widget->type]->isDataProviderExpected()
+                                || $modules[$widget->type]->isWidgetProviderAvailable()
+                            ) {
                                 // A node specifically for the widget data.
                                 if ($isSupportsDataUrl) {
                                     $dataFile = $requiredFilesXml->createElement('file');

--- a/lib/Xmds/Soap7.php
+++ b/lib/Xmds/Soap7.php
@@ -146,13 +146,16 @@ class Soap7 extends Soap6
                         throw new NotFoundException('Cache not ready');
                     }
 
+                    $this->getLog()->debug('Cache ready and populated');
+
                     // Get media references
                     $media = [];
                     $requiredFiles = [];
                     $mediaIds = $widgetDataProviderCache->getCachedMediaIds();
 
                     if (count($mediaIds) > 0) {
-                        // Process media links.
+                        $this->getLog()->debug('Processing media links');
+
                         $sql = '
                             SELECT `media`.`mediaId`,
                                    `media`.`storedAs`,
@@ -212,6 +215,8 @@ class Soap7 extends Soap6
                                 ),
                             ];
                         }
+                    } else {
+                        $this->getLog()->debug('No media links');
                     }
 
                     $resource = json_encode([


### PR DESCRIPTION
fixes xibosignage/xibo#3128

 - Wsdl:getRoot doesn't work in XTR
 - Display specific cache keys must have %displayId% in them
 - Get Resource must return data nodes for widget provider modules
 - Preview mode on DataProvider doesn't work for any key that is not display specific