### PR TITLE
Module: improve the way widget data is cached and returned

### DIFF
--- a/lib/Widget/Render/WidgetDataProviderCache.php
+++ b/lib/Widget/Render/WidgetDataProviderCache.php
@@ -216,11 +216,10 @@ class WidgetDataProviderCache
         }
 
         // Set some cache dates so that we can track when this data provider was cached and when it should expire.
-        // The expireDt must always be 15 minutes to allow plenty of time for the WidgetSyncTask to regenerate.
         $dataProvider->addOrUpdateMeta('cacheDt', Carbon::now()->format('c'));
         $dataProvider->addOrUpdateMeta(
             'expireDt',
-            Carbon::now()->addSeconds(max($dataProvider->getCacheTtl(), 900))->format('c')
+            Carbon::now()->addSeconds($dataProvider->getCacheTtl())->format('c')
         );
 
         // Set our cache from the data provider.
@@ -235,7 +234,8 @@ class WidgetDataProviderCache
         }
 
         // Keep the cache 50% longer than necessary
-        $this->cache->expiresAfter(ceil($dataProvider->getCacheTtl() * 1.5));
+        // The expireDt must always be 15 minutes to allow plenty of time for the WidgetSyncTask to regenerate.
+        $this->cache->expiresAfter(ceil(max($dataProvider->getCacheTtl() * 1.5, 900)));
 
         // Save to the pool
         $this->pool->save($this->cache);


### PR DESCRIPTION
https://github.com/xibosignage/xibo/issues/3434

This PR recognises that when using Stash the OLD invalidation method, it will only return old data if another cache is currently regenerating the cache and has called lock. This means that we were very unlikely to return old cache via XMDS.

This PR extends the expiry time on all caches by 50% or sets it to 15 minutes, whichever is longer. The original expiry information is stored inside the cache, so that we can decide ourselves whether that data is a miss or valid.

The upshot is that we should avoid any getData errors once this PR is included, although there will be a possibility of returning old data for widgets which are set to update data very frequently.