### PR TITLE
Resolve handling for onTemplateDataLoad and ensure data items are passed correctly

### DIFF
--- a/lib/Entity/Module.php
+++ b/lib/Entity/Module.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2023 Xibo Signage Ltd
+ * Copyright (C) 2024 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -202,12 +202,6 @@ class Module implements \JsonSerializable
      * @var string
      */
     public $onDataLoad;
-
-    /**
-     * @SWG\Property(description="An error function to run when the widget is unable to fetch data")
-     * @var string
-     */
-    public $onDataError;
 
     /**
      * @SWG\Property(description="JavaScript function run when a module is rendered, after data has been returned")

--- a/lib/Entity/ModuleTemplate.php
+++ b/lib/Entity/ModuleTemplate.php
@@ -130,12 +130,6 @@ class ModuleTemplate implements \JsonSerializable
      */
     public $assets;
 
-    /**
-     * @SWG\Property(description="A load function to run when the template first fetches data")
-     * @var string
-     */
-    public $onTemplateDataLoad;
-
     /** @var string A Renderer to run if custom rendering is required. */
     public $onTemplateRender;
 

--- a/lib/Entity/ModuleTemplate.php
+++ b/lib/Entity/ModuleTemplate.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2023 Xibo Signage Ltd
+ * Copyright (C) 2024 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -129,6 +129,12 @@ class ModuleTemplate implements \JsonSerializable
      * @var Asset[]
      */
     public $assets;
+
+    /**
+     * @SWG\Property(description="A load function to run when the template first fetches data")
+     * @var string
+     */
+    public $onTemplateDataLoad;
 
     /** @var string A Renderer to run if custom rendering is required. */
     public $onTemplateRender;

--- a/lib/Factory/ModuleFactory.php
+++ b/lib/Factory/ModuleFactory.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2023 Xibo Signage Ltd
+ * Copyright (C) 2024 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -704,11 +704,6 @@ class ModuleFactory extends BaseFactory
         $module->onDataLoad = $this->getFirstValueOrDefaultFromXmlNode($xml, 'onDataLoad');
         if (!empty($module->onDataLoad)) {
             $module->onDataLoad = trim($module->onDataLoad);
-        }
-
-        $module->onDataError = $this->getFirstValueOrDefaultFromXmlNode($xml, 'onDataError');
-        if (!empty($module->onDataError)) {
-            $module->onDataError = trim($module->onDataError);
         }
 
         $module->onRender = $this->getFirstValueOrDefaultFromXmlNode($xml, 'onRender');

--- a/lib/Factory/ModuleTemplateFactory.php
+++ b/lib/Factory/ModuleTemplateFactory.php
@@ -232,15 +232,10 @@ class ModuleTemplateFactory extends BaseFactory
         $template->startHeight = intval($this->getFirstValueOrDefaultFromXmlNode($xml, 'startHeight'));
         $template->hasDimensions = $this->getFirstValueOrDefaultFromXmlNode($xml, 'hasDimensions', 'true') === 'true';
         $template->canRotate = $this->getFirstValueOrDefaultFromXmlNode($xml, 'canRotate', 'false') === 'true';
-        $template->onTemplateDataLoad = $this->getFirstValueOrDefaultFromXmlNode($xml, 'onTemplateDataLoad');
         $template->onTemplateRender = $this->getFirstValueOrDefaultFromXmlNode($xml, 'onTemplateRender');
         $template->onTemplateVisible = $this->getFirstValueOrDefaultFromXmlNode($xml, 'onTemplateVisible');
         $template->onElementParseData = $this->getFirstValueOrDefaultFromXmlNode($xml, 'onElementParseData');
         $template->showIn = $this->getFirstValueOrDefaultFromXmlNode($xml, 'showIn') ?? 'both';
-
-        if (!empty($template->onTemplateDataLoad)) {
-            $template->onTemplateDataLoad = trim($template->onTemplateDataLoad);
-        }
 
         if (!empty($template->onTemplateRender)) {
             $template->onTemplateRender = trim($template->onTemplateRender);

--- a/lib/Factory/ModuleTemplateFactory.php
+++ b/lib/Factory/ModuleTemplateFactory.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2023 Xibo Signage Ltd
+ * Copyright (C) 2024 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -232,10 +232,16 @@ class ModuleTemplateFactory extends BaseFactory
         $template->startHeight = intval($this->getFirstValueOrDefaultFromXmlNode($xml, 'startHeight'));
         $template->hasDimensions = $this->getFirstValueOrDefaultFromXmlNode($xml, 'hasDimensions', 'true') === 'true';
         $template->canRotate = $this->getFirstValueOrDefaultFromXmlNode($xml, 'canRotate', 'false') === 'true';
+        $template->onTemplateDataLoad = $this->getFirstValueOrDefaultFromXmlNode($xml, 'onTemplateDataLoad');
         $template->onTemplateRender = $this->getFirstValueOrDefaultFromXmlNode($xml, 'onTemplateRender');
         $template->onTemplateVisible = $this->getFirstValueOrDefaultFromXmlNode($xml, 'onTemplateVisible');
         $template->onElementParseData = $this->getFirstValueOrDefaultFromXmlNode($xml, 'onElementParseData');
         $template->showIn = $this->getFirstValueOrDefaultFromXmlNode($xml, 'showIn') ?? 'both';
+
+        if (!empty($template->onTemplateDataLoad)) {
+            $template->onTemplateDataLoad = trim($template->onTemplateDataLoad);
+        }
+
         if (!empty($template->onTemplateRender)) {
             $template->onTemplateRender = trim($template->onTemplateRender);
         }

--- a/lib/Widget/Render/WidgetHtmlRenderer.php
+++ b/lib/Widget/Render/WidgetHtmlRenderer.php
@@ -397,8 +397,8 @@ class WidgetHtmlRenderer
         $twig['onRender'] = [];
         $twig['onParseData'] = [];
         $twig['onDataLoad'] = [];
-        $twig['onDataError'] = [];
         $twig['onElementParseData'] = [];
+        $twig['onTemplateDataLoad'] = [];
         $twig['onTemplateRender'] = [];
         $twig['onTemplateVisible'] = [];
         $twig['onInitialize'] = [];
@@ -521,9 +521,6 @@ class WidgetHtmlRenderer
             }
             if (!empty($module->onDataLoad)) {
                 $twig['onDataLoad'][$widget->widgetId] = $module->onDataLoad;
-            }
-            if (!empty($module->onDataError)) {
-                $twig['onDataError'][$widget->widgetId] = $module->onDataError;
             }
             if (!empty($module->onRender)) {
                 $twig['onRender'][$widget->widgetId] = $module->onRender;
@@ -731,6 +728,10 @@ class WidgetHtmlRenderer
                 && $moduleTemplate->type === 'element'
             ) {
                 $twig['style'][] = $moduleTemplate->stencil->style;
+            }
+
+            if ($moduleTemplate->onTemplateDataLoad !== null) {
+                $twig['onTemplateDataLoad'][$moduleTemplate->templateId] = $moduleTemplate->onTemplateDataLoad;
             }
 
             if ($moduleTemplate->onTemplateRender !== null) {

--- a/lib/Widget/Render/WidgetHtmlRenderer.php
+++ b/lib/Widget/Render/WidgetHtmlRenderer.php
@@ -398,7 +398,6 @@ class WidgetHtmlRenderer
         $twig['onParseData'] = [];
         $twig['onDataLoad'] = [];
         $twig['onElementParseData'] = [];
-        $twig['onTemplateDataLoad'] = [];
         $twig['onTemplateRender'] = [];
         $twig['onTemplateVisible'] = [];
         $twig['onInitialize'] = [];
@@ -728,10 +727,6 @@ class WidgetHtmlRenderer
                 && $moduleTemplate->type === 'element'
             ) {
                 $twig['style'][] = $moduleTemplate->stencil->style;
-            }
-
-            if ($moduleTemplate->onTemplateDataLoad !== null) {
-                $twig['onTemplateDataLoad'][$moduleTemplate->templateId] = $moduleTemplate->onTemplateDataLoad;
             }
 
             if ($moduleTemplate->onTemplateRender !== null) {

--- a/modules/calendar.xml
+++ b/modules/calendar.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (C) 2023 Xibo Signage Ltd
+  ~ Copyright (C) 2024 Xibo Signage Ltd
   ~
   ~ Xibo - Digital Signage - https://xibosignage.com
   ~
@@ -179,17 +179,6 @@
             <default></default>
         </property>
     </properties>
-    <onDataError><![CDATA[
-    if (typeof httpStatus === 'undefined' || typeof response === 'undefined') {
-        return false;
-    }
-
-    var hasSucceed = response.hasOwnProperty('success') && response.success === true;
-
-    if (!hasSucceed) {
-        return false;
-    }
-]]></onDataError>
     <onDataLoad><![CDATA[
 // items: The items to render
 // meta: Metadata

--- a/modules/src/xibo-player.js
+++ b/modules/src/xibo-player.js
@@ -104,29 +104,14 @@ const XiboPlayer = function() {
     this.loadWidgetFunctions(playerWidget, widgetDataItems);
 
     if (isDataWidget) {
-      const templateDataState =
-        playerWidget.onTemplateDataLoad(widgetDataItems);
+      const dataLoadState = playerWidget.onDataLoad(widgetDataItems);
+      console.log('onDataLoad::handled = ', dataLoadState.handled);
 
-      widgetDataItems = templateDataState.dataItems;
-      console.log('onTemplateDataLoad::widgetDataItems ', widgetDataItems);
+      widgetDataItems = dataLoadState.dataItems;
 
-      if (!templateDataState.handled) {
-        const dataLoadState = playerWidget.onDataLoad(widgetDataItems);
-        console.log(
-          'onTemplateDataLoad::handled = ', templateDataState.handled);
-
-        widgetDataItems = dataLoadState.dataItems;
-        console.log('dataLoadState::widgetDataItems ', widgetDataItems);
-
-        if (!dataLoadState.handled) {
-          console.log('onDataLoad::handled = ', dataLoadState.handled);
-          widgetDataItems = playerWidget.onParseData(widgetDataItems);
-          console.log('onParseData::widgetDataItems ', widgetDataItems);
-        }
-      } else {
-        console.log(
-          'onTemplateDataLoad::handled = ', templateDataState.handled);
-        widgetDataItems = playerWidget.onParseData();
+      if (!dataLoadState.handled) {
+        widgetDataItems = playerWidget.onParseData(widgetDataItems);
+        console.log('onParseData::widgetDataItems ', widgetDataItems);
       }
     }
 
@@ -203,15 +188,6 @@ const XiboPlayer = function() {
       globalOptions,
     );
 
-    playerWidget.onTemplateDataLoad = function(widgetDataItems) {
-      return self.onTemplateDataLoad({
-        widgetId: playerWidget.widgetId,
-        dataItems: widgetDataItems,
-        meta: playerWidget.meta,
-        properties: playerWidget.properties,
-        isDataReady: playerWidget.isDataReady,
-      });
-    };
     playerWidget.onDataLoad = function(widgetDataItems) {
       return self.onDataLoad({
         widgetId: playerWidget.widgetId,
@@ -1421,53 +1397,6 @@ XiboPlayer.prototype.isStaticWidget = function(playerWidget) {
 XiboPlayer.prototype.isModule = function(currentWidget) {
   return (!currentWidget.isDataExpected && $('#hbs-module').length > 0) ||
     (!currentWidget.isDataExpected && this.inputElements.length === 0);
-};
-
-/**
- * Caller function for onTemplateDataLoad
- * @param {Object} params
- * @return {Object} State to determine next step. E.g. {handled: false}
- */
-XiboPlayer.prototype.onTemplateDataLoad = function(params) {
-  let onTemplateDataLoad = null;
-  // onTemplateDataLoad function should be checked and run first before
-  if (typeof window['onTemplateDataLoad_' + params.widgetId] ===
-    'function') {
-    onTemplateDataLoad =
-      window['onTemplateDataLoad_' + params.widgetId];
-  }
-
-  let onTemplateDataLoadResponse =
-    {handled: false, dataItems: params.dataItems ?? []};
-
-  if (onTemplateDataLoad) {
-    const onTemplateDataLoadResult = onTemplateDataLoad(
-      params.dataItems,
-      params.meta,
-      params.properties,
-      params.isDataReady,
-    );
-
-    if (onTemplateDataLoadResult !== undefined &&
-      Object.keys(onTemplateDataLoadResult).length > 0
-    ) {
-      if ((onTemplateDataLoadResult ?? {}).hasOwnProperty('handled')) {
-        onTemplateDataLoadResponse = {
-          ...onTemplateDataLoadResponse,
-          handled: onTemplateDataLoadResult.handled,
-        };
-      }
-
-      if ((onTemplateDataLoadResult ?? {}).hasOwnProperty('dataItems')) {
-        onTemplateDataLoadResponse = {
-          ...onTemplateDataLoadResponse,
-          dataItems: onTemplateDataLoadResult.dataItems,
-        };
-      }
-    }
-  }
-
-  return onTemplateDataLoadResponse;
 };
 
 /**

--- a/modules/src/xibo-player.js
+++ b/modules/src/xibo-player.js
@@ -45,22 +45,29 @@ const XiboPlayer = function() {
           method: 'GET',
           url: currentWidget.url,
         }).done(function(data) {
+          // The contents of the JSON file will be an object with data and meta
           resolve({
             ...data,
-            onDataReady: true,
+            isDataReady: true,
           });
         }).fail(function(jqXHR, textStatus, errorThrown) {
           console.log(jqXHR, textStatus, errorThrown);
           resolve({
-            onDataReady: false,
+            isDataReady: false,
             error: jqXHR.status,
             success: false,
             data: jqXHR.responseJSON,
           });
         });
       } else if (currentWidget.data?.data !== undefined) {
-        resolve(currentWidget.data);
+        // This happens for v3 players where the data is already
+        // added to the HTML
+        resolve({
+          ...currentWidget.data,
+          isDataReady: true,
+        });
       } else {
+        // This should be impossible.
         resolve(null);
       }
     });
@@ -80,28 +87,31 @@ const XiboPlayer = function() {
     let widgetDataItems = [];
     let shouldShowError = false;
     let withErrorMessage = null;
-    let isDataReady = null;
 
     if (isDataWidget) {
-      const {dataItems, showError, errorMessage, onDataReady} =
+      const {dataItems, showError, errorMessage} =
           this.loadData(playerWidget, data);
       widgetDataItems = dataItems;
       shouldShowError = showError;
       withErrorMessage = errorMessage;
-      isDataReady = onDataReady;
     }
 
-    playerWidget.onDataReady = isDataReady;
+    playerWidget.isDataReady = data?.isDataReady || false;
     playerWidget.meta = data !== null ? data?.meta : {};
     playerWidget.items = [];
 
+    // Decorate this widget with all applicable functions
     this.loadWidgetFunctions(playerWidget, widgetDataItems);
 
     if (isDataWidget) {
-      const templateDataState = playerWidget.onTemplateDataLoad();
+      const templateDataState =
+        playerWidget.onTemplateDataLoad(widgetDataItems);
+
+      widgetDataItems = templateDataState.dataItems;
+      console.log('onTemplateDataLoad::widgetDataItems ', widgetDataItems);
 
       if (!templateDataState.handled) {
-        const dataLoadState = playerWidget.onDataLoad();
+        const dataLoadState = playerWidget.onDataLoad(widgetDataItems);
         console.log(
           'onTemplateDataLoad::handled = ', templateDataState.handled);
 
@@ -184,9 +194,8 @@ const XiboPlayer = function() {
   /**
    * Define widget functions used for render flow
    * @param {Object} playerWidget Widget object
-   * @param {Array} dataItems Widget data
    */
-  this.loadWidgetFunctions = function(playerWidget, dataItems) {
+  this.loadWidgetFunctions = function(playerWidget) {
     const self = this;
     const params = this.getRenderParams(
       playerWidget,
@@ -194,21 +203,26 @@ const XiboPlayer = function() {
       globalOptions,
     );
 
-    playerWidget.onTemplateDataLoad = function() {
+    playerWidget.onTemplateDataLoad = function(widgetDataItems) {
       return self.onTemplateDataLoad({
         widgetId: playerWidget.widgetId,
-      });
-    };
-    playerWidget.onDataLoad = function() {
-      return self.onDataLoad({
-        widgetId: playerWidget.widgetId,
-        dataItems,
+        dataItems: widgetDataItems,
         meta: playerWidget.meta,
         properties: playerWidget.properties,
+        isDataReady: playerWidget.isDataReady,
+      });
+    };
+    playerWidget.onDataLoad = function(widgetDataItems) {
+      return self.onDataLoad({
+        widgetId: playerWidget.widgetId,
+        dataItems: widgetDataItems,
+        meta: playerWidget.meta,
+        properties: playerWidget.properties,
+        isDataReady: playerWidget.isDataReady,
       });
     };
     playerWidget.onParseData = function(widgetDataItems) {
-      return self.onParseData(playerWidget, widgetDataItems ?? dataItems);
+      return self.onParseData(playerWidget, widgetDataItems);
     };
     playerWidget.onTemplateRender = function(currentWidget, options) {
       return self.onTemplateRender(
@@ -717,7 +731,7 @@ XiboPlayer.prototype.isEditor = function() {
 };
 
 /**
- * Compose widget data
+ * Show sample data or an error if in the editor.
  * @param {Object} currentWidget Widget object
  * @param {Object|Array} data Widget data from data provider
  * @return {Object} widgetData
@@ -728,7 +742,6 @@ XiboPlayer.prototype.loadData = function(currentWidget, data) {
     isSampleData: false,
     dataItems: [],
     isArray: Array.isArray(data?.data),
-    onDataReady: data?.onDataReady,
     showError: false,
     errorMessage: null,
   };
@@ -901,6 +914,12 @@ XiboPlayer.prototype.renderStaticWidget = function(staticWidget) {
     }).html(errorMessage);
 
     $target.append($errMsg);
+  }
+
+  // Expire if the data is not ready
+  if (!staticWidget.isDataReady) {
+    console.error('static widget where data is not ready, expiring');
+    xiboIC.expireNow({targetId: xiboICTargetId});
   }
 
   // Add meta to the widget if it exists
@@ -1418,29 +1437,37 @@ XiboPlayer.prototype.onTemplateDataLoad = function(params) {
       window['onTemplateDataLoad_' + params.widgetId];
   }
 
-  let onTemplateDataLoadRes = {handled: false};
+  let onTemplateDataLoadResponse =
+    {handled: false, dataItems: params.dataItems ?? []};
 
   if (onTemplateDataLoad) {
-    const onTemplateDataLoadResult = onTemplateDataLoad(params.widgetId);
+    const onTemplateDataLoadResult = onTemplateDataLoad(
+      params.dataItems,
+      params.meta,
+      params.properties,
+      params.isDataReady,
+    );
 
     if (onTemplateDataLoadResult !== undefined &&
       Object.keys(onTemplateDataLoadResult).length > 0
     ) {
       if ((onTemplateDataLoadResult ?? {}).hasOwnProperty('handled')) {
-        onTemplateDataLoadRes = {
-          ...onTemplateDataLoadRes,
+        onTemplateDataLoadResponse = {
+          ...onTemplateDataLoadResponse,
           handled: onTemplateDataLoadResult.handled,
         };
-      } else {
-        onTemplateDataLoadRes = {
-          ...onTemplateDataLoadResult,
-          ...onTemplateDataLoadRes,
+      }
+
+      if ((onTemplateDataLoadResult ?? {}).hasOwnProperty('dataItems')) {
+        onTemplateDataLoadResponse = {
+          ...onTemplateDataLoadResponse,
+          dataItems: onTemplateDataLoadResult.dataItems,
         };
       }
     }
   }
 
-  return onTemplateDataLoadRes;
+  return onTemplateDataLoadResponse;
 };
 
 /**
@@ -1464,6 +1491,7 @@ XiboPlayer.prototype.onDataLoad = function(params) {
       params.dataItems,
       params.meta,
       params.properties,
+      params.isDataReady,
     );
 
     if (onDataLoadResult !== undefined &&

--- a/modules/widget-html-render.twig
+++ b/modules/widget-html-render.twig
@@ -114,13 +114,6 @@
       }
     </script>
 {% endfor %}
-{% for widgetId, parser in onTemplateDataLoad %}
-    <script type="text/javascript" id="onTemplateDataLoad-{{ widgetId }}">
-      function onTemplateDataLoad_{{ widgetId }}(items, meta, properties, isDataReady) {
-        {{ parser|raw }}
-      }
-    </script>
-{% endfor %}
 {% for widgetId, parser in onDataLoad %}
     <script type="text/javascript" id="onDataLoad-{{ widgetId }}">
       function onDataLoad_{{ widgetId }}(items, meta, properties, isDataReady) {

--- a/modules/widget-html-render.twig
+++ b/modules/widget-html-render.twig
@@ -114,16 +114,16 @@
       }
     </script>
 {% endfor %}
-{% for widgetId, parser in onDataLoad %}
-    <script type="text/javascript" id="onDataLoad-{{ widgetId }}">
-      function onDataLoad_{{ widgetId }}(items, meta, properties) {
+{% for widgetId, parser in onTemplateDataLoad %}
+    <script type="text/javascript" id="onTemplateDataLoad-{{ widgetId }}">
+      function onTemplateDataLoad_{{ widgetId }}(items, meta, properties, isDataReady) {
         {{ parser|raw }}
       }
     </script>
 {% endfor %}
-{% for widgetId, parser in onDataError %}
-    <script type="text/javascript" id="onDataError-{{ widgetId }}">
-      function onDataError_{{ widgetId }}(httpStatus, response) {
+{% for widgetId, parser in onDataLoad %}
+    <script type="text/javascript" id="onDataLoad-{{ widgetId }}">
+      function onDataLoad_{{ widgetId }}(items, meta, properties, isDataReady) {
         {{ parser|raw }}
       }
     </script>


### PR DESCRIPTION
PlayerJS: make sure we pass dataItems into both data load methods and hook those up on the back end. 
PlayerJS: Fix v3 players isDataReady.
PlayerJS: call expire now on static widgets where data is not ready
Modules: remove old onDataError.

relates to xibosignageltd/xibo-private#611