### PR TITLE
Bandwidth Report: Fixed Table/Chart is not showing any data

### DIFF
--- a/lib/Report/Bandwidth.php
+++ b/lib/Report/Bandwidth.php
@@ -1,4 +1,24 @@
 <?php
+/*
+ * Copyright (C) 2024 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 namespace Xibo\Report;
 
@@ -256,7 +276,8 @@ class Bandwidth implements ReportInterface
         }
 
         // Decide what our units are going to be, based on the size
-        $base = floor(log($maxSize) / log(1024));
+        // We need to put a fallback value in case it returns an infinite value
+        $base = !is_infinite(floor(log($maxSize) / log(1024))) ? floor(log($maxSize) / log(1024)) : 0;
 
         $labels = [];
         $data = [];


### PR DESCRIPTION
## Changes:
- Fixes error in displaying the table/chart in Bandwidth Report
- RCA: When the data returned is empty, infinite value is calculated in the $base, hence, causes the type error

Relates to: https://github.com/xibosignage/xibo/issues/3438