### PR TITLE
Data Widget: increasing/decreasing the number of slots does not update the duration when durationPerItem is checked

### DIFF
--- a/lib/Controller/Widget.php
+++ b/lib/Controller/Widget.php
@@ -1692,7 +1692,18 @@ class Widget extends Base
         }
 
         if ($uniqueSlots > 0) {
+            $currentItemsPerPage = $widget->getOptionValue('itemsPerPage', null);
+
             $widget->setOptionValue('itemsPerPage', 'attrib', $uniqueSlots);
+
+            // We should calculate the widget duration as it might have changed
+            if ($currentItemsPerPage != $uniqueSlots) {
+                $this->getLog()->debug('saveElements: updating unique slots to ' . $uniqueSlots
+                    . ', currentItemsPerPage: ' . $currentItemsPerPage);
+
+                $module = $this->moduleFactory->getByType($widget->type);
+                $widget->calculateDuration($module);
+            }
         }
 
         // Save elements

--- a/lib/Widget/DataSetProvider.php
+++ b/lib/Widget/DataSetProvider.php
@@ -50,8 +50,6 @@ class DataSetProvider implements WidgetProviderInterface
     public function fetchDuration(DurationProviderInterface $durationProvider): WidgetProviderInterface
     {
         if ($durationProvider->getWidget()->getOptionValue('durationIsPerItem', 0) == 1) {
-            $this->getLog()->debug('fetchDuration: duration is per item');
-
             // Count of rows
             $numItems = $durationProvider->getWidget()->getOptionValue('numItems', 0);
 
@@ -66,6 +64,13 @@ class DataSetProvider implements WidgetProviderInterface
             }
 
             $durationProvider->setDuration($durationProvider->getWidget()->calculatedDuration * $numItems);
+
+            $this->getLog()->debug(sprintf(
+                'fetchDuration: duration is per item, numItems: %s, rowsPerPage: %s, itemsPerPage: %s',
+                $numItems,
+                $rowsPerPage,
+                $itemsPerPage
+            ));
         }
         return $this;
     }

--- a/ui/src/editor-core/widget.js
+++ b/ui/src/editor-core/widget.js
@@ -685,12 +685,10 @@ Widget.prototype.saveElements = function(
   let savePending;
 
   const reloadLayout = function(forceReload = false) {
-    if (reload || forceReload) {
-      app.reloadData(app.layout,
-        {
-          refreshEditor: true,
-        });
-    }
+    app.reloadData(app.layout,
+      {
+        refreshEditor: (reload || forceReload),
+      });
   };
 
   // If there's no more elements in widget, remove it

--- a/ui/src/layout-editor/main.js
+++ b/ui/src/layout-editor/main.js
@@ -2951,6 +2951,7 @@ lD.checkLayoutStatus = function() {
         res.extra.status,
         res.html,
         res.extra.statusMessage,
+        res.extra.duration,
       );
 
       if (


### PR DESCRIPTION
This PR fixes two problems:
 - the duration was not being calculated when the number of unique slots (pages) was changed
 - the UI was not refreshing layout status after saving elements