### PR TITLE
Auth: serialise logic for oAuth objects in session xibosignage/xibo#3184

### DIFF
--- a/lib/Entity/Application.php
+++ b/lib/Entity/Application.php
@@ -1,8 +1,8 @@
 <?php
 /*
- * Copyright (c) 2022 Xibo Signage Ltd
+ * Copyright (C) 2023 Xibo Signage Ltd
  *
- * Xibo - Digital Signage - http://www.xibo.org.uk
+ * Xibo - Digital Signage - https://xibosignage.com
  *
  * This file is part of Xibo.
  *
@@ -164,6 +164,18 @@ class Application implements \JsonSerializable, ClientEntityInterface
 
         $this->applicationRedirectUriFactory = $applicationRedirectUriFactory;
         $this->applicationScopeFactory = $applicationScopeFactory;
+    }
+
+    public function __serialize(): array
+    {
+        return $this->jsonSerialize();
+    }
+
+    public function __unserialize(array $data): void
+    {
+        foreach ($data as $key => $value) {
+            $this->{$key} = $value;
+        }
     }
 
     /**

--- a/lib/Entity/ApplicationRedirectUri.php
+++ b/lib/Entity/ApplicationRedirectUri.php
@@ -1,8 +1,8 @@
 <?php
 /*
- * Copyright (c) 2022 Xibo Signage Ltd
+ * Copyright (C) 2023 Xibo Signage Ltd
  *
- * Xibo - Digital Signage - http://www.xibo.org.uk
+ * Xibo - Digital Signage - https://xibosignage.com
  *
  * This file is part of Xibo.
  *
@@ -59,6 +59,18 @@ class ApplicationRedirectUri implements \JsonSerializable
     public function __construct($store, $log, $dispatcher)
     {
         $this->setCommonDependencies($store, $log, $dispatcher);
+    }
+
+    public function __serialize(): array
+    {
+        return $this->jsonSerialize();
+    }
+
+    public function __unserialize(array $data): void
+    {
+        foreach ($data as $key => $value) {
+            $this->{$key} = $value;
+        }
     }
 
     /**

--- a/lib/Entity/ApplicationScope.php
+++ b/lib/Entity/ApplicationScope.php
@@ -1,8 +1,8 @@
 <?php
 /*
- * Copyright (c) 2022 Xibo Signage Ltd
+ * Copyright (C) 2023 Xibo Signage Ltd
  *
- * Xibo - Digital Signage - http://www.xibo.org.uk
+ * Xibo - Digital Signage - https://xibosignage.com
  *
  * This file is part of Xibo.
  *
@@ -58,6 +58,18 @@ class ApplicationScope implements \JsonSerializable
     public function __construct($store, $log, $dispatcher)
     {
         $this->setCommonDependencies($store, $log, $dispatcher);
+    }
+
+    public function __serialize(): array
+    {
+        return $this->jsonSerialize();
+    }
+
+    public function __unserialize(array $data): void
+    {
+        foreach ($data as $key => $value) {
+            $this->{$key} = $value;
+        }
     }
 
     /**


### PR DESCRIPTION
The root cause for the "Authorisation parameters missing from session" is that the session isn't being updated in the database for the `GET /api/authorize` request. It seems to be either silently failing, or not updating at all (no log showing the SQL is recorded, but it is for other requests).

I think this might be due to us serialising the private member variables on the application/redirect/scope objects. This PR limits the data we serialise.

This is only a theory.