### PR TITLE
Layout editor viewer: Element Groups with layer 0 show out of order

### DIFF
--- a/ui/src/layout-editor/viewer.js
+++ b/ui/src/layout-editor/viewer.js
@@ -1453,7 +1453,7 @@ Viewer.prototype.renderElement = function(
     });
 
     // Update element group index
-    if (element.group.layer) {
+    if (element.group.layer != undefined) {
       $groupContainer.css({
         'z-index': element.group.layer,
       });


### PR DESCRIPTION
relates to xibosignage/xibo#3221