### PR TITLE
Schedule grid fixes

### DIFF
--- a/lib/Controller/Schedule.php
+++ b/lib/Controller/Schedule.php
@@ -1776,6 +1776,20 @@ class Schedule extends Base
                     );
                 }
             ]);
+
+            // if this was originally Campaign event, now changed to interrupt,
+            // check if the selected Campaign is Layout specific
+            // set parentCampaignId to null, otherwise the event will not be editable.
+            if ($schedule->getOriginalValue('eventTypeId') === \Xibo\Entity\Schedule::$CAMPAIGN_EVENT) {
+                $campaign = $this->campaignFactory->getById($schedule->campaignId);
+                if ($campaign->isLayoutSpecific === 0) {
+                    throw new InvalidArgumentException(
+                        __('Cannot schedule campaign as an interrupt, please select a Layout instead.'),
+                        'campaignId'
+                    );
+                }
+                $schedule->parentCampaignId = null;
+            }
         } else {
             $schedule->shareOfVoice = null;
         }

--- a/lib/Controller/Schedule.php
+++ b/lib/Controller/Schedule.php
@@ -2296,7 +2296,7 @@ class Schedule extends Base
                 $repeatsOn = '';
                 $repeatsUntil = '';
 
-                if ($event->recurrenceType === 'Week') {
+                if ($event->recurrenceType === 'Week' && !empty($event->recurrenceRepeatsOn)) {
                     $weekdays = Carbon::getDays();
                     $repeatDays = explode(',', $event->recurrenceRepeatsOn);
                     $i = 0;

--- a/views/schedule-page.twig
+++ b/views/schedule-page.twig
@@ -1483,7 +1483,7 @@
             responsivePriority: 4,
             data: function (data) {
               if (data.recurringEvent) {
-                if (data.recurrenceType === 'Week') {
+                if (data.recurrenceType === 'Week' && data.recurrenceRepeatsOn) {
                   const daysOfTheWeek = [
                     '{% trans "Monday" %}',
                     '{% trans "Tuesday" %}',


### PR DESCRIPTION
- Fix js error (and PHP deprecated use of explode) when recurring event is set with recurrenceRepeatsOn null.
Relates to https://github.com/xibosignage/xibo/issues/3301
- Fix two issues with switching from Campaign to Interrupt event type - campaign should not be allowed, parentCampaignId should be cleared.
Relates to https://github.com/xibosignage/xibo/issues/3298