### PR TITLE
PlayerJS: Fix for dashboard module so template can be added to the DOM

### DIFF
--- a/modules/src/xibo-player.js
+++ b/modules/src/xibo-player.js
@@ -913,6 +913,9 @@ XiboPlayer.prototype.renderStaticWidget = function(staticWidget) {
   let $template = null;
   if ($('#hbs-' + staticWidget.templateId).length > 0) {
     $template = $('#hbs-' + staticWidget.templateId);
+  } else if ($('#hbs-module').length > 0) {
+    // Dashboard module is using this template
+    $template = $('#hbs-module');
   }
 
   let hbs = null;


### PR DESCRIPTION
* Dashboard Widget doesn't work (the HBS is not getting added to the DOM)

relates to xibosignageltd/xibo-private#606