### PR TITLE
Date Picker: Set default time to 12am and not 12pm

### DIFF
--- a/ui/src/core/xibo-cms.js
+++ b/ui/src/core/xibo-cms.js
@@ -3498,6 +3498,7 @@ function initDatePicker($element, baseFormat, displayFormat, options, onChangeCa
             altFormat: displayFormat,
             dateFormat: baseFormat,
             locale: (language != 'en-GB') ? language : 'default',
+            defaultHour: '00',
             getWeek: function(dateObj) {
                 return moment(dateObj).week();
             },


### PR DESCRIPTION
relates to xibosignageltd/xibo-private#479