### PR TITLE
Elements: add an API check to ensure we aren't trying to save a widget with no elements

### DIFF
--- a/lib/Controller/Widget.php
+++ b/lib/Controller/Widget.php
@@ -1658,6 +1658,14 @@ class Widget extends Base
             throw new InvalidArgumentException(__('Invalid element JSON'), 'body');
         }
 
+        // Validate that we have elements remaining.
+        if (count($elementJson) <= 0) {
+            throw new InvalidArgumentException(
+                __('At least one element is required for this Widget. Please delete it if you no longer need it.'),
+                'body',
+            );
+        }
+
         // Parse the element JSON to see if we need to set `itemsPerPage`
         $slots = [];
         $uniqueSlots = 0;


### PR DESCRIPTION
related to xibosignageltd/xibo-private#617

I elected to throw an error instead of deleting the widget as we shouldn't make a DELETE inside a POST API call. Hopefully the error will give us an example for where this happens in the FE which we can diagnose.