### PR TITLE
Misc fixes for 4.0.4

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1511,12 +1511,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/dasgarner/picofeed.git",
-                "reference": "cda52f4966e959e553ff30c9a8d37206b87c6011"
+                "reference": "654bdfa1a03ed1a47b0e67305580b4f8b6f9a10d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dasgarner/picofeed/zipball/cda52f4966e959e553ff30c9a8d37206b87c6011",
-                "reference": "cda52f4966e959e553ff30c9a8d37206b87c6011",
+                "url": "https://api.github.com/repos/dasgarner/picofeed/zipball/654bdfa1a03ed1a47b0e67305580b4f8b6f9a10d",
+                "reference": "654bdfa1a03ed1a47b0e67305580b4f8b6f9a10d",
                 "shasum": ""
             },
             "require": {
@@ -1558,7 +1558,7 @@
             "support": {
                 "source": "https://github.com/dasgarner/picofeed/tree/westphal/php8"
             },
-            "time": "2023-04-05T12:35:43+00:00"
+            "time": "2023-09-22T11:49:47+00:00"
         },
         {
             "name": "intervention/image",

--- a/db/migrations/20220330111440_modules_table_ver_four_migration.php
+++ b/db/migrations/20220330111440_modules_table_ver_four_migration.php
@@ -60,17 +60,18 @@ class ModulesTableVerFourMigration extends AbstractMigration
 
         // Pull through old modules, having a guess at their names.
         try {
+            //phpcs:disable
             $this->execute('
-            INSERT INTO `module` (`moduleId`, `enabled`, `previewEnabled`, `defaultDuration`, `settings`)
-            SELECT DISTINCT LOWER(CASE WHEN `class` LIKE \'%Custom%\' 
-                       THEN IFNULL(installname, module)
-                       ELSE CONCAT(\'core-\', `module`)
-                   END),
-                   `enabled`,
-                   `previewEnabled`,
-                   `defaultDuration`, 
-                   `settings`
-              FROM `module_old`');
+                INSERT INTO `module` (`moduleId`, `enabled`, `previewEnabled`, `defaultDuration`, `settings`)
+                SELECT LOWER(CASE WHEN `class` LIKE \'%Custom%\' THEN IFNULL(installname, module) ELSE CONCAT(\'core-\', `module`) END),
+                    MAX(`enabled`),
+                    MAX(`previewEnabled`),
+                    MAX(`defaultDuration`),
+                    MAX(`settings`)
+                  FROM `module_old`
+                GROUP BY LOWER(CASE WHEN `class` LIKE \'%Custom%\' THEN IFNULL(installname, module) ELSE CONCAT(\'core-\', `module`) END)
+            ');
+            //phpcs:enable
 
             // Handle any specific renames
             $this->execute('UPDATE `module` SET moduleId = \'core-rss-ticker\' WHERE moduleId = \'core-ticker\'');

--- a/lib/Controller/StatusDashboard.php
+++ b/lib/Controller/StatusDashboard.php
@@ -35,6 +35,7 @@ use Xibo\Factory\DisplayGroupFactory;
 use Xibo\Factory\MediaFactory;
 use Xibo\Factory\UserFactory;
 use Xibo\Helper\ByteFormatter;
+use Xibo\Helper\DateFormatHelper;
 use Xibo\Service\MediaService;
 use Xibo\Storage\StorageServiceInterface;
 
@@ -367,8 +368,10 @@ class StatusDashboard extends Base
 
                         // Pull out the content type and body
                         $result = explode('charset=', $responseGuzzle->getHeaderLine('Content-Type'));
-                        $document['encoding'] = isset($result[1]) ? $result[1] : '';
+                        $document['encoding'] = $result[1] ?? '';
                         $document['xml'] = $responseGuzzle->getBody();
+
+                        $this->getLog()->debug($document['xml']);
 
                         // Get the feed parser
                         $reader = new Reader();
@@ -381,24 +384,25 @@ class StatusDashboard extends Base
                         $latestNews = [];
 
                         foreach ($feed->getItems() as $item) {
-                            /* @var \PicoFeed\Parser\Item $item */
-
                             // Try to get the description tag
-                            if (!$desc = $item->getTag('description')) {
+                            $desc = $item->getTag('description');
+                            if (!$desc) {
                                 // use content with tags stripped
                                 $content = strip_tags($item->getContent());
                             } else {
                                 // use description
-                                $content = (isset($desc[0]) ? $desc[0] : strip_tags($item->getContent()));
+                                $content = ($desc[0] ?? strip_tags($item->getContent()));
                             }
 
-                            $latestNews[] = array(
+                            $latestNews[] = [
                                 'title' => $item->getTitle(),
                                 'description' => $content,
                                 'link' => $item->getUrl(),
-                                'date' => Carbon::createFromTimestamp($item->getDate()->format('U'))
-                            );
+                                'date' => Carbon::instance($item->getDate())->format(DateFormatHelper::getSystemFormat()),
+                            ];
                         }
+
+                        $this->getLog()->debug(var_export($latestNews, true));
 
                         // Store in the cache for 1 day
                         $cache->set($latestNews);

--- a/lib/Factory/ModuleXmlTrait.php
+++ b/lib/Factory/ModuleXmlTrait.php
@@ -421,6 +421,7 @@ trait ModuleXmlTrait
                 $extend->template = trim($node->textContent);
                 $extend->override = $node->getAttribute('override');
                 $extend->with = $node->getAttribute('with');
+                $extend->escapeHtml = $node->getAttribute('escapeHtml') !== 'false';
                 $extends[] = $extend;
             }
         }

--- a/lib/Helper/Environment.php
+++ b/lib/Helper/Environment.php
@@ -30,7 +30,7 @@ use Phinx\Wrapper\TextWrapper;
  */
 class Environment
 {
-    public static $WEBSITE_VERSION_NAME = '4.0.3';
+    public static $WEBSITE_VERSION_NAME = '4.0.4';
     public static $XMDS_VERSION = '7';
     public static $XLF_VERSION = 4;
     public static $VERSION_REQUIRED = '8.1.0';

--- a/lib/Widget/Definition/Extend.php
+++ b/lib/Widget/Definition/Extend.php
@@ -30,6 +30,7 @@ class Extend implements \JsonSerializable
     public $template;
     public $override;
     public $with;
+    public $escapeHtml;
 
     /** @inheritDoc */
     public function jsonSerialize(): array
@@ -38,6 +39,7 @@ class Extend implements \JsonSerializable
             'template' => $this->template,
             'override' => $this->override,
             'with' => $this->with,
+            'escapeHtml' => $this->escapeHtml,
         ];
     }
 }

--- a/modules/embedded.xml
+++ b/modules/embedded.xml
@@ -39,18 +39,18 @@
         <property id="transparency" type="checkbox">
             <title>Background transparent?</title>
             <helpText>Should the Widget be shown with a transparent background? Also requires the embedded content to have a transparent background.</helpText>
-            <default>1</default>
+            <default>0</default>
         </property>
         <property id="scaleContent" type="checkbox">
             <title>Scale Content?</title>
             <helpText>Should the embedded content be scaled along with the layout?</helpText>
-            <default>1</default>
+            <default>0</default>
             <playerCompatibility windows="v2 R253+"></playerCompatibility>
         </property>
         <property id="isPreNavigate" type="checkbox">
             <title>Preload?</title>
             <helpText>Should this Widget be loaded entirely off-screen so that it is ready when shown? Dynamic content will start running off screen.</helpText>
-            <default>1</default>
+            <default>0</default>
         </property>
         <property id="embedHtml" type="code" allowLibraryRefs="true" variant="html">
             <title>HTML to embed</title>

--- a/modules/templates/article-elements.xml
+++ b/modules/templates/article-elements.xml
@@ -43,7 +43,7 @@
     </template>
     <template>
         <id>article_content</id>
-        <extends override="text" with="data.content" escape="false">text</extends>
+        <extends override="text" with="data.content" escapeHtml="false">text</extends>
         <title>Content</title>
         <type>element</type>
         <dataType>article</dataType>

--- a/views/common.twig
+++ b/views/common.twig
@@ -394,7 +394,7 @@
                 zoomOutEditor: "{{ "Zoom out"|trans }}",
                 couldNotCopy: "{{ "Could not copy"|trans }}",
                 copied: "{{ "Copied!"|trans }}",
-                invalidModule:  "{{ "Module not enabled!"|trans }}",
+                invalidModule:  "{{ "This widget isn't enabled and can't be configured, please contact your administrator for help."|trans }}",
                 timeline: "{{ "Timeline"|trans }}",
                 actions: {
                     layouts:  "{{ "Layouts"|trans }}",

--- a/views/dashboard-status-page.twig
+++ b/views/dashboard-status-page.twig
@@ -381,11 +381,12 @@
             }
         });
 
-        $(".article_date").each(function(index, element) {
-            if($(".article_date").length > 1){
-                // Replace the ISO date with a nice formatted date "for humans"
-                $(this).html(moment($(this).html(), systemDateFormat).fromNow());
-            }
+        $('.article_date').each(function(index, element) {
+          // Replace the ISO date with a nice formatted date "for humans"
+          const date = $(element).html();
+          if (date) {
+            $(element).html(moment(date, systemDateFormat).fromNow());
+          }
         });
 
         var table = $("#displays").DataTable({


### PR DESCRIPTION
A number of small issues addressed: 
 - Modules: BE mapping for the escapeHtml attribute on extends, needs FE to complete
 - Modules: Improve the "not enabled" message
 - Upgrade: handle duplicates in the table causing the insert to fail
 - RSS: date parsing broken in PHP 8.2
 - Embedded Widget: set the defaults as they were in v3