### PR TITLE
Android settings: add setting to toggle restart wifi on failure

### DIFF
--- a/lib/Controller/DisplayProfileConfigFields.php
+++ b/lib/Controller/DisplayProfileConfigFields.php
@@ -1,8 +1,8 @@
 <?php
-/**
- * Copyright (C) 2021 Xibo Signage Ltd
+/*
+ * Copyright (C) 2024 Xibo Signage Ltd
  *
- * Xibo - Digital Signage - http://www.xibo.org.uk
+ * Xibo - Digital Signage - https://xibosignage.com
  *
  * This file is part of Xibo.
  *
@@ -193,6 +193,24 @@ trait DisplayProfileConfigFields
                 if ($sanitizedParams->hasParam('dayPartId')) {
                     $this->handleChangedSettings('dayPartId', ($ownConfig) ? $displayProfile->getSetting('dayPartId') : $display->getSetting('dayPartId'), $sanitizedParams->getInt('dayPartId'), $changedSettings);
                     $displayProfile->setSetting('dayPartId', $sanitizedParams->getInt('dayPartId'), $ownConfig, $config);
+                }
+
+                if ($sanitizedParams->hasParam('restartWifiOnConnectionFailure')) {
+                    $this->handleChangedSettings(
+                        'restartWifiOnConnectionFailure',
+                        ($ownConfig)
+                            ? $displayProfile->getSetting('restartWifiOnConnectionFailure')
+                            : $display->getSetting('restartWifiOnConnectionFailure'),
+                        $sanitizedParams->getCheckbox('restartWifiOnConnectionFailure'),
+                        $changedSettings
+                    );
+
+                    $displayProfile->setSetting(
+                        'restartWifiOnConnectionFailure',
+                        $sanitizedParams->getCheckbox('restartWifiOnConnectionFailure'),
+                        $ownConfig,
+                        $config
+                    );
                 }
 
                 if ($sanitizedParams->hasParam('webViewPluginState')) {

--- a/lib/Factory/DisplayProfileFactory.php
+++ b/lib/Factory/DisplayProfileFactory.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2023 Xibo Signage Ltd
+ * Copyright (C) 2024 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -254,6 +254,7 @@ class DisplayProfileFactory extends BaseFactory
                 ['name' => 'updateStartWindow', 'default' => '00:00'],
                 ['name' => 'updateEndWindow', 'default' => '00:00'],
                 ['name' => 'dayPartId', 'default' => null],
+                ['name' => 'restartWifiOnConnectionFailure', 'default' => 0, 'type' => 'checkbox'],
                 ['name' => 'webViewPluginState', 'default' => 'DEMAND'],
                 ['name' => 'hardwareAccelerateWebViewMode', 'default' => '2'],
                 ['name' => 'timeSyncFromCms', 'default' => 0, 'type' => 'checkbox'],

--- a/views/displayprofile-form-edit-android.twig
+++ b/views/displayprofile-form-edit-android.twig
@@ -148,6 +148,9 @@
                     ] %}
                     {{ forms.dropdown("dayPartId", "single", title, displayProfile.getSetting("dayPartId"), [{dayPartId:null, name:""}]|merge(dayParts), "dayPartId", "name", helpText, "pagedSelect", "", "", "", attributes) }}
 
+                    {% set title = "Restart Wifi on connection failure?"|trans %}
+                    {% set helpText = "If an attempted connection to the CMS fails 10 times in a row, restart the Wifi adaptor."|trans %}
+                    {{ forms.checkbox("restartWifiOnConnectionFailure", title, displayProfile.getSetting("restartWifiOnConnectionFailure"), helpText) }}
                 </div>
 
                 <div class="tab-pane" id="location">


### PR DESCRIPTION
This PR adds a new setting to the Android display settings profile, defaulted to off to match the android app.