### PR TITLE
Library upload API returns plain/text instead of application/json (fixed)

### DIFF
--- a/lib/Controller/Display.php
+++ b/lib/Controller/Display.php
@@ -2219,9 +2219,6 @@ class Display extends Base
             ob_end_clean();
         }
 
-        // Explicitly set the Content-Type header to application/json
-        $response = $response->withHeader('Content-Type', 'application/json');
-
         echo $img->encode();
         return $this->render($request, $response);
     }

--- a/lib/Controller/Preview.php
+++ b/lib/Controller/Preview.php
@@ -128,9 +128,6 @@ class Preview extends Base
             $this->layoutFactory->concurrentRequestRelease($layout);
         }
 
-        // Explicitly set the Content-Type header to application/json
-        $response = $response->withHeader('Content-Type', 'application/json');
-
         return $this->render($request, $response);
     }
 

--- a/lib/Controller/Task.php
+++ b/lib/Controller/Task.php
@@ -473,9 +473,6 @@ class Task extends Base
 
         $this->setNoOutput();
 
-        // Explicitly set the Content-Type header to application/json
-        $response = $response->withHeader('Content-Type', 'application/json');
-
         return $this->render($request, $response);
     }
 
@@ -577,9 +574,6 @@ class Task extends Base
 
         $this->getLog()->debug('XTR poll stopped');
         $this->setNoOutput();
-
-        // Explicitly set the Content-Type header to application/json
-        $response = $response->withHeader('Content-Type', 'application/json');
 
         return $this->render($request, $response);
     }

--- a/lib/Controller/Widget.php
+++ b/lib/Controller/Widget.php
@@ -1332,9 +1332,6 @@ class Widget extends Base
             throw new ConfigurationException(__('Problem rendering widget'));
         }
 
-        // Explicitly set the Content-Type header to application/json
-        $response = $response->withHeader('Content-Type', 'application/json');
-
         return $this->render($request, $response);
     }
 


### PR DESCRIPTION
relates to xibosignage/xibo#3427

- Removed the setting of the content-type header to application/json in some of the modified methods where it was previously set to json.