### PR TITLE
Dynamic Playlist and Widget delete fixes

### DIFF
--- a/lib/Entity/Playlist.php
+++ b/lib/Entity/Playlist.php
@@ -457,15 +457,13 @@ class Playlist implements \JsonSerializable
                     // This widget is >= the display order and therefore needs to be moved down one position.
                     $existingWidget->displayOrder = $existingWidget->displayOrder + 1;
                 }
-
-                // Set the incoming widget to the requested display order.
-                $widget->displayOrder = $displayOrder;
             }
+            // Set the incoming widget to the requested display order.
+            $widget->displayOrder = $displayOrder;
         } else {
             // Take the next available one
             $widget->displayOrder = count($this->widgets) + 1;
         }
-
         $this->widgets[] = $widget;
     }
 
@@ -515,7 +513,8 @@ class Playlist implements \JsonSerializable
             'loadPermissions' => true,
             'loadWidgets' => true,
             'loadTags' => true,
-            'loadActions' => true
+            'loadActions' => true,
+            'checkDisplayOrder' => false,
         ], $loadOptions);
 
         $this->getLog()->debug('Load Playlist with ' . json_encode($options));
@@ -531,6 +530,27 @@ class Playlist implements \JsonSerializable
                 /* @var Widget $widget */
                 $widget->load($options['loadActions']);
                 $this->widgets[] = $widget;
+            }
+
+            // for dynamic sync task
+            // make sure we have correct displayOrder on all existing Widgets here.
+            if ($this->isDynamic === 1 && $options['checkDisplayOrder']) {
+                // Sort the widgets by their display order
+                usort($this->widgets, function ($a, $b) {
+                    /**
+                     * @var Widget $a
+                     * @var Widget $b
+                     */
+                    return $a->displayOrder - $b->displayOrder;
+                });
+
+                $i = 0;
+                foreach ($this->widgets as $widget) {
+                    /* @var Widget $widget */
+                    $i++;
+                    // Assert the displayOrder
+                    $widget->displayOrder = $i;
+                }
             }
         }
 

--- a/lib/Entity/Widget.php
+++ b/lib/Entity/Widget.php
@@ -1084,9 +1084,13 @@ class Widget implements \JsonSerializable
             $action->delete();
         }
 
-        // Delete any actions that were targeting this Widget, to avoid orphaned records in action table.
-        $this->getStore()->update('DELETE FROM `action` WHERE widgetId = :widgetId', ['widgetId' => $this->widgetId]);
-
+        // Set widgetId to null on any navWidget action that was using this drawer Widget.
+        $this->getStore()->update(
+            'UPDATE `action` SET `action`.widgetId = NULL
+                WHERE widgetId = :widgetId AND `action`.actionType = \'navWidget\' ',
+            ['widgetId' => $this->widgetId]
+        );
+        
         // Unlink Media
         $this->mediaIds = [];
         $this->unlinkMedia();

--- a/lib/XTR/DynamicPlaylistSyncTask.php
+++ b/lib/XTR/DynamicPlaylistSyncTask.php
@@ -114,7 +114,7 @@ class DynamicPlaylistSyncTask implements TaskInterface
         foreach ($this->playlistFactory->query(null, ['isDynamic' => 1]) as $playlist) {
             try {
                 // We want to detect any differences in what should be assigned to this Playlist.
-                $playlist->load();
+                $playlist->load(['checkDisplayOrder' => true]);
 
                 $this->log->debug('Assessing Playlist: ' . $playlist->name);
 
@@ -137,6 +137,7 @@ class DynamicPlaylistSyncTask implements TaskInterface
                 // Query for media which would be assigned to this Playlist and see if there are any differences
                 $media = [];
                 $mediaIds = [];
+                $displayOrder = [];
                 foreach ($this->mediaFactory->query(null, [
                     'name' => $playlist->filterMediaName,
                     'logicalOperatorName' => $playlist->filterMediaNameLogicalOperator,
@@ -146,9 +147,11 @@ class DynamicPlaylistSyncTask implements TaskInterface
                     'userCheckUserId' => $playlist->getOwnerId(),
                     'start' => 0,
                     'length' => $playlist->maxNumberOfItems
-                ]) as $item) {
+                ]) as $index => $item) {
                     $media[$item->mediaId] = $item;
                     $mediaIds[] = $item->mediaId;
+                    // store the expected display order
+                    $displayOrder[$item->mediaId] = $index + 1;
                 }
 
                 // Work out if the set of widgets is different or not.
@@ -250,7 +253,8 @@ class DynamicPlaylistSyncTask implements TaskInterface
                                 break;
                             }
                             $assignmentMade = true;
-                            $this->createAndAssign($playlist, $item, $count);
+                            // make sure we pass the expected displayOrder for the new item we are about to add.
+                            $this->createAndAssign($playlist, $item,  $displayOrder[$item->mediaId]);
                         }
                     }
 
@@ -319,6 +323,7 @@ class DynamicPlaylistSyncTask implements TaskInterface
         $widget->assignMedia($media->mediaId);
 
         // Assign the widget to the playlist
-        $playlist->assignWidget($widget);
+        // making sure we pass the displayOrder here, otherwise it would be added to the end of the array.
+        $playlist->assignWidget($widget, $displayOrder);
     }
 }


### PR DESCRIPTION
- Widget : on delete of a drawer Widget, make sure we do not delete the whole action, just remove the widgetId from the record.
- Playlists : Fix various displayOrder issues after replacing, removing and the re-adding files that match Dynamic Playlist filters