### PR TITLE
Schedule add/edit - Cannot manually input time in Firefox

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "datatables.net-select-bs4": "^1.3.1",
     "ekko-lightbox": "~5.3.0",
     "fibers": "^4.0.3",
-    "flatpickr": "^4.6.3",
+    "flatpickr": "^4.6.13",
     "font-awesome": "~4.7.0",
     "form-serializer": "~2.5.0",
     "globalthis": "^1.0.3",


### PR DESCRIPTION
relates to xibosignage/xibo#2587