### PR TITLE
Fix for Video In duration getting set to 1 and XLF output tidying

### DIFF
--- a/lib/Entity/Layout.php
+++ b/lib/Entity/Layout.php
@@ -1413,6 +1413,7 @@ class Layout implements \JsonSerializable
                     && $countWidgets <= 1
                     && $regionLoop == 0
                     && $widget->type != 'video'
+                    && $widget->type != 'videoin'
                     && $layoutCountRegionsWithDuration >= 1
                     && $region->isDrawer === 0
                 ) {

--- a/lib/Entity/Layout.php
+++ b/lib/Entity/Layout.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2023 Xibo Signage Ltd
+ * Copyright (C) 2024 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -1651,8 +1651,8 @@ class Layout implements \JsonSerializable
                 $module->decorateProperties($widget, true, false);
 
                 foreach ($module->properties as $property) {
-                    // We only output properties for native rendered widgets
-                    if ($module->renderAs === 'native' || $property->includeInXlf) {
+                    // We only output certain properties
+                    if ($property->includeInXlf) {
                         if (($uriInjected && $property->id == 'uri') || empty($property->id)) {
                             // Skip any property named "uri" if we've already injected a special node for that.
                             // Skip properties without an id

--- a/lib/Factory/ModuleXmlTrait.php
+++ b/lib/Factory/ModuleXmlTrait.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2023 Xibo Signage Ltd
+ * Copyright (C) 2024 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -122,11 +122,19 @@ trait ModuleXmlTrait
                 $property->allowLibraryRefs = $node->getAttribute('allowLibraryRefs') === 'true';
                 $property->allowAssetRefs = $node->getAttribute('allowAssetRefs') === 'true';
                 $property->parseTranslations = $node->getAttribute('parseTranslations') === 'true';
-                $property->includeInXlf = $node->getAttribute('includeInXlf') === 'true';
                 $property->title = __($this->getFirstValueOrDefaultFromXmlNode($node, 'title'));
                 $property->helpText = __($this->getFirstValueOrDefaultFromXmlNode($node, 'helpText'));
                 $property->value = $this->getFirstValueOrDefaultFromXmlNode($node, 'value');
                 $property->dependsOn = $this->getFirstValueOrDefaultFromXmlNode($node, 'dependsOn');
+
+                // How should we default includeInXlf?
+                if ($module?->renderAs === 'native') {
+                    // Include by default
+                    $property->includeInXlf = $node->getAttribute('includeInXlf') !== 'false';
+                } else {
+                    // Exclude by default
+                    $property->includeInXlf = $node->getAttribute('includeInXlf') === 'true';
+                }
 
                 // Default value
                 $defaultValue = $this->getFirstValueOrDefaultFromXmlNode($node, 'default');

--- a/modules/video.xml
+++ b/modules/video.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (C) 2023 Xibo Signage Ltd
+  ~ Copyright (C) 2024 Xibo Signage Ltd
   ~
   ~ Xibo - Digital Signage - https://xibosignage.com
   ~
@@ -56,7 +56,7 @@
         </property>
     </settings>
     <properties>
-        <property id="message-duration" type="message">
+        <property id="message-duration" type="message" includeInXlf="false">
             <title>This video will play for %media.duration% seconds. Cut the video short by setting a shorter duration in the Advanced tab. Wait on the last frame or set to Loop by setting a higher duration in the Advanced tab.</title>
         </property>
         <property id="loop" type="checkbox">

--- a/modules/videoin.xml
+++ b/modules/videoin.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (C) 2023 Xibo Signage Ltd
+  ~ Copyright (C) 2024 Xibo Signage Ltd
   ~
   ~ Xibo - Digital Signage - https://xibosignage.com
   ~
@@ -51,7 +51,7 @@
             <helpText>Should the video expand over the top of existing content and show in full screen?</helpText>
             <default>0</default>
         </property>
-        <property id="message" type="message">
+        <property id="message" type="message" includeInXlf="false">
             <title>This Module is compatible with webOS, Tizen and Philips SOC Players only</title>
         </property>
     </properties>


### PR DESCRIPTION
This PR fixes https://github.com/xibosignage/xibo/issues/3284.

It also tidies up the contents of the XLF where messages were being output for native widgets.