### PR TITLE
Misc fixes related to sharing in 4.0

### DIFF
--- a/lib/Controller/Layout.php
+++ b/lib/Controller/Layout.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2023 Xibo Signage Ltd
+ * Copyright (C) 2024 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -2599,11 +2599,15 @@ class Layout extends Base
             $this->getConfig()->getSetting('SENDFILE_MODE')
         );
         $downloader->useLogger($this->getLog()->getLoggerInterface());
-        $response = $downloader->imagePreview($this->getSanitizer([
-            'width' => $layout->width,
-            'height' => $layout->height,
-            'proportional' => 0
-        ]), $media->storedAs, $response);
+        $response = $downloader->imagePreview(
+            $this->getSanitizer([
+                'width' => $layout->width,
+                'height' => $layout->height,
+                'proportional' => 0,
+            ]),
+            $media->storedAs,
+            $response,
+        );
 
         $this->setNoOutput(true);
         return $this->render($request, $response);

--- a/lib/Controller/Library.php
+++ b/lib/Controller/Library.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2023 Xibo Signage Ltd
+ * Copyright (C) 2024 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -1585,6 +1585,8 @@ class Library extends Base
      */
     public function download(Request $request, Response $response, $id)
     {
+        $this->setNoOutput();
+
         // We can download by mediaId or by mediaName.
         if (is_numeric($id)) {
             $media = $this->mediaFactory->getById($id);
@@ -1592,16 +1594,10 @@ class Library extends Base
             $media = $this->mediaFactory->getByName($id);
         }
 
-        $this->getLog()->debug('Download request for mediaId ' . $id
+        $this->getLog()->debug('download: Download request for mediaId ' . $id
             . '. Media is a ' . $media->mediaType . ', is system file:' . $media->moduleSystemFile);
 
-        // TODO: Permissions check
-        //  decide how we grant permissions to module files.
-        if ($media->mediaType !== 'module' && !$this->getUser()->checkViewable($media)) {
-            throw new AccessDeniedException();
-        }
-
-        // Make a module
+        // Create the appropriate module
         if ($media->mediaType === 'module') {
             $module = $this->moduleFactory->getByType('image');
         } else {
@@ -1622,29 +1618,43 @@ class Library extends Base
 
         $params = $this->getSanitizer($request->getParams());
         if ($params->getCheckbox('preview') == 1) {
+            $this->getLog()->debug('download: preview mode, seeing if we can output an image/video');
+
+            // Output a 1px image if we're not allowed to see the media.
+            if (!$this->getUser()->checkViewable($media)) {
+                echo Img::make($this->getConfig()->uri('img/1x1.png', true))->encode();
+                return $this->render($request, $response);
+            }
+
             // Various different behaviours for the different types of file.
             if ($module->type === 'image') {
                 $response = $downloader->imagePreview(
                     $params,
                     $media->storedAs,
                     $response,
-                    $this->getConfig()->uri('img/error.png', true)
+                    $this->getUser()->checkViewable($media),
                 );
             } else if ($module->type === 'video') {
                 $response = $downloader->imagePreview(
                     $params,
                     $media->mediaId . '_videocover.png',
                     $response,
-                    $this->getConfig()->uri('img/1x1.png', true)
+                    $this->getUser()->checkViewable($media),
                 );
             } else {
                 $response = $downloader->download($media, $response, $media->getMimeType());
             }
         } else {
+            $this->getLog()->debug('download: not preview mode, expect a full download');
+
+            // We are not a preview, and therefore we ought to check sharing before we download
+            if (!$this->getUser()->checkViewable($media)) {
+                throw new AccessDeniedException();
+            }
+
             $response = $downloader->download($media, $response, null, $params->getString('attachment'));
         }
 
-        $this->setNoOutput(true);
         return $this->render($request, $response);
     }
 

--- a/lib/Controller/User.php
+++ b/lib/Controller/User.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2023 Xibo Signage Ltd
+ * Copyright (C) 2024 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -1908,13 +1908,26 @@ class User extends Base
             if ($object->permissionsClass() == 'Xibo\Entity\Campaign') {
                 $this->getLog()->debug('Changing owner on child Layout');
 
-                $this->getDispatcher()->dispatch(LayoutOwnerChangeEvent::$NAME, new LayoutOwnerChangeEvent($object->getId(), $ownerId));
+                $this->getDispatcher()->dispatch(
+                    new LayoutOwnerChangeEvent($object->getId(), $ownerId),
+                    LayoutOwnerChangeEvent::$NAME,
+                );
             }
         }
 
         if ($object->permissionsClass() === 'Xibo\Entity\Folder') {
             /** @var $object \Xibo\Entity\Folder */
             $object->managePermissions();
+        } else if ($object->permissionsClass() === 'Xibo\Entity\Region') {
+            /** @var $object \Xibo\Entity\Region */
+            // The regions own playlist should always have the same permissions.
+            $permissions = $this->permissionFactory->getAllByObjectId(
+                $this->getUser(),
+                'Xibo\Entity\Playlist',
+                $object->getPlaylist()->playlistId
+            );
+
+            $this->updatePermissions($permissions, $groupIds);
         }
 
         // Return

--- a/lib/Controller/Widget.php
+++ b/lib/Controller/Widget.php
@@ -1212,6 +1212,22 @@ class Widget extends Base
             $this->getLog()->debug('getData: Returning cache');
         }
 
+        // Add permissions needed to see linked media
+        $media = $widgetDataProviderCache->getCachedMediaIds();
+        $this->getLog()->debug('getData: linking ' . count($media) . ' images');
+
+        foreach ($media as $mediaId) {
+            // We link these module images to the user.
+            foreach ($this->permissionFactory->getAllByObjectId(
+                $this->getUser(),
+                'Xibo\Entity\Media',
+                $mediaId,
+            ) as $permission) {
+                $permission->view = 1;
+                $permission->save();
+            }
+        }
+
         // Decorate for output.
         $data = $widgetDataProviderCache->decorateForPreview(
             $dataProvider->getData(),

--- a/lib/Widget/Provider/DataProvider.php
+++ b/lib/Widget/Provider/DataProvider.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2023 Xibo Signage Ltd
+ * Copyright (C) 2024 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -364,7 +364,7 @@ class DataProvider implements DataProviderInterface
     }
 
     /**
-     * @return \Xibo\Entity\Media[]
+     * @return int[]
      */
     public function getImageIds(): array
     {

--- a/ui/src/layout-editor/viewer.js
+++ b/ui/src/layout-editor/viewer.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Xibo Signage Ltd
+ * Copyright (C) 2024 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -1884,7 +1884,8 @@ Viewer.prototype.renderElementContent = function(
         hbsHtml.match(mediaURLRegex)?.forEach((match) => {
           const mediaId = match.split('[[mediaId=')[1].split(']]')[0];
           const mediaUrl =
-            urlsForApi.library.download.url.replace(':id', mediaId);
+            urlsForApi.library.download.url.replace(':id', mediaId) +
+              '?preview=1';
 
           // Replace asset id with asset url
           hbsHtml = hbsHtml.replace(match, mediaUrl);


### PR DESCRIPTION
This PR makes a change to the way we serve images/video thumbnails from the /library/download endpoint, so that if we say we're in preview mode (`preview=1`) we return a 1px placeholder when access is denied.

It also makes a change to the way module files have their permissions checked so that when data is returned users are granted permissions to any linked modules files. That means these files can be checked in the same way as any other file.

It also links together the sharing options applied to a Region and its Region Playlist, which means if we add a playlist (which adds a playlist region), we can set sharing on it.