### PR TITLE
Widget: xiboIC not initialised with a widgetId

### DIFF
--- a/lib/Widget/Render/WidgetHtmlRenderer.php
+++ b/lib/Widget/Render/WidgetHtmlRenderer.php
@@ -237,7 +237,7 @@ class WidgetHtmlRenderer
             }
 
             // Render
-            $output = $this->render($region, $widgets, $moduleTemplates);
+            $output = $this->render($widget->widgetId, $region, $widgets, $moduleTemplates);
 
             // Cache to the library
             file_put_contents($cachePath, $output);
@@ -382,12 +382,14 @@ class WidgetHtmlRenderer
      * @throws \Xibo\Support\Exception\NotFoundException
      */
     private function render(
+        int $widgetId,
         Region $region,
         array $widgets,
         array $moduleTemplates
     ): string {
         // Build up some data for twig
         $twig = [];
+        $twig['widgetId'] = $widgetId;
         $twig['hbs'] = [];
         $twig['twig'] = [];
         $twig['style'] = [];

--- a/modules/widget-html-render.twig
+++ b/modules/widget-html-render.twig
@@ -68,6 +68,7 @@
     {% endif %}
     </body>
     <script type="text/javascript">
+        var xiboICTargetId = {{ widgetId }};
         window.globalOptions = {
           originalWidth: {{ width }},
           originalHeight: {{ height }},


### PR DESCRIPTION
v3 initialised xiboIC with the targetId, this is missing in v4
related to: xibosignage/xibo#3147 and xibosignageltd/xibo-private#264