### PR TITLE
Schedule: fix monthly repeat and from/to dates for time zone.

### DIFF
--- a/lib/Controller/Schedule.php
+++ b/lib/Controller/Schedule.php
@@ -2284,8 +2284,9 @@ class Schedule extends Base
             ], $params)
         );
 
-        // Setting for whether we show Layouts with out permissions
+        // Grab some settings which determine how events are displayed.
         $showLayoutName = ($this->getConfig()->getSetting('SCHEDULE_SHOW_LAYOUT_NAME') == 1);
+        $defaultTimezone = $this->getConfig()->getSetting('defaultTimezone');
 
         foreach ($events as $event) {
             $event->load();
@@ -2348,15 +2349,25 @@ class Schedule extends Base
                         $i++;
                     }
                 } else if ($event->recurrenceType === 'Month') {
+                    // Force the timezone for this date (schedule from/to dates are timezone agnostic, but this
+                    // date still has timezone information, which could lead to use formatting as the wrong day)
+                    $date = Carbon::parse($event->fromDt)->tz($defaultTimezone);
+                    $this->getLog()->debug('grid: setting description for monthly event with date: '
+                        . $date->toAtomString());
+
                     if ($event->recurrenceMonthlyRepeatsOn === 0) {
-                        $repeatsOn = 'the ' . Carbon::parse($event->fromDt)->format('jS') . ' day of the month';
+                        $repeatsOn = 'the ' . $date->format('jS') . ' day of the month';
                     } else {
-                        $date = Carbon::parse($event->fromDt);
+                        // Which day of the month is this?
                         $firstDay = Carbon::parse('first ' . $date->format('l') . ' of ' . $date->format('F'));
+
+                        $this->getLog()->debug('grid: the first day of the month for this date is: '
+                            . $firstDay->toAtomString());
+
                         $nth = $firstDay->diffInDays($date) / 7 + 1;
                         $repeatWeekDayDate = $date->copy()->setDay($nth)->format('jS');
                         $repeatsOn = 'the ' . $repeatWeekDayDate . ' '
-                            . Carbon::parse($event->fromDt)->format('l')
+                            . $date->format('l')
                             . ' of the month';
                     }
                 }
@@ -2390,6 +2401,16 @@ class Schedule extends Base
             if ($event->eventTypeId == \Xibo\Entity\Schedule::$COMMAND_EVENT) {
                 $event->toDt = $event->fromDt;
             }
+
+            // Set the row from/to date to be an ISO date for display (no timezone)
+            $event->setUnmatchedProperty(
+                'displayFromDt',
+                Carbon::createFromTimestamp($event->fromDt)->format(DateFormatHelper::getSystemFormat())
+            );
+            $event->setUnmatchedProperty(
+                'displayToDt',
+                Carbon::createFromTimestamp($event->toDt)->format(DateFormatHelper::getSystemFormat())
+            );
 
             if ($this->isApi($request)) {
                 continue;

--- a/views/schedule-page.twig
+++ b/views/schedule-page.twig
@@ -1374,7 +1374,7 @@
               if (data.isAlways === 1) {
                 return '{{ "Always"|trans }}'
               } else {
-                return moment(data.fromDt, 'X').format(jsDateFormat)
+                return moment(data.displayFromDt, systemDateFormat).format(jsDateFormat)
               }
             }
           },
@@ -1386,7 +1386,7 @@
               if (data.isAlways === 1) {
                 return '{{ "Always"|trans }}'
               } else {
-                return moment(data.toDt, 'X').format(jsDateFormat)
+                return moment(data.displayToDt, systemDateFormat).format(jsDateFormat)
               }
             }
           },


### PR DESCRIPTION
The from/to date are being shown with respect to CMS timezone, instead of timezone agnostic. In addition the recurrence detail uses the timezone specific date during formatting.

xibosignage/xibo#3429