### PR TITLE
Widgets with only 1 element and 1 data slot don't page correctly

### DIFF
--- a/modules/src/player.js
+++ b/modules/src/player.js
@@ -1001,8 +1001,7 @@ $(function() {
 
                     if (hasStandaloneSlotFilled) {
                       hasStandaloneSlotFilled = false;
-                      if (lastSingleSlotFilled % maxSlot === 0 &&
-                          itemsObj.length > 1) {
+                      if (lastSingleSlotFilled % maxSlot === 0) {
                         lastSingleSlotFilled = null;
                       }
                       return false;


### PR DESCRIPTION
relates to xibosignage/xibo#3131