### PR TITLE
XMDS: use update interval default value 

### DIFF
--- a/lib/Entity/ModulePropertyTrait.php
+++ b/lib/Entity/ModulePropertyTrait.php
@@ -166,6 +166,22 @@ trait ModulePropertyTrait
     }
 
     /**
+     * Gets the default value for a property
+     * @param string $id
+     * @return mixed
+     */
+    public function getPropertyDefault(string $id): mixed
+    {
+        foreach ($this->properties as $property) {
+            if ($property->id === $id) {
+                return $property->default;
+            }
+        }
+
+        return null;
+    }
+
+    /**
      * @throws \Xibo\Support\Exception\InvalidArgumentException|\Xibo\Support\Exception\ValueTooLargeException
      */
     public function validateProperties(string $stage, $additionalProperties = []): void

--- a/lib/Xmds/Soap.php
+++ b/lib/Xmds/Soap.php
@@ -897,7 +897,10 @@ class Soap
                                     $dataFile->setAttribute('id', $widget->widgetId);
                                     $dataFile->setAttribute(
                                         'updateInterval',
-                                        $widget->getOptionValue('updateInterval', 120)
+                                        $widget->getOptionValue(
+                                            'updateInterval',
+                                            $dataModule->getPropertyDefault('updateInterval') ?? 120,
+                                        )
                                     );
                                     $fileElements->appendChild($dataFile);
                                 } else if ($isShouldSendHtml) {


### PR DESCRIPTION
If the module default is used we don't set the widget option and always end up with 2 hours as our update interval.

relates to xibosignage/xibo#3145