### PR TITLE
Module: cache issues with weather and others

### DIFF
--- a/lib/Xmds/Soap.php
+++ b/lib/Xmds/Soap.php
@@ -927,6 +927,12 @@ class Soap
                                     // TODO: Does this need to be the most recent updated date for all the widgets in
                                     //  this region?
                                     $dataProvider = $dataModule->createDataProvider($widget);
+                                    $dataProvider->setDisplayProperties(
+                                        $this->display->latitude,
+                                        $this->display->longitude,
+                                        $this->display->displayId
+                                    );
+
                                     try {
                                         $widgetDataProviderCache = $this->moduleFactory
                                             ->createWidgetDataProviderCache();
@@ -2368,6 +2374,11 @@ class Soap
                     if ($dataModule->isDataProviderExpected()) {
                         // We only ever return cache.
                         $dataProvider = $dataModule->createDataProvider($widget);
+                        $dataProvider->setDisplayProperties(
+                            $this->display->latitude,
+                            $this->display->longitude,
+                            $this->display->displayId
+                        );
 
                         // Use the cache if we can.
                         try {

--- a/lib/Xmds/Soap7.php
+++ b/lib/Xmds/Soap7.php
@@ -128,6 +128,11 @@ class Soap7 extends Soap6
             if ($dataModule->isDataProviderExpected()) {
                 // We only ever return cache.
                 $dataProvider = $module->createDataProvider($widget);
+                $dataProvider->setDisplayProperties(
+                    $this->display->latitude,
+                    $this->display->longitude,
+                    $this->display->displayId
+                );
 
                 // We only __ever__ return cache from XMDS.
                 try {


### PR DESCRIPTION
Fix an issue where the data provider `useDisplayLocation` variable in the cache key is not substituted correctly https://github.com/xibosignage/xibo/issues/3422

Also a potential solution for "cache not ready" on display specific caches, caused by not supplying the data provider with lat/long/displayId in all cases.