### PR TITLE
Editor: Viewer dimensions wrong when refreshing page with toolbar toggled off

### DIFF
--- a/ui/src/style/toolbar.scss
+++ b/ui/src/style/toolbar.scss
@@ -1080,6 +1080,10 @@
 }
 
 /* Side bar */
+.editor-toolbar.editor-side-bar {
+    min-width: $toolbar-width;
+}
+
 .editor-toolbar.editor-side-bar nav {
     width: $toolbar-width;
     padding: 1rem 0 !important;


### PR DESCRIPTION
relates to xibosignageltd/xibo-private#794