### PR TITLE
Widget issues with data cache

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -242,6 +242,8 @@ then
         echo "#!/bin/bash" > /var/www/maintenance.sh
         echo "" >> /var/www/maintenance.sh
         /usr/bin/env | sed 's/^\(.*\)$/export \1/g' | grep -E "^export MYSQL" >> /var/www/maintenance.sh
+        /usr/bin/env | sed 's/^\(.*\)$/export \1/g' | grep -E "^export MEMCACHED" >> /var/www/maintenance.sh
+        echo "export CMS_USE_MEMCACHED=$CMS_USE_MEMCACHED" >> /var/www/maintenance.sh
         echo "cd /var/www/cms && /usr/bin/php bin/xtr.php" >> /var/www/maintenance.sh
         chmod 755 /var/www/maintenance.sh
 

--- a/lib/Controller/Module.php
+++ b/lib/Controller/Module.php
@@ -292,7 +292,7 @@ class Module extends Base
     public function clearCache(Request $request, Response $response, $id)
     {
         $module = $this->moduleFactory->getById($id);
-        if ($module->isDataProviderExpected() || $module->isWidgetProviderAvailable()) {
+        if ($module->isDataProviderExpected()) {
             $this->moduleFactory->clearCacheForDataType($module->dataType);
         }
 

--- a/lib/Controller/Widget.php
+++ b/lib/Controller/Widget.php
@@ -1120,7 +1120,8 @@ class Widget extends Base
         $module = $this->moduleFactory->getByType($widget->type);
 
         // This is always a preview
-        if (!$module->isDataProviderExpected() && !$module->isWidgetProviderAvailable()) {
+        // We only return data if a data provider is expected.
+        if (!$module->isDataProviderExpected()) {
             return $response->withJson([]);
         }
 

--- a/lib/Entity/Module.php
+++ b/lib/Entity/Module.php
@@ -352,15 +352,6 @@ class Module implements \JsonSerializable
     }
 
     /**
-     * Is a widget provider available
-     * @return bool
-     */
-    public function isWidgetProviderAvailable(): bool
-    {
-        return $this->widgetProvider !== null;
-    }
-
-    /**
      * Get this module's widget provider, or null if there isn't one
      * @return \Xibo\Widget\Provider\WidgetProviderInterface|null
      */

--- a/lib/Service/DisplayNotifyService.php
+++ b/lib/Service/DisplayNotifyService.php
@@ -395,159 +395,17 @@ class DisplayNotifyService implements DisplayNotifyServiceInterface
     /** @inheritdoc */
     public function notifyByDataSetId($dataSetId)
     {
-        $this->log->debug('Notify by DataSetId ' . $dataSetId);
+        $this->log->debug('notifyByDataSetId: dataSetId: ' . $dataSetId);
 
-        if (in_array('dataSet_' . $dataSetId, $this->keysProcessed)) {
-            $this->log->debug('Already processed ' . $dataSetId . ' skipping this time.');
+        if (in_array('dataSet', $this->keysProcessed)) {
+            $this->log->debug('notifyByDataSetId: already processed.');
             return;
         }
 
-        $sql = '
-           SELECT DISTINCT display.displayId, 
-                schedule.eventId, 
-                schedule.fromDt, 
-                schedule.toDt, 
-                schedule.recurrence_type AS recurrenceType,
-                schedule.recurrence_detail AS recurrenceDetail,
-                schedule.recurrence_range AS recurrenceRange,
-                schedule.recurrenceRepeatsOn,
-                schedule.lastRecurrenceWatermark,
-                schedule.dayPartId
-             FROM `schedule`
-               INNER JOIN `lkscheduledisplaygroup`
-               ON `lkscheduledisplaygroup`.eventId = `schedule`.eventId
-               INNER JOIN `lkdgdg`
-               ON `lkdgdg`.parentId = `lkscheduledisplaygroup`.displayGroupId
-               INNER JOIN `lkdisplaydg`
-               ON lkdisplaydg.DisplayGroupID = `lkdgdg`.childId
-               INNER JOIN `display`
-               ON lkdisplaydg.DisplayID = display.displayID
-               INNER JOIN `lkcampaignlayout`
-               ON `lkcampaignlayout`.campaignId = `schedule`.campaignId
-               INNER JOIN `region`
-               ON `region`.layoutId = `lkcampaignlayout`.layoutId
-               INNER JOIN `playlist`
-               ON `playlist`.regionId = `region`.regionId
-               INNER JOIN `widget`
-               ON `widget`.playlistId = `playlist`.playlistId
-               INNER JOIN `widgetoption`
-               ON `widgetoption`.widgetId = `widget`.widgetId
-                    AND `widgetoption`.type = \'attrib\'
-                    AND `widgetoption`.option = \'dataSetId\'
-                    AND `widgetoption`.value = :activeDataSetId
-            WHERE (
-               (schedule.FromDT < :toDt AND IFNULL(`schedule`.toDt, UNIX_TIMESTAMP()) > :fromDt) 
-                  OR `schedule`.recurrence_range >= :fromDt 
-                  OR (
-                    IFNULL(`schedule`.recurrence_range, 0) = 0 AND IFNULL(`schedule`.recurrence_type, \'\') <> \'\' 
-                  )
-               )
-           UNION
-           SELECT DISTINCT display.displayId,
-                0 AS eventId, 
-                0 AS fromDt, 
-                0 AS toDt, 
-                NULL AS recurrenceType, 
-                NULL AS recurrenceDetail,
-                NULL AS recurrenceRange,
-                NULL AS recurrenceRepeatsOn,
-                NULL AS lastRecurrenceWatermark,
-                NULL AS dayPartId
-             FROM `display`
-               INNER JOIN `lkcampaignlayout`
-               ON `lkcampaignlayout`.LayoutID = `display`.DefaultLayoutID
-               INNER JOIN `region`
-               ON `region`.layoutId = `lkcampaignlayout`.layoutId
-               INNER JOIN `playlist`
-               ON `playlist`.regionId = `region`.regionId
-               INNER JOIN `widget`
-               ON `widget`.playlistId = `playlist`.playlistId
-               INNER JOIN `widgetoption`
-               ON `widgetoption`.widgetId = `widget`.widgetId
-                    AND `widgetoption`.type = \'attrib\'
-                    AND `widgetoption`.option = \'dataSetId\'
-                    AND `widgetoption`.value = :activeDataSetId2
-           UNION
-           SELECT DISTINCT `lkdisplaydg`.displayId,
-                0 AS eventId, 
-                0 AS fromDt, 
-                0 AS toDt, 
-                NULL AS recurrenceType, 
-                NULL AS recurrenceDetail,
-                NULL AS recurrenceRange,
-                NULL AS recurrenceRepeatsOn,
-                NULL AS lastRecurrenceWatermark,
-                NULL AS dayPartId
-              FROM `lklayoutdisplaygroup`
-                INNER JOIN `lkdgdg`
-                ON `lkdgdg`.parentId = `lklayoutdisplaygroup`.displayGroupId
-                INNER JOIN `lkdisplaydg`
-                ON lkdisplaydg.DisplayGroupID = `lkdgdg`.childId
-                INNER JOIN `lkcampaignlayout`
-                ON `lkcampaignlayout`.layoutId = `lklayoutdisplaygroup`.layoutId
-                INNER JOIN `region`
-                ON `region`.layoutId = `lkcampaignlayout`.layoutId
-                INNER JOIN `playlist`
-               ON `playlist`.regionId = `region`.regionId
-                INNER JOIN `widget`
-                ON `widget`.playlistId = `playlist`.playlistId
-                INNER JOIN `widgetoption`
-                ON `widgetoption`.widgetId = `widget`.widgetId
-                    AND `widgetoption`.type = \'attrib\'
-                    AND `widgetoption`.option = \'dataSetId\'
-                    AND `widgetoption`.value = :activeDataSetId3
-        ';
-
-        $currentDate = Carbon::now();
-        $rfLookAhead = $currentDate->copy()->addSeconds($this->config->getSetting('REQUIRED_FILES_LOOKAHEAD'));
-
-        $params = [
-            'fromDt' => $currentDate->subHour()->format('U'),
-            'toDt' => $rfLookAhead->format('U'),
-            'activeDataSetId' => $dataSetId,
-            'activeDataSetId2' => $dataSetId,
-            'activeDataSetId3' => $dataSetId
-        ];
-
-        foreach ($this->store->select($sql, $params) as $row) {
-            // Don't process if the displayId is already in the collection (there is little point in running the
-            // extra query)
-            if (in_array($row['displayId'], $this->displayIds)) {
-                $this->log->debug('displayId ' . $row['displayId'] . ' already in collection, skipping.');
-                continue;
-            }
-
-            // Is this schedule active?
-            if ($row['eventId'] != 0) {
-                $scheduleEvents = $this->scheduleFactory
-                    ->createEmpty()
-                    ->hydrate($row)
-                    ->getEvents($currentDate, $rfLookAhead);
-
-                if (count($scheduleEvents) <= 0) {
-                    $this->log->debug(
-                        'Skipping eventId ' . $row['eventId'] .
-                        ' because it doesnt have any active events in the window'
-                    );
-                    continue;
-                }
-            }
-
-            $this->log->debug(
-                'DataSet[' . $dataSetId .'] change caused notify on displayId[' .
-                $row['displayId'] . ']'
-            );
-
-            $this->displayIds[] = $row['displayId'];
-
-            if ($this->collectRequired) {
-                $this->displayIdsRequiringActions[] = $row['displayId'];
-            }
-        }
-
-        $this->keysProcessed[] = 'dataSet_' . $dataSetId;
-
-        $this->log->debug('Finished notify for dataSetId ' . $dataSetId);
+        // Set the Sync task to runNow
+        $this->store->update('UPDATE `task` SET `runNow` = 1 WHERE `class` LIKE :taskClassLike', [
+            'taskClassLike' => '%WidgetSyncTask%',
+        ]);
     }
 
     /** @inheritdoc */
@@ -1056,5 +914,19 @@ class DisplayNotifyService implements DisplayNotifyServiceInterface
         $this->keysProcessed[] = 'menuBoard_' . $menuId;
 
         $this->log->debug('Finished notify for Menu Board ID ' . $menuId);
+    }
+
+    /** @inheritdoc */
+    public function notifyDataUpdate(int $displayId, int $widgetId): void
+    {
+        if (in_array('dataUpdate_' . $displayId . '_' . $widgetId, $this->keysProcessed)) {
+            $this->log->debug('notifyDataUpdate: Already processed displayId: ' . $displayId . ', widgetId: '
+                . $widgetId . ', skipping this time.');
+            return;
+        }
+        $this->log->debug('notifyDataUpdate: Process displayId: ' . $displayId . ', widgetId: ' . $widgetId);
+
+        // TODO: queue a message for updating a specific data item.
+
     }
 }

--- a/lib/Service/DisplayNotifyServiceInterface.php
+++ b/lib/Service/DisplayNotifyServiceInterface.php
@@ -24,6 +24,7 @@
 namespace Xibo\Service;
 
 use Stash\Interfaces\PoolInterface;
+use Xibo\Entity\Display;
 use Xibo\Factory\ScheduleFactory;
 use Xibo\Storage\StorageServiceInterface;
 
@@ -110,9 +111,9 @@ interface DisplayNotifyServiceInterface
 
     /**
      * Notify that data has been updated for this display
-     * @param int $displayId
+     * @param \Xibo\Entity\Display $display
      * @param int $widgetId
      * @return void
      */
-    public function notifyDataUpdate(int $displayId, int $widgetId): void;
+    public function notifyDataUpdate(Display $display, int $widgetId): void;
 }

--- a/lib/Service/DisplayNotifyServiceInterface.php
+++ b/lib/Service/DisplayNotifyServiceInterface.php
@@ -1,8 +1,8 @@
 <?php
-/**
- * Copyright (C) 2021 Xibo Signage Ltd
+/*
+ * Copyright (C) 2023 Xibo Signage Ltd
  *
- * Xibo - Digital Signage - http://www.xibo.org.uk
+ * Xibo - Digital Signage - https://xibosignage.com
  *
  * This file is part of Xibo.
  *
@@ -24,7 +24,6 @@
 namespace Xibo\Service;
 
 use Stash\Interfaces\PoolInterface;
-use Xibo\Factory\DayPartFactory;
 use Xibo\Factory\ScheduleFactory;
 use Xibo\Storage\StorageServiceInterface;
 
@@ -108,4 +107,12 @@ interface DisplayNotifyServiceInterface
      * @param $menuId
      */
     public function notifyByMenuBoardId($menuId);
+
+    /**
+     * Notify that data has been updated for this display
+     * @param int $displayId
+     * @param int $widgetId
+     * @return void
+     */
+    public function notifyDataUpdate(int $displayId, int $widgetId): void;
 }

--- a/lib/Widget/Render/WidgetDataProviderCache.php
+++ b/lib/Widget/Render/WidgetDataProviderCache.php
@@ -169,6 +169,28 @@ class WidgetDataProviderCache
     }
 
     /**
+     * Get the cache date for this data provider and key
+     * @param DataProvider $dataProvider
+     * @param string $cacheKey
+     * @return Carbon|null
+     */
+    public function getCacheDate(DataProvider $dataProvider, string $cacheKey): ?Carbon
+    {
+        // Construct a key
+        $this->key = '/widget/'
+            . ($dataProvider->getDataType() ?: $dataProvider->getDataSource())
+            . '/' . md5($cacheKey);
+
+        $this->getLog()->debug('getCacheDate: key is ' . $this->key);
+
+        // Get the cache
+        $this->cache = $this->pool->getItem($this->key);
+        $cacheCreationDt = $this->cache->getCreation();
+
+        return $cacheCreationDt ? Carbon::instance($cacheCreationDt) : null;
+    }
+
+    /**
      * @param DataProviderInterface $dataProvider
      * @throws \Xibo\Support\Exception\GeneralException
      */

--- a/lib/Widget/Render/WidgetHtmlRenderer.php
+++ b/lib/Widget/Render/WidgetHtmlRenderer.php
@@ -479,7 +479,7 @@ class WidgetHtmlRenderer
             ];
 
             // Should we expect data?
-            if ($module->isDataProviderExpected() || $module->isWidgetProviderAvailable()) {
+            if ($module->isDataProviderExpected()) {
                 $widgetData['url'] = '[[dataUrl=' . $widget->widgetId . ']]';
                 $widgetData['data'] = '[[data=' . $widget->widgetId . ']]';
             } else {

--- a/lib/XMR/DataUpdateAction.php
+++ b/lib/XMR/DataUpdateAction.php
@@ -1,0 +1,48 @@
+<?php
+/*
+ * Copyright (C) 2023 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+namespace Xibo\XMR;
+
+/**
+ * Class DataUpdateAction
+ *  Used to indicate that a widget has been recently updated and should be downloaded again
+ * @package Xibo\XMR
+ */
+class DataUpdateAction extends PlayerAction
+{
+    /**
+     * @param int $widgetId The widgetId which has been updated
+     */
+    public function __construct(protected int $widgetId)
+    {
+    }
+
+    /** @inheritdoc */
+    public function getMessage()
+    {
+        $this->setQos(1);
+        $this->action = 'dataUpdate';
+
+        return $this->serializeToJson(['widgetId']);
+    }
+}

--- a/lib/XTR/WidgetSyncTask.php
+++ b/lib/XTR/WidgetSyncTask.php
@@ -108,7 +108,7 @@ class WidgetSyncTask implements TaskInterface
                     // data is cached ahead of time here.
                     // This also refreshes any library or external images referenced by the data so that they aren't
                     // considered for removal.
-                    if ($module->isDataProviderExpected() || $module->isWidgetProviderAvailable()) {
+                    if ($module->isDataProviderExpected()) {
                         $this->getLogger()->debug('widgetSyncTask: data provider expected.');
 
                         // Record start time

--- a/lib/Xmds/Soap.php
+++ b/lib/Xmds/Soap.php
@@ -886,7 +886,7 @@ class Soap
                                 // Does this also have an associated data file?
                                 // we add this for < XMDS v7 as well, because the record is used by the widget sync task
                                 // the player shouldn't receive it.
-                                if ($dataModule->isDataProviderExpected() || $dataModule->isWidgetProviderAvailable()) {
+                                if ($dataModule->isDataProviderExpected()) {
                                     // A node specifically for the widget data.
                                     if ($isSupportsDataUrl) {
                                         // Newer player (v4 onward), add widget node for returning data
@@ -2339,7 +2339,7 @@ class Soap
             if (!$isSupportsDataUrl) {
                 foreach ($widgets as $widget) {
                     $dataModule = $this->moduleFactory->getByType($widget->type);
-                    if ($dataModule->isDataProviderExpected() || $dataModule->isWidgetProviderAvailable()) {
+                    if ($dataModule->isDataProviderExpected()) {
                         // We only ever return cache.
                         $dataProvider = $module->createDataProvider($widget);
 

--- a/lib/Xmds/Soap7.php
+++ b/lib/Xmds/Soap7.php
@@ -125,7 +125,7 @@ class Soap7 extends Soap6
 
             // We just want the data.
             $dataModule = $this->moduleFactory->getByType($widget->type);
-            if ($dataModule->isDataProviderExpected() || $dataModule->isWidgetProviderAvailable()) {
+            if ($dataModule->isDataProviderExpected()) {
                 // We only ever return cache.
                 $dataProvider = $module->createDataProvider($widget);
 

--- a/modules/dashboard.xml
+++ b/modules/dashboard.xml
@@ -27,7 +27,7 @@
     <class>\Xibo\Widget\DashboardProvider</class>
     <dataCacheKey>%widgetId%_%displayId%</dataCacheKey>
     <type>dashboard</type>
-    <dataType></dataType>
+    <dataType>xibo-dashboard-service</dataType>
     <schemaVersion>1</schemaVersion>
     <assignable>1</assignable>
     <regionSpecific>1</regionSpecific>

--- a/views/dataset-form-edit.twig
+++ b/views/dataset-form-edit.twig
@@ -83,6 +83,10 @@
                         {% set title %}{% trans "Remote?" %}{% endset %}
                         {% set helpText %}{% trans "Is this DataSet connected to a remote data source?" %}{% endset %}
                         {{ forms.checkbox("isRemote", title, dataSet.isRemote, helpText) }}
+
+                        {% if dataSet.isActive() %}
+                        {{ forms.message("This DataSet has been accessed or updated recently, which means the CMS will keep it active."|trans, "alert alert-success") }}
+                        {% endif %}
                     </div>
                     <div class="tab-pane" id="gateway">
                         {% set title %}{% trans "Method" %}{% endset %}

--- a/views/dataset-page.twig
+++ b/views/dataset-page.twig
@@ -83,6 +83,7 @@
                                         <th>{% trans "Owner" %}</th>
                                         <th>{% trans "Sharing" %}</th>
                                         <th>{% trans "Last Sync" %}</th>
+                                        <th>{% trans "Data Last Modified" %}</th>
                                         <th class="rowMenu"></th>
                                     </tr>
                                 </thead>
@@ -142,6 +143,11 @@
                     },
                     {
                         "data": "lastSync",
+                        responsivePriority: 4,
+                        "render": dataTableDateFromUnix
+                    },
+                    {
+                        "data": "lastDataEdit",
                         responsivePriority: 4,
                         "render": dataTableDateFromUnix
                     },


### PR DESCRIPTION
DataSet takes too long to update on the player after editing
 - add data last modified and active info to data set page for debugging
 - XMDS required files needs to push the `updated` attribute on resource for older players
 - DataSet notify should run the widget sync task immediately
 - Widget Sync task should notify now for older displays and should have some way to notify newer players that data has changed 
- fixes xibosignage/xibo#3145

PDF widget is broken because it expects data, fixes xibosignage/xibo#3147