### PR TITLE
Widget: Marquee up/down scrolling on android

### DIFF
--- a/modules/src/xibo-text-render.js
+++ b/modules/src/xibo-text-render.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Xibo Signage Ltd
+ * Copyright (C) 2024 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -326,6 +326,11 @@ jQuery.fn.extend({
 
         // Make sure the speed is something sensible
         options.speed = (options.speed === 0) ? 1 : options.speed;
+
+        // Set the content div height, if we don't do this when the marquee
+        // plugin floats the content inside, this goes to 0 and up/down
+        // marquees don't work
+        $contentDiv.css('height', height);
       }
 
       if (marquee) {
@@ -364,8 +369,10 @@ jQuery.fn.extend({
           options.effect === 'marqueeUp' ||
           options.effect === 'marqueeDown'
         ) {
-          $contentDiv.css('height', '100%');
-          $contentDiv.find('.scroll').css('height', '100%').children()
+          // Set the height of the scroller to 100%
+          $contentDiv.find('.scroll')
+            .css('height', '100%')
+            .children()
             .css({'white-space': 'normal', float: 'none'});
         }
 


### PR DESCRIPTION
The marquee sets the contents of scroller to float:left, which on android causes the containing div height to go from 100% to 0 (as the things inside it are all floated). Fixing a pixel height to the content div makes the container for the scroller have a height.

fixes xibosignage/xibo#3388