### PR TITLE
Misc fixes for duration is per item

### DIFF
--- a/lib/Widget/DataSetProvider.php
+++ b/lib/Widget/DataSetProvider.php
@@ -57,8 +57,12 @@ class DataSetProvider implements WidgetProviderInterface
             $upperLimit = $durationProvider->getWidget()->getOptionValue('upperLimit', 15);
             $numItems = $upperLimit - $lowerLimit;
 
+            // Workaround: dataset static (from v3 dataset view) has rowsPerPage instead.
+            $rowsPerPage = $durationProvider->getWidget()->getOptionValue('rowsPerPage', 0);
+            $itemsPerPage = $durationProvider->getWidget()->getOptionValue('itemsPerPage', 0);
+
             // If we have paging involved then work out the page count.
-            $itemsPerPage = $durationProvider->getWidget()->getOptionValue('rowsPerPage', 0);
+            $itemsPerPage = max($itemsPerPage, $rowsPerPage);
             if ($itemsPerPage > 0) {
                 $numItems = ceil($numItems / $itemsPerPage);
             }

--- a/lib/Widget/MenuBoardProductProvider.php
+++ b/lib/Widget/MenuBoardProductProvider.php
@@ -46,19 +46,20 @@ class MenuBoardProductProvider implements WidgetProviderInterface
 
     public function fetchDuration(DurationProviderInterface $durationProvider): WidgetProviderInterface
     {
-        $this->getLog()->debug('fetchDuration');
-        
-        $lowerLimit = $durationProvider->getWidget()->getOptionValue('lowerLimit', 0);
-        $upperLimit = $durationProvider->getWidget()->getOptionValue('upperLimit', 15);
-        $numItems = $upperLimit - $lowerLimit;
+        if ($durationProvider->getWidget()->getOptionValue('durationIsPerItem', 0) == 1) {
+            $this->getLog()->debug('fetchDuration: duration is per item');
 
-        $itemsPerPage = $durationProvider->getWidget()->getOptionValue('itemsPerPage', 0);
-        if ($itemsPerPage > 0) {
-            $numItems = ceil($numItems / $itemsPerPage);
+            $lowerLimit = $durationProvider->getWidget()->getOptionValue('lowerLimit', 0);
+            $upperLimit = $durationProvider->getWidget()->getOptionValue('upperLimit', 15);
+            $numItems = $upperLimit - $lowerLimit;
+
+            $itemsPerPage = $durationProvider->getWidget()->getOptionValue('itemsPerPage', 0);
+            if ($itemsPerPage > 0) {
+                $numItems = ceil($numItems / $itemsPerPage);
+            }
+
+            $durationProvider->setDuration($durationProvider->getWidget()->calculatedDuration * $numItems);
         }
-
-        $durationProvider->setDuration(($numItems)
-            * $durationProvider->getWidget()->calculatedDuration);
         return $this;
     }
 

--- a/modules/menuboard-product.xml
+++ b/modules/menuboard-product.xml
@@ -55,6 +55,11 @@
                 </test>
             </visibility>
         </property>
+        <property id="durationIsPerItem" type="checkbox">
+            <title>Duration is per item</title>
+            <helpText>The duration specified is per item otherwise it is per menu.</helpText>
+            <default>0</default>
+        </property>
         <property id="sortField" type="dropdown" mode="single">
             <title>Sort by</title>
             <helpText>How should we sort the menu items?</helpText>


### PR DESCRIPTION
DataSet: fix table durations per page (rowsPerPage)
MenuBoard: fix duration is per item (reverts prior fix).

relates to xibosignageltd/xibo-private#555