### PR TITLE
Dashboard: remove unused code to improve page load performance.

### DIFF
--- a/lib/Controller/StatusDashboard.php
+++ b/lib/Controller/StatusDashboard.php
@@ -310,16 +310,9 @@ class StatusDashboard extends Base
             $data['libraryWidgetData'] = json_encode($libraryUsage);
 
             // Get a count of users
-            $data['countUsers'] = count($this->userFactory->query());
+            $data['countUsers'] = $this->userFactory->count();
 
             // Get a count of active layouts, only for display groups we have permission for
-            $displayGroups = $this->displayGroupFactory->query(null, ['isDisplaySpecific' => -1]);
-            $displayGroupIds = array_map(function ($element) {
-                return $element->displayGroupId;
-            }, $displayGroups);
-            // Add an empty one
-            $displayGroupIds[] = -1;
-
             $params = ['now' => Carbon::now()->format('U')];
 
             $sql = '
@@ -422,9 +415,7 @@ class StatusDashboard extends Base
 
             // Display Status and Media Inventory data - Level one
             $displays = $this->displayFactory->query();
-            $displayIds = [];
             $displayLoggedIn = [];
-            $displayNames = [];
             $displayMediaStatus = [];
             $displaysOnline = 0;
             $displaysOffline = 0;
@@ -432,8 +423,6 @@ class StatusDashboard extends Base
             $displaysMediaNotUpToDate = 0;
 
             foreach ($displays as $display) {
-                $displayIds[] = $display->displayId;
-                $displayNames[] = $display->display;
                 $displayLoggedIn[] = $display->loggedIn;
                 $displayMediaStatus[] = $display->mediaInventoryStatus;
             }
@@ -456,7 +445,6 @@ class StatusDashboard extends Base
 
             $data['displayStatus'] = json_encode([$displaysOnline, $displaysOffline]);
             $data['displayMediaStatus'] = json_encode([$displaysMediaUpToDate, $displaysMediaNotUpToDate]);
-            $data['displayLabels'] = json_encode($displayNames);
         } catch (Exception $e) {
             $this->getLog()->error($e->getMessage());
             $this->getLog()->debug($e->getTraceAsString());

--- a/lib/Factory/UserFactory.php
+++ b/lib/Factory/UserFactory.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2023 Xibo Signage Ltd
+ * Copyright (C) 2024 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -439,7 +439,7 @@ class UserFactory extends BaseFactory
         if (!$this->getUser()->isSuperAdmin()) {
             // Non-super admins should only get a count of users in their group
             $sql .= '
-                WHERE user.userId IN (
+                WHERE `user`.userId IN (
                     SELECT `otherUserLinks`.userId
                       FROM `lkusergroup`
                         INNER JOIN `group`


### PR DESCRIPTION
This PR adjusts two parts of the status dashboard logic.

1. we queried and looped over display groups for no apparent reason (likely this is legacy code left by mistake) - removed
2. we uses a count() method on an array of users, which has been switched to a direct query approach instead

fixes xibosignage/xibo#3440