### PR TITLE
XMDS: ensure required files outputs the data node for elements

### DIFF
--- a/lib/Xmds/Soap.php
+++ b/lib/Xmds/Soap.php
@@ -853,27 +853,25 @@ class Soap
                             // We've added this widget already
                             $resourcesAdded[] = $widget->widgetId;
 
+                            // Get the widget modified date
+                            // we will use the latter of this vs the layout modified date as the updated attribute
+                            // on required files
+                            $widgetModifiedDt = Carbon::createFromTimestamp($widget->modifiedDt);
+
+                            // Updated date is the greatest of layout/widget modified date
+                            $updatedDt = ($layoutModifiedDt->greaterThan($widgetModifiedDt))
+                                ? $layoutModifiedDt
+                                : $widgetModifiedDt;
+
                             // If this is a canvas region, then only send the data, unless we're the global
                             // widget
-                            if ($region->type !== 'canvas' || $widget->type === 'global') {
-                                // Add nonce
+                            $isShouldSendHtml = $region->type !== 'canvas' || $widget->type === 'global';
+                            if ($isShouldSendHtml) {
+                                // Add the resource node to the XML for this widfget.
                                 $getResourceRf = $this->requiredFileFactory
                                     ->createForGetResource($this->display->displayId, $widget->widgetId)
                                     ->save();
                                 $newRfIds[] = $getResourceRf->rfId;
-
-                                // Get the module
-                                $dataModule = $modules[$widget->type];
-
-                                // Get the widget modified date
-                                // we will use the latter of this vs the layout modified date as the updated attribute
-                                // on required files
-                                $widgetModifiedDt = Carbon::createFromTimestamp($widget->modifiedDt);
-
-                                // Updated date is the greatest of layout/widget modified date
-                                $updatedDt = ($layoutModifiedDt->greaterThan($widgetModifiedDt))
-                                    ? $layoutModifiedDt
-                                    : $widgetModifiedDt;
 
                                 // Append this item to required files
                                 $resourceFile = $requiredFilesXml->createElement('file');
@@ -882,59 +880,66 @@ class Soap
                                 $resourceFile->setAttribute('layoutid', $layoutId);
                                 $resourceFile->setAttribute('regionid', $region->regionId);
                                 $resourceFile->setAttribute('mediaid', $widget->widgetId);
+                            }
 
-                                // Does this also have an associated data file?
-                                // we add this for < XMDS v7 as well, because the record is used by the widget sync task
-                                // the player shouldn't receive it.
-                                if ($dataModule->isDataProviderExpected()) {
-                                    // A node specifically for the widget data.
-                                    if ($isSupportsDataUrl) {
-                                        // Newer player (v4 onward), add widget node for returning data
-                                        $dataFile = $requiredFilesXml->createElement('file');
-                                        $dataFile->setAttribute('type', 'widget');
-                                        $dataFile->setAttribute('id', $widget->widgetId);
-                                        $dataFile->setAttribute(
-                                            'updateInterval',
-                                            $widget->getOptionValue('updateInterval', 120)
+                            // Get the module
+                            $dataModule = $modules[$widget->type];
+
+                            // Does this also have an associated data file?
+                            // we add this for < XMDS v7 as well, because the record is used by the widget sync task
+                            // the player shouldn't receive it.
+                            if ($dataModule->isDataProviderExpected()) {
+                                // A node specifically for the widget data.
+                                if ($isSupportsDataUrl) {
+                                    // Newer player (v4 onward), add widget node for returning data
+                                    $dataFile = $requiredFilesXml->createElement('file');
+                                    $dataFile->setAttribute('type', 'widget');
+                                    $dataFile->setAttribute('id', $widget->widgetId);
+                                    $dataFile->setAttribute(
+                                        'updateInterval',
+                                        $widget->getOptionValue('updateInterval', 120)
+                                    );
+                                    $fileElements->appendChild($dataFile);
+                                } else if ($isShouldSendHtml) {
+                                    // Older player, needs to change the updated date on the resource node
+                                    // Has our widget been updated recently?
+                                    // TODO: Does this need to be the most recent updated date for all the widgets in
+                                    //  this region?
+                                    $dataProvider = $dataModule->createDataProvider($widget);
+                                    try {
+                                        $widgetDataProviderCache = $this->moduleFactory
+                                            ->createWidgetDataProviderCache();
+                                        $cacheKey = $this->moduleFactory->determineCacheKey(
+                                            $dataModule,
+                                            $widget,
+                                            $this->display->displayId,
+                                            $dataProvider,
+                                            $dataModule->getWidgetProviderOrNull()
                                         );
-                                        $fileElements->appendChild($dataFile);
-                                    } else {
-                                        // Older player, needs to change the updated date on the resource node
-                                        // Has our widget been updated recently?
-                                        $dataProvider = $dataModule->createDataProvider($widget);
-                                        try {
-                                            $widgetDataProviderCache = $this->moduleFactory
-                                                ->createWidgetDataProviderCache();
-                                            $cacheKey = $this->moduleFactory->determineCacheKey(
-                                                $dataModule,
-                                                $widget,
-                                                $this->display->displayId,
-                                                $dataProvider,
-                                                $dataModule->getWidgetProviderOrNull()
-                                            );
 
-                                            // We do not pass a modifiedDt in here because we always expect to be cached
-                                            $cacheDt = $widgetDataProviderCache->getCacheDate($dataProvider, $cacheKey);
-                                            if ($cacheDt !== null) {
-                                                $updatedDt = ($cacheDt->greaterThan($updatedDt))
-                                                    ? $cacheDt
-                                                    : $updatedDt;
-                                            }
-                                        } catch (\Exception) {
-                                            $this->getLog()->error(
-                                                'doRequiredFiles: Failed to get data cache modified date for widgetId '
-                                                . $widget->widgetId
-                                            );
+                                        // We do not pass a modifiedDt in here because we always expect to be cached
+                                        $cacheDt = $widgetDataProviderCache->getCacheDate($dataProvider, $cacheKey);
+                                        if ($cacheDt !== null) {
+                                            $updatedDt = ($cacheDt->greaterThan($updatedDt))
+                                                ? $cacheDt
+                                                : $updatedDt;
                                         }
+                                    } catch (\Exception) {
+                                        $this->getLog()->error(
+                                            'doRequiredFiles: Failed to get data cache modified date for widgetId '
+                                            . $widget->widgetId
+                                        );
                                     }
-
-                                    // Used by WidgetSync to understand when to keep the cache warm
-                                    $getDataRf = $this->requiredFileFactory
-                                        ->createForGetData($this->display->displayId, $widget->widgetId)
-                                        ->save();
-                                    $newRfIds[] = $getDataRf->rfId;
                                 }
 
+                                // Used by WidgetSync to understand when to keep the cache warm
+                                $getDataRf = $this->requiredFileFactory
+                                    ->createForGetData($this->display->displayId, $widget->widgetId)
+                                    ->save();
+                                $newRfIds[] = $getDataRf->rfId;
+                            }
+
+                            if ($isShouldSendHtml) {
                                 // Append our resource node.
                                 $resourceFile->setAttribute('updated', $updatedDt->format('U'));
                                 $fileElements->appendChild($resourceFile);


### PR DESCRIPTION
relates to xibosignage/xibo#3145

We're only recording a data file for the global widget in the canvas, which means data is never delivered for elements on widgets with data.