### PR TITLE
Currencies and Stocks duration issue

### DIFF
--- a/lib/Entity/ModulePropertyTrait.php
+++ b/lib/Entity/ModulePropertyTrait.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2023 Xibo Signage Ltd
+ * Copyright (C) 2024 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -126,10 +126,12 @@ trait ModulePropertyTrait
                 // Does this property have library references?
                 if ($property->allowLibraryRefs && !empty($value)) {
                     // Parse them out and replace for our special syntax.
+                    // TODO: Can we improve this regex to ignore things we suspect are JavaScript array access?
                     $matches = [];
                     preg_match_all('/\[(.*?)\]/', $value, $matches);
                     foreach ($matches[1] as $match) {
-                        if (is_numeric($match)) {
+                        // We ignore non-numbers and zero/negative integers
+                        if (is_numeric($match) && intval($match) <= 0) {
                             $value = str_replace(
                                 '[' . $match . ']',
                                 '[[mediaId=' . $match . ']]',

--- a/lib/Widget/CurrenciesAndStocksProvider.php
+++ b/lib/Widget/CurrenciesAndStocksProvider.php
@@ -1,0 +1,96 @@
+<?php
+/*
+ * Copyright (C) 2024 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Xibo\Widget;
+
+use Carbon\Carbon;
+use Xibo\Widget\Provider\DataProviderInterface;
+use Xibo\Widget\Provider\DurationProviderInterface;
+use Xibo\Widget\Provider\WidgetProviderInterface;
+use Xibo\Widget\Provider\WidgetProviderTrait;
+
+/**
+ * A widget provider for stocks and currencies, only used to correctly set the numItems
+ */
+class CurrenciesAndStocksProvider implements WidgetProviderInterface
+{
+    use WidgetProviderTrait;
+
+    /**
+     * We want to pass this out to the event mechanism for 3rd party sources.
+     * @param \Xibo\Widget\Provider\DataProviderInterface $dataProvider
+     * @return \Xibo\Widget\Provider\WidgetProviderInterface
+     */
+    public function fetchData(DataProviderInterface $dataProvider): WidgetProviderInterface
+    {
+        $dataProvider->setIsUseEvent();
+        return $this;
+    }
+
+    /**
+     * Special handling for currencies and stocks where the number of data items is based on the quantity of
+     * items input in the `items` property.
+     * @param \Xibo\Widget\Provider\DurationProviderInterface $durationProvider
+     * @return \Xibo\Widget\Provider\WidgetProviderInterface
+     */
+    public function fetchDuration(DurationProviderInterface $durationProvider): WidgetProviderInterface
+    {
+        $this->getLog()->debug('fetchDuration: CurrenciesAndStocksProvider');
+
+        // Currencies and stocks are based on the number of items set in the respective fields.
+        $items = $durationProvider->getWidget()->getOptionValue('items', null);
+        if ($items === null) {
+            $this->getLog()->debug('fetchDuration: CurrenciesAndStocksProvider: no items set');
+            return $this;
+        }
+
+        if ($durationProvider->getWidget()->getOptionValue('durationIsPerItem', 0) == 0) {
+            $this->getLog()->debug('fetchDuration: CurrenciesAndStocksProvider: duration per item not set');
+            return $this;
+        }
+
+        $numItems = count(explode(',', $items));
+
+        $this->getLog()->debug('fetchDuration: CurrenciesAndStocksProvider: number of items: ' . $numItems);
+
+        if ($numItems > 1) {
+            // If we have paging involved then work out the page count.
+            $itemsPerPage = $durationProvider->getWidget()->getOptionValue('itemsPerPage', 0);
+            if ($itemsPerPage > 0) {
+                $numItems = ceil($numItems / $itemsPerPage);
+            }
+
+            $durationProvider->setDuration($durationProvider->getWidget()->calculatedDuration * $numItems);
+        }
+        return $this;
+    }
+
+    public function getDataCacheKey(DataProviderInterface $dataProvider): ?string
+    {
+        return null;
+    }
+
+    public function getDataModifiedDt(DataProviderInterface $dataProvider): ?Carbon
+    {
+        return null;
+    }
+}

--- a/lib/Widget/Provider/DataProviderInterface.php
+++ b/lib/Widget/Provider/DataProviderInterface.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2023 Xibo Signage Ltd
+ * Copyright (C) 2024 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -130,6 +130,12 @@ interface DataProviderInterface
      * @return \Carbon\Carbon|null
      */
     public function getWidgetModifiedDt(): ?Carbon;
+
+    /**
+     * Indicate that we should use the event mechanism to handle this event.
+     * @return \Xibo\Widget\Provider\DataProviderInterface
+     */
+    public function setIsUseEvent(): DataProviderInterface;
 
     /**
      * Indicate that this data provider has been handled.

--- a/lib/Widget/Render/WidgetHtmlRenderer.php
+++ b/lib/Widget/Render/WidgetHtmlRenderer.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2023 Xibo Signage Ltd
+ * Copyright (C) 2024 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -493,7 +493,7 @@ class WidgetHtmlRenderer
                 'properties' => $module->getPropertyValues(),
                 'isValid' => $widget->isValid === 1,
                 'isRepeatData' => $widget->getOptionValue('isRepeatData', 1) === 1,
-                'duration' => $widget->duration,
+                'duration' => $widget->useDuration ? $widget->duration : $module->defaultDuration,
                 'calculatedDuration' => $widget->calculatedDuration,
                 'isDataExpected' => $module->isDataProviderExpected(),
             ];

--- a/modules/currencies.xml
+++ b/modules/currencies.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (C) 2023 Xibo Signage Ltd
+  ~ Copyright (C) 2024 Xibo Signage Ltd
   ~
   ~ Xibo - Digital Signage - https://xibosignage.com
   ~
@@ -24,7 +24,7 @@
     <author>Core</author>
     <description>A module for showing Currency pairs and exchange rates</description>
     <icon>fa fa-line-chart</icon>
-    <class></class>
+    <class>\Xibo\Widget\CurrenciesAndStocksProvider</class>
     <compatibilityClass>\Xibo\Widget\Compatibility\CurrenciesWidgetCompatibility</compatibilityClass>
     <type>currencies</type>
     <dataType>currency</dataType>

--- a/modules/stocks.xml
+++ b/modules/stocks.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (C) 2023 Xibo Signage Ltd
+  ~ Copyright (C) 2024 Xibo Signage Ltd
   ~
   ~ Xibo - Digital Signage - https://xibosignage.com
   ~
@@ -24,7 +24,7 @@
     <author>Core</author>
     <description>A module for showing Stock quotes</description>
     <icon>fa fa-bar-chart</icon>
-    <class></class>
+    <class>\Xibo\Widget\CurrenciesAndStocksProvider</class>
     <compatibilityClass>\Xibo\Widget\Compatibility\StocksWidgetCompatibility</compatibilityClass>
     <type>stocks</type>
     <dataType>stock</dataType>


### PR DESCRIPTION
This PR fixes an issue with currencies and stocks not calculating their duration correctly as they did not know how many items were available.

It also adds a change which will ignore the `[0]` library reference in JavaScript, which seems to be the most common array accessor.