### PR TITLE
Canvas region sharing and undo button invalid step removal

### DIFF
--- a/ui/src/layout-editor/canvas.js
+++ b/ui/src/layout-editor/canvas.js
@@ -317,4 +317,150 @@ Canvas.prototype.removeFromCanvasWidget = function(
   }
 };
 
+
+/**
+ * Edit property by type
+ * @param {string} property - property to edit
+ */
+Canvas.prototype.editPropertyForm = function(property) {
+  const self = this;
+  const app = lD;
+
+  // Load form the API
+  const linkToAPI = urlsForApi.region['get' + property];
+
+  let requestPath = linkToAPI.url;
+
+  // Replace widget id
+  requestPath = requestPath.replace(':id', this.regionId);
+
+  // Create dialog
+  const calculatedId = new Date().getTime();
+
+  // Create dialog
+  const dialog = bootbox.dialog({
+    className: 'second-dialog',
+    title: editorsTrans.loadPropertyForObject
+      .replace('%prop%', property)
+      .replace('%obj%', 'region'),
+    message:
+        '<p><i class="fa fa-spin fa-spinner"></i>' +
+        editorsTrans.loading +
+        '...</p>',
+    size: 'large',
+    buttons: {
+      cancel: {
+        label: translations.cancel,
+        className: 'btn-white btn-bb-cancel',
+      },
+      done: {
+        label: translations.done,
+        className: 'btn-primary test btn-bb-done',
+        callback: function(res) {
+          app.common.showLoadingScreen();
+
+          let dataToSave = '';
+          const options = {
+            addToHistory: false, // options.addToHistory
+          };
+
+          // Get data to save
+          if (property === 'Permissions') {
+            dataToSave = formHelpers.permissionsFormBeforeSubmit(dialog);
+            options.customRequestPath = {
+              url: dialog.find('.permissionsGrid').data('url'),
+              type: 'POST',
+            };
+          } else {
+            dataToSave = form.serialize();
+          }
+
+          app.historyManager.addChange(
+            'save' + property,
+            'widget', // targetType
+            self.regionId, // targetId
+            null, // oldValues
+            dataToSave, // newValues
+            options,
+          ).then((res) => { // Success
+            app.common.hideLoadingScreen();
+
+            dialog.modal('hide');
+
+            app.reloadData(app.layout);
+          }).catch((error) => { // Fail/error
+            app.common.hideLoadingScreen();
+
+            // Show error returned or custom message to the user
+            let errorMessage = '';
+
+            if (typeof error == 'string') {
+              errorMessage += error;
+            } else {
+              errorMessage += error.errorThrown;
+            }
+
+            // Display message in form
+            formHelpers.displayErrorMessage(
+              dialog.find('form'),
+              errorMessage,
+              'danger',
+            );
+
+            // Show toast message
+            toastr.error(errorMessage);
+          });
+        },
+
+      },
+    },
+  }).attr('id', calculatedId).attr('data-test', 'region' + property + 'Form');
+
+  // Request and load property form
+  $.ajax({
+    url: requestPath,
+    type: linkToAPI.type,
+  }).done(function(res) {
+    if (res.success) {
+      // Add title
+      dialog.find('.modal-title').html(res.dialogTitle);
+
+      // Add body main content
+      dialog.find('.bootbox-body').html(res.html);
+
+      dialog.data('extra', res.extra);
+
+      if (property == 'Permissions') {
+        formHelpers.permissionsFormAfterOpen(dialog);
+      }
+
+      // Call Xibo Init for this form
+      // eslint-disable-next-line new-cap
+      XiboInitialise('#' + dialog.attr('id'));
+    } else {
+      // Login Form needed?
+      if (res.login) {
+        window.location.href = window.location.href;
+        location.reload();
+      } else {
+        toastr.error(errorMessagesTrans.formLoadFailed);
+
+        // Just an error we dont know about
+        if (res.message == undefined) {
+          console.error(res);
+        } else {
+          console.error(res.message);
+        }
+
+        dialog.modal('hide');
+      }
+    }
+  }).catch(function(jqXHR, textStatus, errorThrown) {
+    console.error(jqXHR, textStatus, errorThrown);
+    toastr.error(errorMessagesTrans.formLoadFailed);
+
+    dialog.modal('hide');
+  });
+};
+
 module.exports = Canvas;

--- a/ui/src/layout-editor/main.js
+++ b/ui/src/layout-editor/main.js
@@ -1133,6 +1133,9 @@ lD.undoLastAction = function() {
       errorMessage = error.errorThrown;
     }
 
+    // Remove last change
+    lD.historyManager.removeLastChange();
+
     toastr.error(
       errorMessagesTrans.revertFailed.replace('%error%', errorMessage),
     );

--- a/ui/src/layout-editor/main.js
+++ b/ui/src/layout-editor/main.js
@@ -2959,6 +2959,7 @@ lD.openContextMenu = function(obj, position = {x: 0, y: 0}) {
         layoutObject.type === 'element-group'
       ),
       elementWidget: elementWidget,
+      canvas: lD.getObjectByTypeAndId('canvas'),
     })),
   );
 
@@ -3357,6 +3358,17 @@ lD.openContextMenu = function(obj, position = {x: 0, y: 0}) {
         const canvasWidget =
           lD.getObjectByTypeAndId('widget', objAuxId, 'canvas');
         canvasWidget.editPropertyForm('Permissions');
+      } else if (
+        property === 'PermissionsCanvas' &&
+        (
+          layoutObject.type === 'element' ||
+          layoutObject.type === 'element-group'
+        )
+      ) {
+        // Call edit for canvas widget instead
+        const canvas =
+          lD.getObjectByTypeAndId('canvas');
+        canvas.editPropertyForm('Permissions');
       } else {
         // Call normal edit form
         layoutObject.editPropertyForm(

--- a/ui/src/playlist-editor/main.js
+++ b/ui/src/playlist-editor/main.js
@@ -416,6 +416,9 @@ pE.undoLastAction = function() {
       errorMessage = error.errorThrown;
     }
 
+    // Remove last change
+    pE.historyManager.removeLastChange();
+
     toastr.error(errorMessagesTrans.revertFailed
       .replace('%error%', errorMessage));
   });

--- a/ui/src/templates/context-menu.hbs
+++ b/ui/src/templates/context-menu.hbs
@@ -81,8 +81,14 @@
                 {{/if}}
             {{else if isElementBased}}
                 {{#if elementWidget.isPermissionsModifiable}}
-                    <div class="context-menu-btn permissionsBtn" data-title="{{trans.editPermissions}}" data-property="PermissionsCanvasWidget" data-toggle="tooltip" data-container=".context-menu" data-placement="bottom">
-                        <i class="tool-icon-permissions"></i><span>{{trans.editPermissions}}</span>
+                    <div class="context-menu-btn permissionsBtn" data-title="{{trans.editWidgetPermissions}}" data-property="PermissionsCanvasWidget" data-toggle="tooltip" data-container=".context-menu" data-placement="bottom">
+                        <i class="tool-icon-permissions"></i><span>{{trans.editWidgetPermissions}}</span>
+                    </div>
+                {{/if}}
+
+                {{#if canvas.isPermissionsModifiable}}
+                    <div class="context-menu-btn permissionsBtn" data-title="{{trans.editCanvasPermissions}}" data-property="PermissionsCanvas" data-toggle="tooltip" data-container=".context-menu" data-placement="bottom">
+                        <i class="tool-icon-permissions"></i><span>{{trans.editCanvasPermissions}}</span>
                     </div>
                 {{/if}}
             {{else}}

--- a/views/common.twig
+++ b/views/common.twig
@@ -458,6 +458,8 @@
                 editTransOut: "{{ "Edit Transition Out" |trans }}",
                 editPermissions: "{{ "Edit Sharing" |trans }}",
                 editRegionPermissions: "{{ "Edit Region Sharing" |trans }}",
+                editWidgetPermissions: "{{ "Edit Widget Sharing" |trans }}",
+                editCanvasPermissions: "{{ "Edit Canvas Sharing" |trans }}",
                 editPlaylist: "{{ "Edit Playlist" |trans }}",
                 options: "{% trans "Options" %}",
                 moveLeft: "{{ "Move one step left" |trans }}",

--- a/views/user-form-permissions.twig
+++ b/views/user-form-permissions.twig
@@ -38,6 +38,8 @@
     {% elseif object.type == "frame" %}
         {% set objectName = "Region"|trans %}
     {% elseif object.type == "global" %}
+        {% set objectName = "Canvas global widget"|trans %}
+    {% elseif object.type == "canvas" %}
         {% set objectName = "Canvas"|trans %}
     {% else %}
         {% set objectName = entity|trans %}


### PR DESCRIPTION
- Add sharing for Canvas region
- When we revert/undo a widget save that is invalid ( like reverting Calendar widget to without URL ), remove that step from the history manager to allow more "Undos"