### PR TITLE
Module: data provider: make sure there is always a lat/lon

### DIFF
--- a/lib/Connector/OpenWeatherMapConnector.php
+++ b/lib/Connector/OpenWeatherMapConnector.php
@@ -151,15 +151,11 @@ class OpenWeatherMapConnector implements ConnectorInterface
         }
 
         // Build the URL
-        $url = '?units=' . $units
+        $url = '?lat=' . $providedLat
+            . '&lon=' . $providedLon
+            . '&units=' . $units
             . '&lang=' . $dataProvider->getProperty('lang', 'en')
             . '&appid=[API_KEY]';
-
-        // If lat/lon is provided
-        if (!empty($providedLat) && !empty($providedLon)) {
-            $url .= '&lat=' . $providedLat
-                . '&lon=' . $providedLon;
-        }
 
         // Cache expiry date
         $cacheExpire = Carbon::now()->addSeconds($this->getSetting('cachePeriod'));

--- a/lib/Connector/OpenWeatherMapConnector.php
+++ b/lib/Connector/OpenWeatherMapConnector.php
@@ -151,11 +151,15 @@ class OpenWeatherMapConnector implements ConnectorInterface
         }
 
         // Build the URL
-        $url = '?lat=' . ($providedLat ?? '')
-            . '&lon=' . ($providedLon ?? '')
-            . '&units=' . $units
+        $url = '?units=' . $units
             . '&lang=' . $dataProvider->getProperty('lang', 'en')
             . '&appid=[API_KEY]';
+
+        // If lat/lon is provided
+        if (!empty($providedLat) && !empty($providedLon)) {
+            $url .= '&lat=' . $providedLat
+                . '&lon=' . $providedLon;
+        }
 
         // Cache expiry date
         $cacheExpire = Carbon::now()->addSeconds($this->getSetting('cachePeriod'));

--- a/lib/XTR/WidgetSyncTask.php
+++ b/lib/XTR/WidgetSyncTask.php
@@ -194,14 +194,11 @@ class WidgetSyncTask implements TaskInterface
         $dataProvider->setMediaFactory($this->mediaFactory);
 
         // Set our provider up for the display
-        if ($display !== null) {
-            $dataProvider->setDisplayProperties($display->latitude, $display->longitude, $display->displayId);
-        } else {
-            $dataProvider->setDisplayProperties(
-                $this->getConfig()->getSetting('DEFAULT_LAT'),
-                $this->getConfig()->getSetting('DEFAULT_LONG')
-            );
-        }
+        $dataProvider->setDisplayProperties(
+            $display?->latitude ?: $this->getConfig()->getSetting('DEFAULT_LAT'),
+            $display?->longitude ?: $this->getConfig()->getSetting('DEFAULT_LONG'),
+            $display?->displayId ?? 0
+        );
 
         $widgetDataProviderCache = $this->moduleFactory->createWidgetDataProviderCache();
 

--- a/lib/Xmds/Soap.php
+++ b/lib/Xmds/Soap.php
@@ -928,8 +928,8 @@ class Soap
                                     //  this region?
                                     $dataProvider = $dataModule->createDataProvider($widget);
                                     $dataProvider->setDisplayProperties(
-                                        $this->display->latitude,
-                                        $this->display->longitude,
+                                        $this->display->latitude ?: $this->getConfig()->getSetting('DEFAULT_LAT'),
+                                        $this->display->longitude ?: $this->getConfig()->getSetting('DEFAULT_LONG'),
                                         $this->display->displayId
                                     );
 
@@ -2375,8 +2375,8 @@ class Soap
                         // We only ever return cache.
                         $dataProvider = $dataModule->createDataProvider($widget);
                         $dataProvider->setDisplayProperties(
-                            $this->display->latitude,
-                            $this->display->longitude,
+                            $this->display->latitude ?: $this->getConfig()->getSetting('DEFAULT_LAT'),
+                            $this->display->longitude ?: $this->getConfig()->getSetting('DEFAULT_LONG'),
                             $this->display->displayId
                         );
 

--- a/lib/Xmds/Soap7.php
+++ b/lib/Xmds/Soap7.php
@@ -129,8 +129,8 @@ class Soap7 extends Soap6
                 // We only ever return cache.
                 $dataProvider = $module->createDataProvider($widget);
                 $dataProvider->setDisplayProperties(
-                    $this->display->latitude,
-                    $this->display->longitude,
+                    $this->display->latitude ?: $this->getConfig()->getSetting('DEFAULT_LAT'),
+                    $this->display->longitude ?: $this->getConfig()->getSetting('DEFAULT_LONG'),
                     $this->display->displayId
                 );
 


### PR DESCRIPTION
The root cause of our issue is that we did not provide the CMS lat/lon when the display one was null/empty.

xibosignage/xibo#3428