### PR TITLE
DataSet: Add oauth2 client_credentials support for access_token auth

### DIFF
--- a/db/migrations/20232402024000_add_auth_url_for_oauth2_to_dataset_table.php
+++ b/db/migrations/20232402024000_add_auth_url_for_oauth2_to_dataset_table.php
@@ -1,0 +1,50 @@
+<?php
+/*
+ * Copyright (C) 2022 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - http://www.xibo.org.uk
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Add display venue metadata
+ * @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+ */
+
+class AddAuthUrlForOauth2ToDatasetTable extends AbstractMigration
+{
+    /** @inheritDoc */
+    public function change()
+    {
+        // Add new column
+        $this->table('dataset')
+            ->addColumn('oauth2Url', 'string', ['after' => 'authentication', 'limit' => 1024, 'default' => null, 'null' => true])
+            ->addColumn('oauth2Client', 'string', ['after' => 'oauth2Url', 'limit' => 1024, 'default' => null, 'null' => true])
+            ->addColumn('oauth2ClientSecret', 'string', ['after' => 'oauth2Client', 'limit' => 1024, 'default' => null, 'null' => true])
+            ->addColumn('oauth2GrantType', 'enum', ['values' => ['client_credentials', 'authorization_code'], 'default' => null, 'null' => true])
+            ->save();
+
+        // Modify the existing 'authentication' column to add the 'oauth2' value
+        $tableName = 'dataset';
+        $columnName = 'authentication';
+        $newValues = "'none', 'plain', 'basic', 'digest', 'bearer', 'ntlm', 'oauth2'";
+        
+        $this->execute("ALTER TABLE `$tableName` CHANGE `$columnName` `$columnName` ENUM($newValues) DEFAULT NULL");
+    }
+}

--- a/db/migrations/20232902024000_extend_dataset_password_column_length.php
+++ b/db/migrations/20232902024000_extend_dataset_password_column_length.php
@@ -1,0 +1,32 @@
+<?php
+/*
+ * Copyright (C) 2022 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - http://www.xibo.org.uk
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use Phinx\Migration\AbstractMigration;
+
+class ExtendDatasetPasswordColumnLength extends AbstractMigration
+{
+    public function change(): void
+    {
+        // Updating the password column to accept much longer tokens for the Bearer method
+        $this->execute("ALTER TABLE `dataset` MODIFY `password` VARCHAR(1024)");
+    }
+}

--- a/lib/Controller/DataSet.php
+++ b/lib/Controller/DataSet.php
@@ -88,6 +88,9 @@ class DataSet extends Base
     public function displayPage(Request $request, Response $response)
     {
         $this->getState()->template = 'dataset-page';
+        $this->getState()->setData([
+            'users' => $this->userFactory->query(),
+        ]);
 
         return $this->render($request, $response);
     }
@@ -423,6 +426,34 @@ class DataSet extends Base
      *      required=false
      *   ),
      *  @SWG\Parameter(
+     *      name="oauth2Url",
+     *      in="formData",
+     *      description="Oauth2.0 Authorization Token Endpoint",
+     *      type="string",
+     *      required=false
+     *   ),
+     *   @SWG\Parameter(
+     *      name="oauth2Client",
+     *      in="formData",
+     *      description="Oauth2.0 Client ID",
+     *      type="string",
+     *      required=false
+     *   ),
+     *   @SWG\Parameter(
+     *      name="oauth2ClientSecret",
+     *      in="formData",
+     *      description="Oauth2.0 Client Secret",
+     *      type="string",
+     *      required=false
+     *   ),
+     *  @SWG\Parameter(
+     *      name="oauth2GrantType",
+     *      in="formData",
+     *      description="Oauth2.0 Grant Type Requested client_credentials|authorization_code",
+     *      type="string",
+     *      required=false
+     *   ),
+     *  @SWG\Parameter(
      *      name="customHeaders",
      *      in="formData",
      *      description="Comma separated string of custom HTTP headers",
@@ -581,6 +612,10 @@ class DataSet extends Base
             $dataSet->username = $sanitizedParams->getString('username');
             $dataSet->password = $sanitizedParams->getString('password');
             $dataSet->customHeaders = $sanitizedParams->getString('customHeaders');
+            $dataSet->oauth2Url = $sanitizedParams->getString('oauth2Url');
+            $dataSet->oauth2Client = $sanitizedParams->getString('oauth2Client');
+            $dataSet->oauth2ClientSecret = $sanitizedParams->getString('oauth2ClientSecret');
+            $dataSet->oauth2GrantType = $sanitizedParams->getString('oauth2GrantType');
             $dataSet->userAgent = $sanitizedParams->getString('userAgent');
             $dataSet->refreshRate = $sanitizedParams->getInt('refreshRate');
             $dataSet->clearRate = $sanitizedParams->getInt('clearRate');
@@ -748,6 +783,34 @@ class DataSet extends Base
      *      required=false
      *   ),
      *  @SWG\Parameter(
+     *      name="oauth2Url",
+     *      in="formData",
+     *      description="Oauth2.0 Authorization Token Endpoint",
+     *      type="string",
+     *      required=false
+     *   ),
+     *   @SWG\Parameter(
+     *      name="oauth2Client",
+     *      in="formData",
+     *      description="Oauth2.0 Client ID",
+     *      type="string",
+     *      required=false
+     *   ),
+     *   @SWG\Parameter(
+     *      name="oauth2ClientSecret",
+     *      in="formData",
+     *      description="Oauth2.0 Client Secret",
+     *      type="string",
+     *      required=false
+     *   ),
+     *  @SWG\Parameter(
+     *      name="oauth2GrantType",
+     *      in="formData",
+     *      description="Oauth2.0 Grant Type Requested client_credentials|authorization_code",
+     *      type="string",
+     *      required=false
+     *   ),
+     *  @SWG\Parameter(
      *      name="customHeaders",
      *      in="formData",
      *      description="Comma separated string of custom HTTP headers",
@@ -890,6 +953,10 @@ class DataSet extends Base
             $dataSet->username = $sanitizedParams->getString('username');
             $dataSet->password = $sanitizedParams->getString('password');
             $dataSet->customHeaders = $sanitizedParams->getString('customHeaders');
+            $dataSet->oauth2Url = $sanitizedParams->getString('oauth2Url');
+            $dataSet->oauth2Client = $sanitizedParams->getString('oauth2Client');
+            $dataSet->oauth2ClientSecret = $sanitizedParams->getString('oauth2ClientSecret');
+            $dataSet->oauth2GrantType = $sanitizedParams->getString('oauth2GrantType');
             $dataSet->userAgent = $sanitizedParams->getString('userAgent');
             $dataSet->refreshRate = $sanitizedParams->getInt('refreshRate');
             $dataSet->clearRate = $sanitizedParams->getInt('clearRate');
@@ -1420,9 +1487,24 @@ class DataSet extends Base
         $dataSet->authentication = $sanitizedParams->getString('authentication');
         $dataSet->username = $sanitizedParams->getString('username');
         $dataSet->password = $sanitizedParams->getString('password');
+        $dataSet->customHeaders = $sanitizedParams->getString('customHeaders');
+        $dataSet->oauth2Url = $sanitizedParams->getString('oauth2Url');
+        $dataSet->oauth2Client = $sanitizedParams->getString('oauth2Client');
+        $dataSet->oauth2ClientSecret = $sanitizedParams->getString('oauth2ClientSecret');
+        $dataSet->oauth2GrantType = $sanitizedParams->getString('oauth2GrantType');
+        $dataSet->userAgent = $sanitizedParams->getString('userAgent');
+        $dataSet->refreshRate = $sanitizedParams->getInt('refreshRate');
+        $dataSet->clearRate = $sanitizedParams->getInt('clearRate');
+        $dataSet->truncateOnEmpty = $sanitizedParams->getCheckbox('truncateOnEmpty');
+        $dataSet->runsAfter = $sanitizedParams->getInt('runsAfter');
         $dataSet->dataRoot = $sanitizedParams->getString('dataRoot');
+        $dataSet->summarize = $sanitizedParams->getString('summarize');
+        $dataSet->summarizeField = $sanitizedParams->getString('summarizeField');
         $dataSet->sourceId = $sanitizedParams->getInt('sourceId');
         $dataSet->ignoreFirstRow = $sanitizedParams->getCheckbox('ignoreFirstRow');
+        $dataSet->rowLimit = $sanitizedParams->getInt('rowLimit');
+        $dataSet->limitPolicy = $sanitizedParams->getString('limitPolicy') ?? 'stop';
+        $dataSet->csvSeparator = ($dataSet->sourceId === 2) ? $sanitizedParams->getString('csvSeparator') ?? ',' : null;
 
         // Set this DataSet as active.
         $dataSet->setActive();
@@ -1571,3 +1653,4 @@ class DataSet extends Base
         return $this->render($request, $response);
     }
 }
+

--- a/views/dataset-form-add.twig
+++ b/views/dataset-form-add.twig
@@ -29,6 +29,7 @@
 {% endblock %}
 
 {% block formButtons %}
+    {% trans "Help" %}, XiboHelpRender("{{ help }}")
     {% trans "Cancel" %}, XiboDialogClose()
     {% trans "Save" %}, $("#dataSetAddForm").submit()    
 {% endblock %}
@@ -116,12 +117,14 @@
                         {% set auth_digest %}{% trans "Digest" %}{% endset %}
                         {% set auth_ntlm %}{% trans "NTLM" %}{% endset %}
                         {% set auth_bearer %}{% trans "Bearer" %}{% endset %}
+                        {% set auth_oauth2 %}{% trans "Oauth2.0" %}{% endset %}
                         {% set options = [
                             { typeid: "none", type: auth_none },
                             { typeid: "basic", type: auth_basic },
                             { typeid: "digest", type: auth_digest },
                             { typeid: "ntlm", type: auth_ntlm },
-                            { typeid: "bearer", type: auth_bearer }
+                            { typeid: "bearer", type: auth_bearer },
+                            { typeid: "oauth2", type: auth_oauth2 }
                         ] %}
                         {{ forms.dropdown("authentication", "single", title, "", options, "typeid", "type", helpText) }}
 
@@ -140,6 +143,30 @@
                         {% set title %}{% trans "User Agent" %}{% endset %}
                         {% set helpText %}{% trans "Optionally set specific User Agent for this request, provide only the value, relevant header will be added automatically" %}{% endset %}
                         {{ forms.input("userAgent", title, "", helpText) }}
+
+                        {% set title %}{% trans "Oauth2.0 Authentication URL" %}{% endset %}
+                        {% set helpText %}{% trans "This will need to be a url ending in access_token" %}{% endset %}
+                        {{ forms.input("oauth2Url", title, dataset.oauth2Url, helpText, "auth-field-oauth2-url", "") }}
+
+                        {% set title %}{% trans "Oauth2.0 Grant Type" %}{% endset %}
+                        {% set helpText %}{% trans "Set the grant type requested" %}{% endset %}
+                        {% set oauth2_grant_client_credentials %}{% trans "client_credentials" %}{% endset %}
+                        {% set oauth2_grant_authorization_code %}{% trans "authorization_code" %}{% endset %}
+                        {% set options = [
+                            { typeid: "client_credentials", type: oauth2_grant_client_credentials },
+                            { typeid: "authorization_code", type: oauth2_grant_authorization_code }
+                        ] %}
+                        <div class="auth-field-oauth2-grant-type">
+                            {{ forms.dropdown("oauth2GrantType", "single", title, dataSet.oauth2GrantType, options, "typeid", "type", helpText) }}
+                        </div>
+
+                        {% set title %}{% trans "Oauth2.0 Client ID" %}{% endset %}
+                        {% set helpText %}{% trans "Please provide the Client ID" %}{% endset %}
+                        {{ forms.input("oauth2Client", title, dataSet.oauth2Client, helpText, "auth-field-oauth2-client-id", "") }}
+
+                        {% set title %}{% trans "Oauth2.0 Client Secret" %}{% endset %}
+                        {% set helpText %}{% trans "Please provide the Client Secret" %}{% endset %}
+                        {{ forms.input("oauth2ClientSecret", title, dataSet.oauth2ClientSecret, helpText, "auth-field-oauth2-client-secret", "") }}
                     </div>
 
                     <div class="tab-pane" id="data">

--- a/views/dataset-form-edit.twig
+++ b/views/dataset-form-edit.twig
@@ -29,6 +29,7 @@
 {% endblock %}
 
 {% block formButtons %}
+    {% trans "Help" %}, XiboHelpRender("{{ help }}")
     {% trans "Cancel" %}, XiboDialogClose()
     {% trans "Save" %}, $("#dataSetEditForm").submit()    
 {% endblock %}
@@ -127,12 +128,14 @@
                         {% set auth_digest %}{% trans "Digest" %}{% endset %}
                         {% set auth_ntlm %}{% trans "NTLM" %}{% endset %}
                         {% set auth_bearer %}{% trans "Bearer" %}{% endset %}
+                        {% set auth_oauth2 %}{% trans "Oauth2.0" %}{% endset %}
                         {% set options = [
                             { typeid: "none", type: auth_none },
                             { typeid: "basic", type: auth_basic },
                             { typeid: "digest", type: auth_digest },
                             { typeid: "ntlm", type: auth_ntlm },
-                            { typeid: "bearer", type: auth_bearer }
+                            { typeid: "bearer", type: auth_bearer },
+                            { typeid: "oauth2", type: auth_oauth2 }
                         ] %}
                         {{ forms.dropdown("authentication", "single", title, dataSet.authentication, options, "typeid", "type", helpText) }}
 
@@ -151,6 +154,29 @@
                         {% set title %}{% trans "User Agent" %}{% endset %}
                         {% set helpText %}{% trans "Optionally set specific User Agent for this request, provide only the value, relevant header will be added automatically" %}{% endset %}
                         {{ forms.input("userAgent", title, dataSet.userAgent, helpText) }}
+
+                        {% set title %}{% trans "Oauth2.0 Authentication URL" %}{% endset %}
+                        {% set helpText %}{% trans "This will need to be a url ending in access_token" %}{% endset %}
+                        {{ forms.input("oauth2Url", title, dataSet.oauth2Url, helpText, "auth-field-oauth2-url", "") }}
+
+                        {% set title %}{% trans "Oauth2.0 Grant Type" %}{% endset %}
+                        {% set helpText %}{% trans "Set the grant type requested" %}{% endset %}
+                        {% set oauth2_grant_client_credentials %}{% trans "client_credentials" %}{% endset %}
+                        {% set oauth2_grant_authorization_code %}{% trans "authorization_code" %}{% endset %}
+                        {% set options = [
+                            { typeid: "client_credentials", type: oauth2_grant_client_credentials },
+                            { typeid: "authorization_code", type: oauth2_grant_authorization_code }
+                        ] %}
+                        <div class="auth-field-oauth2-grant-type">
+                            {{ forms.dropdown("oauth2GrantType", "single", title, dataSet.oauth2GrantType, options, "typeid", "type", helpText) }}
+                        </div>
+                        {% set title %}{% trans "Oauth2.0 Client ID" %}{% endset %}
+                        {% set helpText %}{% trans "Please provide the Client ID" %}{% endset %}
+                        {{ forms.input("oauth2Client", title, dataSet.oauth2Client, helpText, "auth-field-oauth2-client-id", "") }}
+
+                        {% set title %}{% trans "Oauth2.0 Client Secret" %}{% endset %}
+                        {% set helpText %}{% trans "Please provide the Client Secret" %}{% endset %}
+                        {{ forms.input("oauth2ClientSecret", title, dataSet.oauth2ClientSecret, helpText, "auth-field-oauth2-client-secret", "") }}
                     </div>
 
                     <div class="tab-pane" id="data">

--- a/views/dataset-page.twig
+++ b/views/dataset-page.twig
@@ -224,6 +224,13 @@
                                     table.ajax.reload();
                                     XiboDialogClose();
                                 }
+                            },
+                            help: {
+                                label: "{% trans "Help" %}",
+                                className: "default btn-bb-help",
+                                callback: function() {
+                                    XiboHelpRender("{{ helpService.link("dataset") }}#Importing_from_CSV_file");
+                                }
                             }
                         }
                     }).on('shown.bs.modal', function() {
@@ -354,16 +361,39 @@
             var authentication = $(dialog).find("#authentication").val();
             var $authFieldUserName = $(dialog).find(".auth-field-username");
             var $authFieldPassword = $(dialog).find(".auth-field-password");
+            var $oauth2FieldUrl = $(dialog).find(".auth-field-oauth2-url");
+            var $oauth2FieldClientId = $(dialog).find(".auth-field-oauth2-client-id");
+            var $oauth2FieldClientSecret = $(dialog).find(".auth-field-oauth2-client-secret");
+            var $oauth2FieldGrantType = $(dialog).find(".auth-field-oauth2-grant-type");
 
             if (authentication === "none") {
                 $authFieldUserName.addClass("d-none");
                 $authFieldPassword.addClass("d-none");
+                $oauth2FieldUrl.addClass("d-none");
+                $oauth2FieldClientId.addClass("d-none");
+                $oauth2FieldClientSecret.addClass("d-none");
+                $oauth2FieldGrantType.addClass("d-none");
             } else if (authentication === "bearer") {
                 $authFieldUserName.addClass("d-none");
+                $oauth2FieldUrl.addClass("d-none");
+                $oauth2FieldClientId.addClass("d-none");
+                $oauth2FieldClientSecret.addClass("d-none");
+                $oauth2FieldGrantType.addClass("d-none");
                 $authFieldPassword.removeClass("d-none");
+            } else if (authentication === "oauth2") {
+                $authFieldUserName.addClass("d-none");
+                $authFieldPassword.addClass("d-none");
+                $oauth2FieldUrl.removeClass("d-none");
+                $oauth2FieldClientId.removeClass("d-none");
+                $oauth2FieldClientSecret.removeClass("d-none");
+                $oauth2FieldGrantType.removeClass("d-none");
             } else {
                 $authFieldUserName.removeClass("d-none");
                 $authFieldPassword.removeClass("d-none");
+                $oauth2FieldUrl.addClass("d-none");
+                $oauth2FieldClientId.addClass("d-none");
+                $oauth2FieldClientSecret.addClass("d-none");
+                $oauth2FieldGrantType.addClass("d-none");
             }
         }
 


### PR DESCRIPTION
Implements basic framework for oauth2.0 authentication for remote datasets.

+ Added 4 fields to dataset table
+ Updated dataset entity/controller/factory to support new fields
+ Updated `views` dataset twigs for new fields
+ Updated dataset factory logic to interact with the `oauth2Url` and pass token as `Bearer` in header to request going to the remote dataset api endpoint