### PR TITLE
Schedule grid filter improvements and Folder css adjustments

### DIFF
--- a/lib/Controller/Schedule.php
+++ b/lib/Controller/Schedule.php
@@ -2235,6 +2235,8 @@ class Schedule extends Base
                 'name' => $params->getString('name'),
                 'useRegexForName' => $params->getCheckbox('useRegexForName'),
                 'logicalOperatorName' => $params->getString('logicalOperatorName'),
+                'directSchedule' => $params->getCheckbox('directSchedule'),
+                'sharedSchedule' => $params->getCheckbox('sharedSchedule'),
                 'gridFilter' => 1,
             ], $params)
         );

--- a/lib/Factory/ScheduleFactory.php
+++ b/lib/Factory/ScheduleFactory.php
@@ -486,13 +486,41 @@ class ScheduleFactory extends BaseFactory
         // End both dates
 
         if ($parsedFilter->getIntArray('displayGroupIds') != null) {
+            // parameterize the selected display/groups and number of selected display/groups
+            $selectedDisplayGroupIds = implode(',', $parsedFilter->getIntArray('displayGroupIds'));
+            $numberOfSelectedDisplayGroups = count($parsedFilter->getIntArray('displayGroupIds'));
+
+            // build date filter for sub-queries for shared schedules
+            $sharedScheduleDateFilter = '';
+            if ($parsedFilter->getInt('futureSchedulesFrom') !== null
+                && $parsedFilter->getInt('futureSchedulesTo') === null
+            ) {
+                // Get schedules that end after this date, or that recur after this date
+                $sharedScheduleDateFilter .= ' AND (IFNULL(`schedule`.toDt, `schedule`.fromDt) >= :futureSchedulesFrom
+             OR `schedule`.recurrence_range >= :futureSchedulesFrom OR (IFNULL(`schedule`.recurrence_range, 0) = 0)
+              AND IFNULL(`schedule`.recurrence_type, \'\') <> \'\') ';
+                $params['futureSchedulesFrom'] = $parsedFilter->getInt('futureSchedulesFrom');
+            }
+
+            if ($parsedFilter->getInt('futureSchedulesFrom') !== null
+                && $parsedFilter->getInt('futureSchedulesTo') !== null
+            ) {
+                // Get schedules that end after this date, or that recur after this date
+                $sharedScheduleDateFilter .= ' AND ((schedule.fromDt < :futureSchedulesTo 
+            AND IFNULL(`schedule`.toDt, `schedule`.fromDt) >= :futureSchedulesFrom)
+             OR `schedule`.recurrence_range >= :futureSchedulesFrom OR (IFNULL(`schedule`.recurrence_range, 0) = 0
+              AND IFNULL(`schedule`.recurrence_type, \'\') <> \'\') ) ';
+                $params['futureSchedulesFrom'] = $parsedFilter->getInt('futureSchedulesFrom');
+                $params['futureSchedulesTo'] = $parsedFilter->getInt('futureSchedulesTo');
+            }
+
             // non Schedule grid filter, keep it the way it was.
             if ($parsedFilter->getInt('sharedSchedule') === null &&
                 $parsedFilter->getInt('directSchedule') === null
             ) {
                 $body .= ' AND `schedule`.eventId IN (
                     SELECT `lkscheduledisplaygroup`.eventId FROM `lkscheduledisplaygroup`
-                    WHERE displayGroupId IN (' . implode(',', $parsedFilter->getIntArray('displayGroupIds')) . ')
+                    WHERE displayGroupId IN (' . $selectedDisplayGroupIds . ')
                      ) ';
             } else {
                 // Schedule grid query
@@ -506,11 +534,14 @@ class ScheduleFactory extends BaseFactory
                 // Example : Two Displays selected, return only events scheduled directly to both of them
                 if ($sharedSchedule && $directSchedule) {
                     $body .= ' AND `schedule`.eventId IN (
-                        SELECT `lkscheduledisplaygroup`.eventId FROM `lkscheduledisplaygroup`
-                          WHERE displayGroupId IN (' . implode(',', $parsedFilter->getIntArray('displayGroupIds')) . ')
+                        SELECT `lkscheduledisplaygroup`.eventId
+                         FROM `lkscheduledisplaygroup`
+                          INNER JOIN `schedule` ON `schedule`.eventId = `lkscheduledisplaygroup`.eventId
+                          WHERE displayGroupId IN (' . $selectedDisplayGroupIds . ')' .
+                        $sharedScheduleDateFilter . '
                           GROUP BY eventId
                           HAVING COUNT(DISTINCT displayGroupId) >= ' .
-                        count($parsedFilter->getIntArray('displayGroupIds')) .
+                        $numberOfSelectedDisplayGroups .
                         ') ';
                 }
 
@@ -522,36 +553,41 @@ class ScheduleFactory extends BaseFactory
                 // Example : Two Displays selected, return only events scheduled directly to both of them
                 if ($sharedSchedule && !$directSchedule) {
                     $body .= ' AND (
-                        ( `schedule`.eventId IN (SELECT `lkscheduledisplaygroup`.eventId FROM `lkscheduledisplaygroup`
-                         WHERE displayGroupId IN (' . implode(',', $parsedFilter->getIntArray('displayGroupIds')) . ')
+                        ( `schedule`.eventId IN (
+                        SELECT `lkscheduledisplaygroup`.eventId 
+                        FROM `lkscheduledisplaygroup`
+                         INNER JOIN `schedule` ON `schedule`.eventId = `lkscheduledisplaygroup`.eventId
+                         WHERE displayGroupId IN (' . $selectedDisplayGroupIds . ')' .
+                         $sharedScheduleDateFilter . '
                           GROUP BY eventId
-                          HAVING COUNT(DISTINCT displayGroupId) >= ' .
-                        count($parsedFilter->getIntArray('displayGroupIds')) . '
-                          ))
+                          HAVING COUNT(DISTINCT displayGroupId) >= ' . $numberOfSelectedDisplayGroups . '
+                        ))
                         OR `schedule`.eventID IN (
                         SELECT `lkscheduledisplaygroup`.eventId FROM `lkscheduledisplaygroup`
+                            INNER JOIN `schedule` ON `schedule`.eventId = `lkscheduledisplaygroup`.eventId
                             INNER JOIN `lkdgdg` ON `lkdgdg`.parentId = `lkscheduledisplaygroup`.displayGroupId 
                             INNER JOIN `lkdisplaydg` ON lkdisplaydg.DisplayGroupID = `lkdgdg`.childId
                             WHERE `lkdisplaydg`.DisplayID IN (
                                 SELECT lkdisplaydg.displayId FROM lkdisplaydg
                                  INNER JOIN displaygroup ON lkdisplaydg.displayGroupId = displaygroup.displayGroupId 
-                                 WHERE lkdisplaydg.displayGroupId IN ('
-                        . implode(',', $parsedFilter->getIntArray('displayGroupIds')) . ')
-                            AND displaygroup.isDisplaySpecific = 1 ) 
+                                 WHERE lkdisplaydg.displayGroupId IN (' . $selectedDisplayGroupIds . ')
+                            AND displaygroup.isDisplaySpecific = 1 ) ' .
+                            $sharedScheduleDateFilter . '
                             GROUP BY eventId
                             HAVING COUNT(DISTINCT `lkdisplaydg`.displayId) >= ' .
-                        count($parsedFilter->getIntArray('displayGroupIds')) . '
+                            $numberOfSelectedDisplayGroups . '
                         )
                         OR `schedule`.eventID IN (
                             SELECT `lkscheduledisplaygroup`.eventId FROM `lkscheduledisplaygroup`
+                            INNER JOIN `schedule` ON `schedule`.eventId = `lkscheduledisplaygroup`.eventId
                             INNER JOIN `lkdgdg` ON `lkdgdg`.parentId = `lkscheduledisplaygroup`.displayGroupId
                             WHERE `lkscheduledisplaygroup`.displayGroupId IN (
-                            SELECT lkdgdg.childId FROM lkdgdg WHERE lkdgdg.parentId IN (' .
-                        implode(',', $parsedFilter->getIntArray('displayGroupIds')) .') 
-                                AND lkdgdg.depth > 0)
+                            SELECT lkdgdg.childId FROM lkdgdg
+                             WHERE lkdgdg.parentId IN (' . $selectedDisplayGroupIds .')  AND lkdgdg.depth > 0)' .
+                            $sharedScheduleDateFilter . '
                             GROUP BY eventId
                             HAVING COUNT(DISTINCT `lkscheduledisplaygroup`.displayGroupId) >= ' .
-                        count($parsedFilter->getIntArray('displayGroupIds')) . '    
+                            $numberOfSelectedDisplayGroups . '    
                         )
                      ) ';
                 }
@@ -561,7 +597,7 @@ class ScheduleFactory extends BaseFactory
                 if (!$sharedSchedule && $directSchedule) {
                     $body .= ' AND `schedule`.eventId IN (
                     SELECT `lkscheduledisplaygroup`.eventId FROM `lkscheduledisplaygroup`
-                    WHERE displayGroupId IN (' . implode(',', $parsedFilter->getIntArray('displayGroupIds')) . ')
+                    WHERE displayGroupId IN (' . $selectedDisplayGroupIds . ')
                      ) ';
                 }
 
@@ -572,8 +608,7 @@ class ScheduleFactory extends BaseFactory
                 if (!$sharedSchedule && !$directSchedule) {
                     $body .= ' AND (
                         ( `schedule`.eventId IN (SELECT `lkscheduledisplaygroup`.eventId FROM `lkscheduledisplaygroup`
-                         WHERE displayGroupId IN (' .
-                        implode(',', $parsedFilter->getIntArray('displayGroupIds')) . ')) )
+                         WHERE displayGroupId IN (' . $selectedDisplayGroupIds . ')) )
                         OR `schedule`.eventID IN (
                         SELECT `lkscheduledisplaygroup`.eventId FROM `lkscheduledisplaygroup`
                             INNER JOIN `lkdgdg` ON `lkdgdg`.parentId = `lkscheduledisplaygroup`.displayGroupId 
@@ -581,17 +616,15 @@ class ScheduleFactory extends BaseFactory
                             WHERE `lkdisplaydg`.DisplayID IN (
                                 SELECT lkdisplaydg.displayId FROM lkdisplaydg 
                                 INNER JOIN displaygroup ON lkdisplaydg.displayGroupId = displaygroup.displayGroupId
-                                 WHERE lkdisplaydg.displayGroupId IN ('
-                        . implode(',', $parsedFilter->getIntArray('displayGroupIds')) . ')
+                                 WHERE lkdisplaydg.displayGroupId IN (' . $selectedDisplayGroupIds . ')
                             AND displaygroup.isDisplaySpecific = 1 ) 
                         )
                         OR `schedule`.eventID IN (
                                 SELECT `lkscheduledisplaygroup`.eventId FROM `lkscheduledisplaygroup`
                                 INNER JOIN `lkdgdg` ON `lkdgdg`.parentId = `lkscheduledisplaygroup`.displayGroupId
                                 WHERE `lkscheduledisplaygroup`.displayGroupId IN (
-                                SELECT lkdgdg.childId FROM lkdgdg WHERE lkdgdg.parentId IN (' .
-                        implode(',', $parsedFilter->getIntArray('displayGroupIds')) .') 
-                                    AND lkdgdg.depth > 0)  
+                                SELECT lkdgdg.childId FROM lkdgdg 
+                                WHERE lkdgdg.parentId IN (' . $selectedDisplayGroupIds .')  AND lkdgdg.depth > 0)  
                         )
                      ) ';
                 }

--- a/views/campaign-page.twig
+++ b/views/campaign-page.twig
@@ -86,23 +86,25 @@
                 </div>
 
                 <div class="row">
-                    <div class="col-sm-2 p-3 bg-light" id="grid-folder-filter">
-                        <input id="jstree-search" class="form-control" type="text" placeholder="{% trans "Search" %}">
-                        <div class="form-check">
-                            <input type="checkbox" class="form-check-input" id="folder-tree-clear-selection-button">
-                            <label class="form-check-label" for="folder-tree-clear-selection-button" title="{% trans "Search in all folders" %}">{% trans "All Folders" %}</label>
+                    <div class="col-sm-2 grid-folder-tree-container" id="grid-folder-filter">
+                        <div class="p-3 mr-2">
+                            <input id="jstree-search" class="form-control" type="text" placeholder="{% trans "Search" %}">
+                            <div class="form-check">
+                                <input type="checkbox" class="form-check-input" id="folder-tree-clear-selection-button">
+                                <label class="form-check-label" for="folder-tree-clear-selection-button" title="{% trans "Search in all folders" %}">{% trans "All Folders" %}</label>
+                            </div>
+                            <div class="folder-search-no-results d-none">
+                                <p>{% trans 'No Folders matching the search term' %}</p>
+                            </div>
+                            <div id="container-folder-tree"></div>
                         </div>
-                        <div class="folder-search-no-results d-none">
-                            <p>{% trans 'No Folders matching the search term' %}</p>
-                        </div>
-                        <div id="container-folder-tree"></div>
                     </div>
                     <div class="folder-controller d-none">
                         <button type="button" id="folder-tree-select-folder-button" class="btn btn-outline-secondary" title="{% trans "Open / Close Folder Search options" %}"><i class="fas fa-folder fa-1x"></i></button>
                         <div id="breadcrumbs" class="mt-2 pl-2"></div>
                     </div>
-                    <div id="datatable-container" class="card col-sm-10 pt-4 px-2">
-                        <div class="XiboData">
+                    <div id="datatable-container" class="col-sm-10 pr-0">
+                        <div class="XiboData card pt-4 px-2">
                             <table id="campaigns" class="table table-striped" data-content-type="campaign" data-content-id-name="campaignId" data-state-preference-name="campaignGrid" style="width: 100%;">
                                 <thead>
                                     <tr>

--- a/views/dataset-page.twig
+++ b/views/dataset-page.twig
@@ -59,23 +59,25 @@
                 </div>
 
                 <div class="row">
-                    <div class="col-sm-2 p-3 bg-light" id="grid-folder-filter">
-                        <input id="jstree-search" class="form-control" type="text" placeholder="{% trans "Search" %}">
-                        <div class="form-check">
-                            <input type="checkbox" class="form-check-input" id="folder-tree-clear-selection-button">
-                            <label class="form-check-label" for="folder-tree-clear-selection-button" title="{% trans "Search in all folders" %}">{% trans "All Folders" %}</label>
+                    <div class="col-sm-2 grid-folder-tree-container" id="grid-folder-filter">
+                        <div class="p-3 mr-2">
+                            <input id="jstree-search" class="form-control" type="text" placeholder="{% trans "Search" %}">
+                            <div class="form-check">
+                                <input type="checkbox" class="form-check-input" id="folder-tree-clear-selection-button">
+                                <label class="form-check-label" for="folder-tree-clear-selection-button" title="{% trans "Search in all folders" %}">{% trans "All Folders" %}</label>
+                            </div>
+                            <div class="folder-search-no-results d-none">
+                                <p>{% trans 'No Folders matching the search term' %}</p>
+                            </div>
+                            <div id="container-folder-tree"></div>
                         </div>
-                        <div class="folder-search-no-results d-none">
-                            <p>{% trans 'No Folders matching the search term' %}</p>
-                        </div>
-                        <div id="container-folder-tree"></div>
                     </div>
                     <div class="folder-controller d-none">
                         <button type="button" id="folder-tree-select-folder-button" class="btn btn-outline-secondary" title="{% trans "Open / Close Folder Search options" %}"><i class="fas fa-folder fa-1x"></i></button>
                         <div id="breadcrumbs" class="mt-2 pl-2"></div>
                     </div>
-                    <div id="datatable-container" class="card col-sm-10 pt-4 px-2">
-                        <div class="XiboData">
+                    <div id="datatable-container" class="col-sm-10 pr-0">
+                        <div class="XiboData card pt-4 px-2">
                             <table id="datasets" class="table table-striped" data-state-preference-name="dataSetGrid" style="width: 100%;">
                                 <thead>
                                     <tr>

--- a/views/display-page.twig
+++ b/views/display-page.twig
@@ -178,16 +178,18 @@
                     </div>
                 </div>
                 <div class="row">
-                    <div class="col-sm-2 p-3 bg-light" id="grid-folder-filter">
-                        <input id="jstree-search" class="form-control" type="text" placeholder="{% trans "Search" %}">
-                        <div class="form-check">
-                            <input type="checkbox" class="form-check-input" id="folder-tree-clear-selection-button">
-                            <label class="form-check-label" for="folder-tree-clear-selection-button" title="{% trans "Search in all folders" %}">{% trans "All Folders" %}</label>
+                    <div class="col-sm-2 grid-folder-tree-container" id="grid-folder-filter">
+                        <div class="p-3 mr-2">
+                            <input id="jstree-search" class="form-control" type="text" placeholder="{% trans "Search" %}">
+                            <div class="form-check">
+                                <input type="checkbox" class="form-check-input" id="folder-tree-clear-selection-button">
+                                <label class="form-check-label" for="folder-tree-clear-selection-button" title="{% trans "Search in all folders" %}">{% trans "All Folders" %}</label>
+                            </div>
+                            <div class="folder-search-no-results d-none">
+                                <p>{% trans 'No Folders matching the search term' %}</p>
+                            </div>
+                            <div id="container-folder-tree"></div>
                         </div>
-                        <div class="folder-search-no-results d-none">
-                            <p>{% trans 'No Folders matching the search term' %}</p>
-                        </div>
-                        <div id="container-folder-tree"></div>
                     </div>
                     <div class="folder-controller d-none">
                         <button type="button" id="folder-tree-select-folder-button" class="btn btn-outline-secondary" title="{{ "Open / Close Folder Search options"|trans }}"><i class="fas fa-folder fa-1x"></i></button>
@@ -200,8 +202,8 @@
                         <button type="button" id="list_button" class="btn btn-primary" title="{{ "List"|trans }}"><i class="fa fa-list"></i></button>
                     </div>
 
-                    <div id="datatable-container" class="card col-sm-10 pt-4 px-2">
-                        <div class="XiboData">
+                    <div id="datatable-container" class="col-sm-10 pr-0">
+                        <div class="XiboData card pt-4 px-2">
                             <table id="displays" class="table table-striped" data-content-type="display" data-content-id-name="displayId" data-state-preference-name="displayGrid" style="width: 100%;">
                                 <thead>
                                     <tr>

--- a/views/displaygroup-page.twig
+++ b/views/displaygroup-page.twig
@@ -83,23 +83,25 @@
                     </div>
                 </div>
                 <div class="row">
-                    <div class="col-sm-2 p-3 bg-light" id="grid-folder-filter">
-                        <input id="jstree-search" class="form-control" type="text" placeholder="{% trans "Search" %}">
-                        <div class="form-check">
-                            <input type="checkbox" class="form-check-input" id="folder-tree-clear-selection-button">
-                            <label class="form-check-label" for="folder-tree-clear-selection-button" title="{% trans "Search in all folders" %}">{% trans "All Folders" %}</label>
+                    <div class="col-sm-2 grid-folder-tree-container" id="grid-folder-filter">
+                        <div class="p-3 mr-2">
+                            <input id="jstree-search" class="form-control" type="text" placeholder="{% trans "Search" %}">
+                            <div class="form-check">
+                                <input type="checkbox" class="form-check-input" id="folder-tree-clear-selection-button">
+                                <label class="form-check-label" for="folder-tree-clear-selection-button" title="{% trans "Search in all folders" %}">{% trans "All Folders" %}</label>
+                            </div>
+                            <div class="folder-search-no-results d-none">
+                                <p>{% trans 'No Folders matching the search term' %}</p>
+                            </div>
+                            <div id="container-folder-tree"></div>
                         </div>
-                        <div class="folder-search-no-results d-none">
-                            <p>{% trans 'No Folders matching the search term' %}</p>
-                        </div>
-                        <div id="container-folder-tree"></div>
                     </div>
                     <div class="folder-controller d-none">
                         <button type="button" id="folder-tree-select-folder-button" class="btn btn-outline-secondary" title="{% trans "Open / Close Folder Search options" %}"><i class="fas fa-folder fa-1x"></i></button>
                         <div id="breadcrumbs" class="mt-2 pl-2"></div>
                     </div>
-                    <div id="datatable-container" class="card col-sm-10 pt-4 px-2">
-                        <div class="XiboData">
+                    <div id="datatable-container" class="col-sm-10 pr-0">
+                        <div class="XiboData card pt-4 px-2">
                             <table id="displaygroups" class="table table-striped" data-content-type="displayGroup" data-content-id-name="displayGroupId" data-state-preference-name="displayGroupGrid" style="width: 100%;">
                                 <thead>
                                     <tr>

--- a/views/layout-page.twig
+++ b/views/layout-page.twig
@@ -112,16 +112,18 @@
                 </div>
 
                 <div class="row">
-                    <div class="col-sm-2 p-3 bg-light" id="grid-folder-filter">
-                        <input id="jstree-search" class="form-control" type="text" placeholder="{% trans "Search" %}">
-                        <div class="form-check">
-                            <input type="checkbox" class="form-check-input" id="folder-tree-clear-selection-button">
-                            <label class="form-check-label" for="folder-tree-clear-selection-button" title="{% trans "Search in all folders" %}">{% trans "All Folders" %}</label>
+                    <div class="col-sm-2 grid-folder-tree-container" id="grid-folder-filter">
+                        <div class="p-3 mr-2">
+                            <input id="jstree-search" class="form-control" type="text" placeholder="{% trans "Search" %}">
+                            <div class="form-check">
+                                <input type="checkbox" class="form-check-input" id="folder-tree-clear-selection-button">
+                                <label class="form-check-label" for="folder-tree-clear-selection-button" title="{% trans "Search in all folders" %}">{% trans "All Folders" %}</label>
+                            </div>
+                            <div class="folder-search-no-results d-none">
+                                <p>{% trans 'No Folders matching the search term' %}</p>
+                            </div>
+                            <div id="container-folder-tree"></div>
                         </div>
-                        <div class="folder-search-no-results d-none">
-                            <p>{% trans 'No Folders matching the search term' %}</p>
-                        </div>
-                        <div id="container-folder-tree"></div>
                     </div>
 
                     <div class="folder-controller d-none">
@@ -129,8 +131,8 @@
                         <div id="breadcrumbs" class="mt-2 pl-2"></div>
                     </div>
 
-                    <div id="datatable-container" class="card col-sm-10 pt-4 px-2">
-                        <div class="XiboData">
+                    <div id="datatable-container" class="col-sm-10 pr-0">
+                        <div class="XiboData card pt-4 px-2">
                             <table id="layouts" class="table table-striped responsive nowrap" data-content-type="layout" data-content-id-name="layoutId" data-state-preference-name="layoutGrid" style="width: 100%;">
                                 <thead>
                                     <tr>

--- a/views/library-page.twig
+++ b/views/library-page.twig
@@ -98,23 +98,25 @@
                     </div>
                 </div>
                 <div class="row">
-                    <div class="col-sm-2 p-3 bg-light" id="grid-folder-filter">
-                        <input id="jstree-search" class="form-control" type="text" placeholder="{% trans "Search" %}">
-                        <div class="form-check">
-                            <input type="checkbox" class="form-check-input" id="folder-tree-clear-selection-button">
-                            <label class="form-check-label" for="folder-tree-clear-selection-button" title="{% trans "Search in all folders" %}">{% trans "All Folders" %}</label>
+                    <div class="col-sm-2 grid-folder-tree-container" id="grid-folder-filter">
+                        <div class="p-3 mr-2">
+                            <input id="jstree-search" class="form-control" type="text" placeholder="{% trans "Search" %}">
+                            <div class="form-check">
+                                <input type="checkbox" class="form-check-input" id="folder-tree-clear-selection-button">
+                                <label class="form-check-label" for="folder-tree-clear-selection-button" title="{% trans "Search in all folders" %}">{% trans "All Folders" %}</label>
+                            </div>
+                            <div class="folder-search-no-results d-none">
+                                <p>{% trans 'No Folders matching the search term' %}</p>
+                            </div>
+                            <div id="container-folder-tree"></div>
                         </div>
-                        <div class="folder-search-no-results d-none">
-                            <p>{% trans 'No Folders matching the search term' %}</p>
-                        </div>
-                        <div id="container-folder-tree"></div>
                     </div>
                     <div class="folder-controller d-none">
                         <button type="button" id="folder-tree-select-folder-button" class="btn btn-outline-secondary" title="{% trans "Open / Close Folder Search options" %}"><i class="fas fa-folder fa-1x"></i></button>
                         <div id="breadcrumbs" class="mt-2 pl-2"></div>
                     </div>
-                    <div id="datatable-container" class="card col-sm-10 pt-4 px-2">
-                        <div class="XiboData">
+                    <div id="datatable-container" class="col-sm-10 pr-0">
+                        <div class="XiboData card pt-4 px-2">
                             <table id="libraryItems" class="table table-striped responsive nowrap" data-content-type="media" data-content-id-name="mediaId" data-state-preference-name="libraryGrid" style="width: 100%;">
                                 <thead>
                                 <tr>

--- a/views/menuboard-page.twig
+++ b/views/menuboard-page.twig
@@ -74,19 +74,21 @@
                 </div>
 
                 <div class="row">
-                    <div class="col-sm-2 p-3 bg-light" id="grid-folder-filter">
-                        <input id="jstree-search" class="form-control" type="text" placeholder="{% trans "Search" %}">
-                        <div class="form-check">
-                            <input type="checkbox" class="form-check-input" id="folder-tree-clear-selection-button">
-                            <label class="form-check-label" for="folder-tree-clear-selection-button" title="{% trans "Search in all folders" %}">{% trans "All Folders" %}</label>
+                    <div class="col-sm-2 grid-folder-tree-container" id="grid-folder-filter">
+                        <div class="p-3 mr-2">
+                            <input id="jstree-search" class="form-control" type="text" placeholder="{% trans "Search" %}">
+                            <div class="form-check">
+                                <input type="checkbox" class="form-check-input" id="folder-tree-clear-selection-button">
+                                <label class="form-check-label" for="folder-tree-clear-selection-button" title="{% trans "Search in all folders" %}">{% trans "All Folders" %}</label>
+                            </div>
+                            <div class="folder-search-no-results d-none">
+                                <p>{% trans 'No Folders matching the search term' %}</p>
+                            </div>
+                            <div id="container-folder-tree"></div>
                         </div>
-                        <div class="folder-search-no-results d-none">
-                            <p>{% trans 'No Folders matching the search term' %}</p>
-                        </div>
-                        <div id="container-folder-tree"></div>
                     </div>
-                    <div id="datatable-container" class="card col-sm-10 pt-4 px-2">
-                        <div class="XiboData">
+                    <div id="datatable-container" class="col-sm-10 pr-0">
+                        <div class="XiboData card pt-4 px-2">
                             <table id="menuBoards" class="table table-striped responsive nowrap" data-content-type="menuBoard" data-content-id-name="menuId" data-state-preference-name="menuBoardGrid" style="width: 100%;">
                                 <thead>
                                 <tr>

--- a/views/playlist-page.twig
+++ b/views/playlist-page.twig
@@ -92,23 +92,25 @@
                 </div>
 
                 <div class="row">
-                    <div class="col-sm-2 p-3 bg-light" id="grid-folder-filter">
-                        <input id="jstree-search" class="form-control" type="text" placeholder="{% trans "Search" %}">
-                        <div class="form-check">
-                            <input type="checkbox" class="form-check-input" id="folder-tree-clear-selection-button">
-                            <label class="form-check-label" for="folder-tree-clear-selection-button" title="{% trans "Search in all folders" %}">{% trans "All Folders" %}</label>
+                    <div class="col-sm-2 grid-folder-tree-container" id="grid-folder-filter">
+                        <div class="p-3 mr-2">
+                            <input id="jstree-search" class="form-control" type="text" placeholder="{% trans "Search" %}">
+                            <div class="form-check">
+                                <input type="checkbox" class="form-check-input" id="folder-tree-clear-selection-button">
+                                <label class="form-check-label" for="folder-tree-clear-selection-button" title="{% trans "Search in all folders" %}">{% trans "All Folders" %}</label>
+                            </div>
+                            <div class="folder-search-no-results d-none">
+                                <p>{% trans 'No Folders matching the search term' %}</p>
+                            </div>
+                            <div id="container-folder-tree"></div>
                         </div>
-                        <div class="folder-search-no-results d-none">
-                            <p>{% trans 'No Folders matching the search term' %}</p>
-                        </div>
-                        <div id="container-folder-tree"></div>
                     </div>
                     <div class="folder-controller d-none">
                         <button type="button" id="folder-tree-select-folder-button" class="btn btn-outline-secondary" title="{% trans "Open / Close Folder Search options" %}"><i class="fas fa-folder fa-1x"></i></button>
                         <div id="breadcrumbs" class="mt-2 pl-2"></div>
                     </div>
-                    <div id="datatable-container" class="card col-sm-10 pt-4 px-2">
-                        <div class="XiboData">
+                    <div id="datatable-container" class="col-sm-10 pr-0">
+                        <div class="XiboData card pt-4 px-2">
                             <table id="playlists" class="table table-striped" data-content-type="playlist"
                                    data-content-id-name="playlistId" data-state-preference-name="playlistGrid" style="width: 100%;">
                                 <thead>

--- a/views/schedule-page.twig
+++ b/views/schedule-page.twig
@@ -128,7 +128,7 @@
                             </div>
 
                             {% set title %}{% trans "Display Groups" %}{% endset %}
-                            <div class="form-group mr-1 mb-1 pagedSelect" style="min-width: 200px">
+                            <div class="form-group mr-2 mb-1 pagedSelect" style="min-width: 200px">
                                 <label class="control-label mr-1" for="DisplayGroupList" title=""
                                        accesskey="">{{ title }}</label>
                                 <select id="DisplayGroupList" class="form-control" name="displayGroupIds[]"
@@ -147,6 +147,37 @@
                                     {% endfor %}
                                 </select>
                             </div>
+
+                            {% set label %}{% trans "Direct Schedule?" %}{% endset %}
+                            {% set title %}{% trans "Show only events scheduled directly on selected Displays/Groups" %}{% endset %}
+                            <div class="form-group mr-1 mb-1">
+                                <label class="control-label mr-1" title="{{ title }}" for="directSchedule" accesskey="">{{ label }}</label>
+                                <div>
+                                    <div class="input-group" style="height: 34px">
+                                        <div class="input-group-append input-group-addon">
+                                            <div class="input-group-text">
+                                                <input title="{{ title }}" type="checkbox" id="directSchedule" name="directSchedule">
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+
+                            {% set title %}{% trans "Only show schedules which appear on all filtered displays/groups?" %}{% endset %}
+                            {% set label %}{% trans "Shared Schedule?" %}{% endset %}
+                            <div class="form-group mr-1 mb-1">
+                                <label class="control-label mr-1" title="{{ title }}" for="directSchedule" accesskey="">{{ label }}</label>
+                                <div>
+                                    <div class="input-group" style="height: 34px">
+                                        <div class="input-group-append input-group-addon">
+                                            <div class="input-group-text">
+                                                <input title="{{ title }}" type="checkbox" id="sharedSchedule" name="sharedSchedule">
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+
                             {% set title %}{% trans 'Geo Aware?' %}{% endset %}
                             {% set options = [
                                 { id: null, name: "Both"|trans },

--- a/views/syncgroup-page.twig
+++ b/views/syncgroup-page.twig
@@ -56,23 +56,25 @@
                     </div>
                 </div>
                 <div class="row">
-                    <div class="col-sm-2 p-3 bg-light" id="grid-folder-filter">
-                        <input id="jstree-search" class="form-control" type="text" placeholder="{% trans "Search" %}">
-                        <div class="form-check">
-                            <input type="checkbox" class="form-check-input" id="folder-tree-clear-selection-button">
-                            <label class="form-check-label" for="folder-tree-clear-selection-button" title="{% trans "Search in all folders" %}">{% trans "All Folders" %}</label>
+                    <div class="col-sm-2 grid-folder-tree-container" id="grid-folder-filter">
+                        <div class="p-3 mr-2">
+                            <input id="jstree-search" class="form-control" type="text" placeholder="{% trans "Search" %}">
+                            <div class="form-check">
+                                <input type="checkbox" class="form-check-input" id="folder-tree-clear-selection-button">
+                                <label class="form-check-label" for="folder-tree-clear-selection-button" title="{% trans "Search in all folders" %}">{% trans "All Folders" %}</label>
+                            </div>
+                            <div class="folder-search-no-results d-none">
+                                <p>{% trans 'No Folders matching the search term' %}</p>
+                            </div>
+                            <div id="container-folder-tree"></div>
                         </div>
-                        <div class="folder-search-no-results d-none">
-                            <p>{% trans 'No Folders matching the search term' %}</p>
-                        </div>
-                        <div id="container-folder-tree"></div>
                     </div>
                     <div class="folder-controller d-none">
                         <button type="button" id="folder-tree-select-folder-button" class="btn btn-outline-secondary" title="{% trans "Open / Close Folder Search options" %}"><i class="fas fa-folder fa-1x"></i></button>
                         <div id="breadcrumbs" class="mt-2 pl-2"></div>
                     </div>
-                    <div id="datatable-container" class="card col-sm-10 pt-4 px-2">
-                        <div class="XiboData">
+                    <div id="datatable-container" class="col-sm-10 pr-0">
+                        <div class="XiboData card pt-4 px-2">
                             <table id="syncgroups" class="table table-striped" data-content-type="syncGroup" data-content-id-name="syncGroupId" data-state-preference-name="syncGroupGrid" style="width: 100%;">
                                 <thead>
                                 <tr>

--- a/views/template-page.twig
+++ b/views/template-page.twig
@@ -57,23 +57,25 @@
                     </div>
                 </div>
                 <div class="row">
-                    <div class="col-sm-2 p-3 bg-light" id="grid-folder-filter">
-                        <input id="jstree-search" class="form-control" type="text" placeholder="{% trans "Search" %}">
-                        <div class="form-check">
-                            <input type="checkbox" class="form-check-input" id="folder-tree-clear-selection-button">
-                            <label class="form-check-label" for="folder-tree-clear-selection-button" title="{% trans "Search in all folders" %}">{% trans "All Folders" %}</label>
+                    <div class="col-sm-2 grid-folder-tree-container" id="grid-folder-filter">
+                        <div class="p-3 mr-2">
+                            <input id="jstree-search" class="form-control" type="text" placeholder="{% trans "Search" %}">
+                            <div class="form-check">
+                                <input type="checkbox" class="form-check-input" id="folder-tree-clear-selection-button">
+                                <label class="form-check-label" for="folder-tree-clear-selection-button" title="{% trans "Search in all folders" %}">{% trans "All Folders" %}</label>
+                            </div>
+                            <div class="folder-search-no-results d-none">
+                                <p>{% trans 'No Folders matching the search term' %}</p>
+                            </div>
+                            <div id="container-folder-tree"></div>
                         </div>
-                        <div class="folder-search-no-results d-none">
-                            <p>{% trans 'No Folders matching the search term' %}</p>
-                        </div>
-                        <div id="container-folder-tree"></div>
                     </div>
                     <div class="folder-controller d-none">
                         <button type="button" id="folder-tree-select-folder-button" class="btn btn-outline-secondary" title="{% trans "Open / Close Folder Search options" %}"><i class="fas fa-folder fa-1x"></i></button>
                         <div id="breadcrumbs" class="mt-2 pl-2"></div>
                     </div>
-                    <div id="datatable-container" class="card col-sm-10 pt-4 px-2">
-                        <div class="XiboData">
+                    <div id="datatable-container" class="col-sm-10 pr-0">
+                        <div class="XiboData card pt-4 px-2">
                             <table id="templates" class="table table-striped" data-content-type="layout" data-content-id-name="layoutId" data-state-preference-name="templateGrid">
                                 <thead>
                                     <tr>

--- a/web/theme/default/css/xibo.css
+++ b/web/theme/default/css/xibo.css
@@ -1518,3 +1518,8 @@ div.dataTables_wrapper div.dataTables_info {
 .text-xibo-primary {
     color: #0E70F6;
 }
+
+.grid-folder-tree-container {
+    border: 1px solid #00000020;
+    border-radius: 0.25rem;
+}


### PR DESCRIPTION
- Folders : few css adjustments to the folder tree next to grids on relevant pages
- Schedule : Added two new filters directSchedule and sharedSchedule
-- Direct Schedule when enabled is pretty much they way it works now, when disabled we should also see for example: any events scheduled to the displayGroup selected Display is a member of
-- Shared Schedule should show only events that are scheduled to all selected Displays/Groups ie it requires for example at least two Displays to be selected to show any events that are scheduled to both of them.