### PR TITLE
Add missing search filters

### DIFF
--- a/lib/Controller/Applications.php
+++ b/lib/Controller/Applications.php
@@ -151,7 +151,13 @@ class Applications extends Base
         $this->getState()->template = 'grid';
         $sanitizedParams = $this->getSanitizer($request->getParams());
 
-        $applications = $this->applicationFactory->query($this->gridRenderSort($sanitizedParams), $this->gridRenderFilter([], $sanitizedParams));
+        $applications = $this->applicationFactory->query(
+            $this->gridRenderSort($sanitizedParams),
+            $this->gridRenderFilter(
+                ['name' => $sanitizedParams->getString('name')],
+                $sanitizedParams
+            )
+        );
 
         foreach ($applications as $application) {
             if ($this->isApi($request)) {
@@ -165,18 +171,17 @@ class Applications extends Base
             $application->buttons = [];
 
             if ($application->userId == $this->getUser()->userId || $this->getUser()->getUserTypeId() == 1) {
-
                 // Edit
                 $application->buttons[] = [
                     'id' => 'application_edit_button',
-                    'url' => $this->urlFor($request,'application.edit.form', ['id' => $application->key]),
+                    'url' => $this->urlFor($request, 'application.edit.form', ['id' => $application->key]),
                     'text' => __('Edit')
                 ];
 
                 // Delete
                 $application->buttons[] = [
                     'id' => 'application_delete_button',
-                    'url' => $this->urlFor($request,'application.delete.form', ['id' => $application->key]),
+                    'url' => $this->urlFor($request, 'application.delete.form', ['id' => $application->key]),
                     'text' => __('Delete')
                 ];
             }

--- a/lib/Controller/Module.php
+++ b/lib/Controller/Module.php
@@ -103,8 +103,7 @@ class Module extends Base
             'moduleId' => $parsedQueryParams->getInt('moduleId')
         ];
 
-        // TODO: do we need a filter?
-        $modules = $this->moduleFactory->getAllExceptCanvas();
+        $modules = $this->moduleFactory->getAllExceptCanvas($filter);
 
         foreach ($modules as $module) {
             /* @var \Xibo\Entity\Module $module */
@@ -116,15 +115,15 @@ class Module extends Base
             $module->includeProperty('buttons');
 
             // Edit button
-            $module->buttons[] = array(
+            $module->buttons[] = [
                 'id' => 'module_button_edit',
                 'url' => $this->urlFor($request, 'module.settings.form', ['id' => $module->moduleId]),
                 'text' => __('Configure')
-            );
+            ];
 
             // Clear cache
             if ($module->regionSpecific == 1) {
-                $module->buttons[] = array(
+                $module->buttons[] = [
                     'id' => 'module_button_clear_cache',
                     'url' => $this->urlFor($request, 'module.clear.cache.form', ['id' => $module->moduleId]),
                     'text' => __('Clear Cache'),
@@ -136,7 +135,7 @@ class Module extends Base
                         ],
                         ['name' => 'commit-method', 'value' => 'PUT']
                     ]
-                );
+                ];
             }
         }
 

--- a/lib/Factory/DataSetFactory.php
+++ b/lib/Factory/DataSetFactory.php
@@ -762,11 +762,7 @@ class DataSetFactory extends BaseFactory
                             break;
                         default:
                             // Default value, assume it will be a string and filter it accordingly.
-                            $result[$column->heading] = filter_var(
-                                $value[1],
-                                FILTER_SANITIZE_STRING,
-                                FILTER_FLAG_NO_ENCODE_QUOTES
-                            );
+                            $result[$column->heading] = strip_tags($value[1]);
                     }
                 }
             } else {

--- a/lib/Factory/ModuleFactory.php
+++ b/lib/Factory/ModuleFactory.php
@@ -274,16 +274,25 @@ class ModuleFactory extends BaseFactory
 
     /**
      * Get an array of all modules except canvas
+     * @param array $filter
      * @return Module[]
      */
-    public function getAllExceptCanvas(): array
+    public function getAllExceptCanvas(array $filter = []): array
     {
+        $sanitizedFilter = $this->getSanitizer($filter);
         $this->getLog()->debug('ModuleFactory: getAllButCanvas');
         $modules = [];
         foreach ($this->load() as $module) {
             // Hide the canvas module from the module list
             if ($module->moduleId != 'core-canvas') {
-                $modules[] = $module;
+                // do we have a name filter?
+                if (!empty($sanitizedFilter->getString('name'))) {
+                    if (str_contains(strtolower($module->name), strtolower($sanitizedFilter->getString('name')))) {
+                        $modules[] = $module;
+                    }
+                } else {
+                    $modules[] = $module;
+                }
             }
         }
         return $modules;

--- a/views/applications-page.twig
+++ b/views/applications-page.twig
@@ -37,9 +37,11 @@
         <div class="widget-title">{% trans "Applications" %}</div>
         <div class="widget-body">
             <div class="XiboGrid" id="{{ random() }}">
-                <div class="XiboFilter">
+                <div class="XiboFilter card mb-3 bg-light">
                     <div class="FilterDiv card-body" id="Filter">
                         <form class="form-inline">
+                            {% set title %}{% trans "Name" %}{% endset %}
+                            {{ inline.inputNameGrid('name', title) }}
                         </form>
                     </div>
                 </div>
@@ -97,7 +99,7 @@
 
         var table;
         $(document).ready(function() {
-            table = $("#applications").DataTable({
+            table = $('#applications').DataTable({
                 language: dataTablesLanguage,
                 dom: dataTablesTemplate,
                 serverSide: true,
@@ -109,7 +111,12 @@
                 filter: false,
                 searchDelay: 3000,
                 "order": [[ 0, "asc"]],
-                ajax: "{{ url_for("application.search") }}",
+                ajax: {
+                  url: "{{ url_for('application.search') }}",
+                  data: function (d) {
+                    $.extend(d, $('#applications').closest(".XiboGrid").find(".FilterDiv form").serializeObject());
+                  }
+                },
                 "columns": [
                     { "data": "name", "render": dataTableSpacingPreformatted },
                     { "data": "owner" },

--- a/views/daypart-page.twig
+++ b/views/daypart-page.twig
@@ -38,9 +38,11 @@
         <div class="widget-title">{% trans "Dayparting" %}</div>
         <div class="widget-body">
             <div class="XiboGrid" id="{{ random() }}">
-                <div class="XiboFilter">
-                    <div class="FilterDiv" id="Filter">
+                <div class="XiboFilter card mb-3 bg-light">
+                    <div class="FilterDiv card-body" id="Filter">
                         <form class="form-inline">
+                            {% set title %}{% trans "Name" %}{% endset %}
+                            {{ inline.inputNameGrid('name', title) }}
                         </form>
                     </div>
                 </div>

--- a/views/module-page.twig
+++ b/views/module-page.twig
@@ -36,10 +36,11 @@
         <div class="widget-title">{% trans "Modules" %}</div>
         <div class="widget-body">
             <div class="XiboGrid" id="{{ random() }}">
-                <div class="XiboFilter">
+                <div class="XiboFilter card mb-3 bg-light">
                     <div class="FilterDiv card-body" id="Filter">
                         <form class="form-inline">
-
+                            {% set title %}{% trans "Name" %}{% endset %}
+                            {{ inline.input('name', title) }}
                         </form>
                     </div>
                 </div>
@@ -83,7 +84,10 @@
             searchDelay: 3000,
             order: [[ 0, 'asc']],
             ajax: {
-                url: '{{ url_for("module.search") }}'
+              url: '{{ url_for("module.search") }}',
+              data: function (d) {
+                $.extend(d, $('#modules').closest(".XiboGrid").find(".FilterDiv form").serializeObject());
+              }
             },
             columns: [
                 { "data": "name" , responsivePriority: 2},


### PR DESCRIPTION
This can go in 4.0.5 if needed.

Search Filters for
- Daypart
- Applications
- Modules

Bonus
- Remote DataSet : Fixed deprecated filter for string, use `strip_tags` instead.