### PR TITLE
PlayerJS: fix for date rendering on overridden elements.

### DIFF
--- a/modules/src/xibo-player.js
+++ b/modules/src/xibo-player.js
@@ -342,9 +342,7 @@ const XiboPlayer = function() {
       elemCopy.escapeHtml =
         $template?.data('escape-html');
 
-      if (String(elemCopy.dataOverride).length > 0 &&
-        String(elemCopy.dataOverrideWith).length > 0
-      ) {
+      if (String(elemCopy.dataOverride).length > 0) {
         elemCopy.isExtended = true;
       }
 
@@ -977,6 +975,13 @@ XiboPlayer.prototype.renderWidgetElements = function(currentWidget) {
               const $grpItem = $(`<div class="${grpCln}"></div>`);
               const isMarquee =
                 PlayerHelper.isMarquee(slotObj?.effect ?? 'noTransition');
+
+              // If the slotObject isn't available lots of failures occur below
+              // this can happen when a user has skipped a slot
+              // (gone from 1 to 3)
+              if (!slotObj) {
+                return;
+              }
 
               if (dataKeys.length > 0) {
                 $.each(dataKeys,


### PR DESCRIPTION
This PR fixes an issue with the date element not outputting formatted when used as an overridden element (i.e. data set date).

It also fixes an issue I discovered in testing where I had missed a slot (I had slot 1 and 3) and that caused an exception.