### PR TITLE
Widget Fixes

### DIFF
--- a/lib/Entity/Layout.php
+++ b/lib/Entity/Layout.php
@@ -1853,6 +1853,9 @@ class Layout implements \JsonSerializable
                 }
             }
         } catch (GeneralException $xiboException) {
+            $this->getLog()->debug('assessWidgetStatus: ' . $module->moduleId . ' invalid, e: '
+                . $xiboException->getMessage());
+
             $moduleStatus = Status::$STATUS_INVALID;
 
             // Include the exception on

--- a/modules/countdown-clock.xml
+++ b/modules/countdown-clock.xml
@@ -86,7 +86,7 @@
                     <condition field="countdownType" type="eq">2</condition>
                 </test>
             </visibility>
-            <rule>
+            <rule onStatus="false">
                 <test type="or" message="Warning duration needs to be lower than the countdown main duration.">
                     <condition type="eq"></condition>
                     <condition field="countdownType" type="neq">2</condition>

--- a/modules/countdown-custom.xml
+++ b/modules/countdown-custom.xml
@@ -90,7 +90,7 @@
                     <condition field="countdownType" type="eq">2</condition>
                 </test>
             </visibility>
-            <rule>
+            <rule onStatus="false">
                 <test type="or" message="Warning duration needs to be lower than the countdown main duration.">
                     <condition type="eq"></condition>
                     <condition field="countdownType" type="neq">2</condition>

--- a/modules/countdown-days.xml
+++ b/modules/countdown-days.xml
@@ -91,7 +91,7 @@
                     <condition field="countdownType" type="eq">2</condition>
                 </test>
             </visibility>
-            <rule>
+            <rule onStatus="false">
                 <test type="or" message="Warning duration needs to be lower than the countdown main duration.">
                     <condition type="eq"></condition>
                     <condition field="countdownType" type="neq">2</condition>

--- a/modules/countdown-table.xml
+++ b/modules/countdown-table.xml
@@ -91,7 +91,7 @@
                     <condition field="countdownType" type="eq">2</condition>
                 </test>
             </visibility>
-            <rule>
+            <rule onStatus="false">
                 <test type="or" message="Warning duration needs to be lower than the countdown main duration.">
                     <condition type="eq"></condition>
                     <condition field="countdownType" type="neq">2</condition>

--- a/modules/countdown-text.xml
+++ b/modules/countdown-text.xml
@@ -91,7 +91,7 @@
                     <condition field="countdownType" type="eq">2</condition>
                 </test>
             </visibility>
-            <rule>
+            <rule onStatus="false">
                 <test type="or" message="Warning duration needs to be lower than the countdown main duration.">
                     <condition type="eq"></condition>
                     <condition field="countdownType" type="neq">2</condition>

--- a/modules/rss-ticker.xml
+++ b/modules/rss-ticker.xml
@@ -29,7 +29,7 @@
     <type>rss-ticker</type>
     <legacyType>ticker</legacyType>
     <dataType>article</dataType>
-    <dataCacheKey>%uri%_%numItems%_%stripTags%</dataCacheKey>
+    <dataCacheKey>%uri%_%numItems%_%stripTags%_%imageSource%_%imageSourceTag%</dataCacheKey>
     <schemaVersion>2</schemaVersion>
     <assignable>1</assignable>
     <regionSpecific>1</regionSpecific>
@@ -98,6 +98,37 @@
             <title>Randomise</title>
             <helpText>Should the order of the feed be randomised? When enabled each time the Widget is shown the items will be randomly shuffled and displayed in a random order.</helpText>
             <default>0</default>
+        </property>
+        <property id="imageSource" type="dropdown" mode="single">
+            <title>Image Tag</title>
+            <helpText>Choose the tag in the feed to get an image URL</helpText>
+            <default>enclosure</default>
+            <options>
+                <option name="enclosure">Enclosure</option>
+                <option name="mediaContent">Media Content</option>
+                <option name="image">Image</option>
+                <option name="custom">Custom</option>
+            </options>
+        </property>
+        <property id="imageSourceTag" type="text">
+            <title>Custom Tag</title>
+            <helpText>A valid tag name which appears in this feed and will be used to get an image URL.</helpText>
+            <default></default>
+            <visibility>
+                <test>
+                    <condition field="imageSource" type="eq">custom</condition>
+                </test>
+            </visibility>
+        </property>
+        <property id="imageSourceAttribute" type="text">
+            <title>Custom Tag Attribute</title>
+            <helpText>If the image URL is on an attribute of the custom tag, provide the attribute name.</helpText>
+            <default></default>
+            <visibility>
+                <test>
+                    <condition field="imageSource" type="eq">custom</condition>
+                </test>
+            </visibility>
         </property>
         <property id="allowedAttributes" type="text">
             <title>Allowable Attributes</title>

--- a/modules/templates/article-static.xml
+++ b/modules/templates/article-static.xml
@@ -192,7 +192,7 @@ $(target).xiboTextRender(properties, $(target).find('#content > *'));
         <stencil>
             <hbs><![CDATA[
 <div class="image">
-    <img src="{{image}}"/>
+    {{#if image}}<img src="{{image}}"/>{{/if}}
 </div>
             ]]></hbs>
             <twig><![CDATA[
@@ -321,7 +321,7 @@ $(target).xiboTextRender(properties, $(target).find('#content > .image, #content
         <stencil>
             <hbs><![CDATA[
 <div class="image">
-  <img src="{{image}}"/>
+  {{#if image}}<img src="{{image}}"/>{{/if}}
   <div class="cycle-overlay background">
     <div class="title">{{title}}</div>
     <div class="description">{{{content}}}</div>
@@ -516,7 +516,7 @@ $(target).xiboTextRender(properties, $(target).find('#content > .image, #content
         <stencil>
             <hbs><![CDATA[
 <div class="image">
-  <img src="{{image}}"/>
+  {{#if image}}<img src="{{image}}"/>{{/if}}
   <div class="cycle-overlay background">
     <div class="title">{{title}}</div>
   </div>

--- a/views/welcome-page.twig
+++ b/views/welcome-page.twig
@@ -68,7 +68,6 @@
                                         <a href="https://xibosignage.com/install-upgrade#upgrade" target="_blank"  class="card-link">Upgrade</a>
                                     {% else %}
                                         <p class="card-text">{{ "Your service provider can help you with installation and upgrade."|trans }}</p>
-                                        <a href="{{ theme.getThemeConfig("product_support_url", "https://community.xibo.org.uk/c/support") }}" target="_blank" class="card-link">Get Help</a>
                                     {% endif %}
                                 </div>
                             </div>
@@ -159,7 +158,6 @@
                                         <a href="https://community.xibo.org.uk" target="_blank"  class="card-link">Community</a>
                                     {% else %}
                                         <p class="card-text">{{ "Contact your service provider for assistance."|trans }}</p>
-                                        <a href="{{ theme.getThemeConfig("product_support_url", "https://community.xibo.org.uk/c/support") }}" target="_blank" class="card-link">{{ "Get Help"|trans }}</a>
                                     {% endif %}
                                 </div>
                             </div>

--- a/web/xmds.php
+++ b/web/xmds.php
@@ -162,8 +162,16 @@ if (isset($_GET['file'])) {
             throw new \Xibo\Support\Exception\InstanceSuspendedException('Bandwidth Exceeded');
         }
 
-        // Check the display specific limit next.
+        // Get the display
+        /** @var \Xibo\Entity\Display $display */
         $display = $container->get('displayFactory')->getById($displayId);
+
+        // Check it is still authorised.
+        if ($display->licensed == 0) {
+            throw new NotFoundException(__('Display unauthorised'));
+        }
+
+        // Check the display specific limit next.
         $usage = 0;
         if ($container->get('bandwidthFactory')->isBandwidthExceeded(
             $display->bandwidthLimit,
@@ -281,6 +289,15 @@ if (isset($_GET['connector'])) {
         if (empty($tokenEvent->getWidgetId())) {
             header('HTTP/1.0 403 Forbidden');
             exit;
+        }
+
+        // Get the display
+        /** @var \Xibo\Entity\Display $display */
+        $display = $container->get('displayFactory')->getById($tokenEvent->getDisplayId());
+
+        // Check it is still authorised.
+        if ($display->licensed == 0) {
+            throw new NotFoundException(__('Display unauthorised'));
         }
 
         // Check the widgetId is permissible, and in required files for the display.


### PR DESCRIPTION
 - Countdown widget warning on layout status (can't use duration in status rule)
 - Dashboards should have a shorter token TTL
 - RSS ticker should support custom image enclosures
 - RSS ticker upgrade from v3 fixed
 - Welcome page uses product_support_url for non Xibo themed, which isn't set.