### PR TITLE
Schedule page shows no events when mobile layout is used

### DIFF
--- a/ui/src/core/xibo-cms.js
+++ b/ui/src/core/xibo-cms.js
@@ -3484,6 +3484,7 @@ function initDatePicker($element, baseFormat, displayFormat, options, onChangeCa
             allowInput: false,
             defaultDate: ((initialValue != undefined) ? initialValue : null),
             altInputClass: 'datePickerHelper ' + $element.attr('class'),
+            disableMobile: true,
             altFormat: displayFormat,
             dateFormat: baseFormat,
             locale: (language != 'en-GB') ? language : 'default',


### PR DESCRIPTION
relates to xibosignage/xibo#3442

 - Flatpickr mobile version disabled to allow the CMS custom code to still work