### PR TITLE
Module: data provider lat/lng might return null if it has not ever need set on a display

### DIFF
--- a/lib/Connector/OpenWeatherMapConnector.php
+++ b/lib/Connector/OpenWeatherMapConnector.php
@@ -151,8 +151,8 @@ class OpenWeatherMapConnector implements ConnectorInterface
         }
 
         // Build the URL
-        $url = '?lat=' . $providedLat
-            . '&lon=' . $providedLon
+        $url = '?lat=' . ($providedLat ?? '')
+            . '&lon=' . ($providedLon ?? '')
             . '&units=' . $units
             . '&lang=' . $dataProvider->getProperty('lang', 'en')
             . '&appid=[API_KEY]';

--- a/lib/Widget/Provider/DataProvider.php
+++ b/lib/Widget/Provider/DataProvider.php
@@ -162,7 +162,7 @@ class DataProvider implements DataProviderInterface
     /**
      * @inheritDoc
      */
-    public function getDisplayLatitude(): float
+    public function getDisplayLatitude(): ?float
     {
         return $this->latitude;
     }
@@ -170,7 +170,7 @@ class DataProvider implements DataProviderInterface
     /**
      * @inheritDoc
      */
-    public function getDisplayLongitude(): float
+    public function getDisplayLongitude(): ?float
     {
         return $this->longitude;
     }

--- a/lib/Widget/Provider/DataProviderInterface.php
+++ b/lib/Widget/Provider/DataProviderInterface.php
@@ -61,15 +61,15 @@ interface DataProviderInterface
 
     /**
      * Get the latitude for this display
-     * @return float
+     * @return float|null
      */
-    public function getDisplayLatitude(): float;
+    public function getDisplayLatitude(): ?float;
 
     /**
      * Get the longitude for this display
-     * @return float
+     * @return float|null
      */
-    public function getDisplayLongitude(): float;
+    public function getDisplayLongitude(): ?float;
 
     /**
      * Get the preview flag


### PR DESCRIPTION
xibosignage/xibo#3428

The prior fix of this issue cause this error:

```
Xibo\Widget\Provider\DataProvider::getDisplayLatitude(): Return value must be of type float, null returned
```

This is because some displays will have `null` in their lat/lng. It is possible we would have seen this error before, but we were not reliably using the lat/lng in all cases.