### PR TITLE
Widget: DataSet issues with duration is per item and freshness timeout

### DIFF
--- a/lib/Widget/DataSetProvider.php
+++ b/lib/Widget/DataSetProvider.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2023 Xibo Signage Ltd
+ * Copyright (C) 2024 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -53,9 +53,7 @@ class DataSetProvider implements WidgetProviderInterface
             $this->getLog()->debug('fetchDuration: duration is per item');
 
             // Count of rows
-            $lowerLimit = $durationProvider->getWidget()->getOptionValue('lowerLimit', 0);
-            $upperLimit = $durationProvider->getWidget()->getOptionValue('upperLimit', 15);
-            $numItems = $upperLimit - $lowerLimit;
+            $numItems = $durationProvider->getWidget()->getOptionValue('numItems', 0);
 
             // Workaround: dataset static (from v3 dataset view) has rowsPerPage instead.
             $rowsPerPage = $durationProvider->getWidget()->getOptionValue('rowsPerPage', 0);

--- a/modules/dataset.xml
+++ b/modules/dataset.xml
@@ -81,10 +81,6 @@
                 <test message="Upper limit must be 0 or above">
                     <condition type="gte">0</condition>
                 </test>
-                <test type="or" message="When duration is per item the upper limit must be greater than 1">
-                    <condition type="gte">1</condition>
-                    <condition field="durationIsPerItem" type="eq">0</condition>
-                </test>
             </rule>
         </property>
         <property id="randomiseItems" type="checkbox">
@@ -106,6 +102,12 @@
                     <condition field="dataSetId" type="neq"></condition>
                 </test>
             </visibility>
+            <rule>
+                <test type="or" message="When duration is per item the number of items must be greater than 1">
+                    <condition type="gte">1</condition>
+                    <condition field="durationIsPerItem" type="eq">0</condition>
+                </test>
+            </rule>
         </property>
         <property id="durationIsPerItem" type="checkbox">
             <title>Duration is per item</title>

--- a/modules/dataset.xml
+++ b/modules/dataset.xml
@@ -259,6 +259,13 @@
 // meta: Metadata
 // properties: The properties for the widget
 
+// Do we have a freshnessTimeout?
+if (properties.freshnessTimeout > 0
+    && moment(meta.cacheDt).add(properties.freshnessTimeout, 'minutes').isBefore(moment())
+  ) {
+  return {dataItems: []};
+}
+
 // Filter the items array we have been given
 if (parseInt(properties.randomiseItems) === 1) {
     // Sort the items in a random order (considering the entire list)
@@ -319,13 +326,14 @@ return {dataItems: items};
     <onVisible><![CDATA[
 // Do we have a freshnessTimeout?
 if (properties.freshnessTimeout > 0) {
-    // Get the now moment time
-    var now = moment();
-    // Set up an interval to check whether or not we have exceeded our freshness
-    var timer = setInterval(function() {
+    // Set up an interval to check whether we have exceeded our freshness
+    if (window.freshnessTimer) {
+        clearInterval(window.freshnessTimer);
+    }
+    window.freshnessTimer = setInterval(function() {
         if (moment(meta.cacheDt).add(properties.freshnessTimeout, 'minutes').isBefore(moment())) {
-            $("#content").empty().append(properties.noDataMessage);
-            clearInterval(timer);
+            // Reload the widget data.
+            XiboPlayer.playerWidgets[id].render();
         }
     }, 10000);
 }

--- a/modules/src/xibo-dataset-render.js
+++ b/modules/src/xibo-dataset-render.js
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) 2023 Xibo Signage Ltd
+ * Copyright (C) 2024 Xibo Signage Ltd
  *
- * Xibo - Digital Signage - http://www.xibo.org.uk
+ * Xibo - Digital Signage - https://xibosignage.com
  *
  * This file is part of Xibo.
  *
@@ -40,7 +40,11 @@ jQuery.fn.extend({
 
       if (options.rowsPerPage > 0) {
         // Cycle handles this for us
-        $(el).cycle({
+        if ($(el).prop('isCycle')) {
+          $(el).cycle('destroy');
+        }
+
+        $(el).prop('isCycle', true).cycle({
           fx: options.transition,
           timeout: duration * 1000,
           slides: '> table',


### PR DESCRIPTION
This PR addresses two issues:
 - The freshness timeout property in DataSet does not work for Elements
 - The validation for ensuring we have a number of items makes more sense on numItems vs upperLimit