### PR TITLE
Store the assetType for older players, so we can rewrite the URL correctly

### DIFF
--- a/lib/Factory/RequiredFileFactory.php
+++ b/lib/Factory/RequiredFileFactory.php
@@ -392,16 +392,11 @@ class RequiredFileFactory extends BaseFactory
                     throw new NotFoundException(__('Missing fileType'));
                 }
 
-                // File type media means that we will use a special negative itemId to get out the actual file.
-                if ($fileType === 'media') {
-                    $itemId = intval($itemId);
-                }
-
+                // HTTP links will always have the realId
                 $file = $this->getByDisplayAndDependency(
                     $displayId,
                     $fileType,
                     $itemId,
-                    !($fileType === 'media' && $itemId < 0)
                 );
 
                 // Update $file->path with the path on disk (likely /assets/$itemId)

--- a/lib/Xmds/Soap.php
+++ b/lib/Xmds/Soap.php
@@ -397,10 +397,16 @@ class Soap
                             $fileType = $node->getAttribute('fileType');
                         }
 
+                        // Use the realId if we have it.
+                        $realId = $node->getAttribute('realId');
+                        if (empty($realId)) {
+                            $realId = $node->getAttribute('id');
+                        }
+
                         // Generate a new URL.
                         $newUrl = $this->generateRequiredFileDownloadPath(
                             $type,
-                            $node->getAttribute('id'),
+                            $realId,
                             $node->getAttribute('saveAs'),
                             $fileType,
                         );
@@ -2870,6 +2876,7 @@ class Soap
             $file->setAttribute('fileType', 'media');
 
             // We need an extra attribute so that we can retrieve the original asset type from cache.
+            $file->setAttribute('realId', $dependency->id);
             $file->setAttribute('assetType', $dependency->fileType);
         }
 

--- a/lib/Xmds/Soap.php
+++ b/lib/Xmds/Soap.php
@@ -387,15 +387,22 @@ class Soap
                             default => 'P',
                         };
 
-                        if ($node->getAttribute('id') < 0 && $type === 'M') {
+                        // HTTP download for a v3 player will have saved the type and fileType as M and media
+                        // respectively, which is different to what we use in the URL.
+                        $assetType = $node->getAttribute('assetType');
+                        if (!empty($assetType)) {
                             $type = 'P';
+                            $fileType = $assetType;
+                        } else {
+                            $fileType = $node->getAttribute('fileType');
                         }
 
+                        // Generate a new URL.
                         $newUrl = $this->generateRequiredFileDownloadPath(
                             $type,
                             $node->getAttribute('id'),
                             $node->getAttribute('saveAs'),
-                            $node->getAttribute('fileType'),
+                            $fileType,
                         );
 
                         $node->setAttribute('path', $newUrl);
@@ -2861,6 +2868,9 @@ class Soap
             }
             $file->setAttribute('id', $dependency->legacyId);
             $file->setAttribute('fileType', 'media');
+
+            // We need an extra attribute so that we can retrieve the original asset type from cache.
+            $file->setAttribute('assetType', $dependency->fileType);
         }
 
         // Add our node


### PR DESCRIPTION
fixes xibosignage/xibo#3193