### PR TITLE
Schedule Edit: Preview button on Edit Event form requires Campaign features to be enabled

### DIFF
--- a/lib/Controller/Preview.php
+++ b/lib/Controller/Preview.php
@@ -69,7 +69,7 @@ class Preview extends Base
         }
 
         if (!$this->getUser()->checkViewable($layout)
-            || !$this->getUser()->featureEnabled(['layout.view', 'playlist.view'])
+            || !$this->getUser()->featureEnabled(['layout.view', 'playlist.view', 'campaign.view'])
         ) {
             throw new AccessDeniedException();
         }

--- a/lib/routes-web.php
+++ b/lib/routes-web.php
@@ -134,13 +134,16 @@ $app->get('/layout/view', ['\Xibo\Controller\Layout', 'displayPage'])
     ->setName('layout.view');
 
 $app->group('', function(\Slim\Routing\RouteCollectorProxy $group) {
-    $group->get('/layout/preview/{id}', ['\Xibo\Controller\Preview', 'show'])->setName('layout.preview');
     $group->get('/layout/xlf/{id}', ['\Xibo\Controller\Preview', 'getXlf'])->setName('layout.getXlf');
     $group->get('/layout/background/{id}', ['\Xibo\Controller\Layout', 'downloadBackground'])->setName('layout.download.background');
     $group->get('/layout/thumbnail/{id}', ['\Xibo\Controller\Layout', 'downloadThumbnail'])->setName('layout.download.thumbnail');
     $group->get('/layout/playerBundle', ['\Xibo\Controller\Preview', 'playerBundle'])->setName('layout.preview.bundle');
     $group->get('/connector/widget/preview', ['\Xibo\Controller\Connector', 'connectorPreview'])->setName('layout.preview.connector');
 })->addMiddleware(new FeatureAuth($app->getContainer(), ['layout.view', 'template.view']));
+
+$app->get('/layout/preview/{id}', ['\Xibo\Controller\Preview', 'show'])
+    ->addMiddleware(new FeatureAuth($app->getContainer(), ['layout.view', 'template.view', 'campaign.view']))
+    ->setName('layout.preview');
 
 // forms
 $app->get('/layout/form/add', ['\Xibo\Controller\Layout','addForm'])

--- a/lib/routes-web.php
+++ b/lib/routes-web.php
@@ -369,8 +369,7 @@ $app->get('/campaign/form/{id}/selectfolder', ['\Xibo\Controller\Campaign','sele
     ->setName('campaign.selectfolder.form');
 
 $app->get('/campaign/{id}/preview', ['\Xibo\Controller\Campaign','preview'])
-    ->addMiddleware(new FeatureAuth($app->getContainer(), ['campaign.view']))
-    ->addMiddleware(new FeatureAuth($app->getContainer(), ['layout.view']))
+    ->addMiddleware(new FeatureAuth($app->getContainer(), ['campaign.view', 'layout.view']))
     ->setName('campaign.preview');
 
 //

--- a/views/schedule-form-add.twig
+++ b/views/schedule-form-add.twig
@@ -152,10 +152,12 @@
                         {{ forms.inputFullScreenSchedule('playlist', title, "", helpText, "playlist-control full-screen-control", playlistId, "", "", readonlySelect) }}
                         {{ forms.hidden('fullScreenCampaignId') }}
 
-                        <div class="form-group row preview-button-container">
-                            <div class="offset-md-2 col-md-10">
-                                <a id="previewButton" class="btn btn-success" target="_blank" data-url="{{ url_for("campaign.preview", {id: ':id'}) }}">{% trans "Preview" %} <span class="fa fa-tablet"></span></a>
-                                <small class="form-text text-muted">{% trans "Preview your selection in a new tab" %}</small>
+                        <div style="{% if not currentUser.featureEnabled('campaign.view') %}display: none;{% endif %}">
+                            <div class="form-group row preview-button-container">
+                                <div class="offset-md-2 col-md-10">
+                                    <a id="previewButton" class="btn btn-success" target="_blank" data-url="{{ url_for("campaign.preview", {id: ':id'}) }}">{% trans "Preview" %} <span class="fa fa-tablet"></span></a>
+                                    <small class="form-text text-muted">{% trans "Preview your selection in a new tab" %}</small>
+                                </div>
                             </div>
                         </div>
 

--- a/views/schedule-form-add.twig
+++ b/views/schedule-form-add.twig
@@ -152,7 +152,7 @@
                         {{ forms.inputFullScreenSchedule('playlist', title, "", helpText, "playlist-control full-screen-control", playlistId, "", "", readonlySelect) }}
                         {{ forms.hidden('fullScreenCampaignId') }}
 
-                        <div style="{% if not currentUser.featureEnabled('campaign.view') %}display: none;{% endif %}">
+                        <div style="{% if not (currentUser.featureEnabled('campaign.view') or currentUser.featureEnabled('layout.view')) %}display: none;{% endif %}">
                             <div class="form-group row preview-button-container">
                                 <div class="offset-md-2 col-md-10">
                                     <a id="previewButton" class="btn btn-success" target="_blank" data-url="{{ url_for("campaign.preview", {id: ':id'}) }}">{% trans "Preview" %} <span class="fa fa-tablet"></span></a>

--- a/views/schedule-form-edit.twig
+++ b/views/schedule-form-edit.twig
@@ -123,7 +123,7 @@
 
                         {{ forms.hidden('fullScreenCampaignId', event.getUnmatchedProperty("fullScreenCampaignId")) }}
 
-                        <div style="{% if not currentUser.featureEnabled('campaign.view') %}display: none;{% endif %}">
+                        <div style="{% if not (currentUser.featureEnabled('campaign.view') or currentUser.featureEnabled('layout.view')) %}display: none;{% endif %}">
                             <div class="form-group row preview-button-container">
                                 <div class="offset-md-2 col-md-10">
                                     <a id="previewButton" class="btn btn-success" target="_blank" data-url="{{ url_for("campaign.preview", {id: ':id'}) }}">{% trans "Preview" %} <span class="fa fa-tablet"></span></a>

--- a/views/schedule-form-edit.twig
+++ b/views/schedule-form-edit.twig
@@ -123,10 +123,12 @@
 
                         {{ forms.hidden('fullScreenCampaignId', event.getUnmatchedProperty("fullScreenCampaignId")) }}
 
-                        <div class="form-group row preview-button-container">
-                            <div class="offset-md-2 col-md-10">
-                                <a id="previewButton" class="btn btn-success" target="_blank" data-url="{{ url_for("campaign.preview", {id: ':id'}) }}">{% trans "Preview" %} <span class="fa fa-tablet"></span></a>
-                                <small class="form-text text-muted">{% trans "Preview your selection in a new tab" %}</small>
+                        <div style="{% if not currentUser.featureEnabled('campaign.view') %}display: none;{% endif %}">
+                            <div class="form-group row preview-button-container">
+                                <div class="offset-md-2 col-md-10">
+                                    <a id="previewButton" class="btn btn-success" target="_blank" data-url="{{ url_for("campaign.preview", {id: ':id'}) }}">{% trans "Preview" %} <span class="fa fa-tablet"></span></a>
+                                    <small class="form-text text-muted">{% trans "Preview your selection in a new tab" %}</small>
+                                </div>
                             </div>
                         </div>
 


### PR DESCRIPTION
relates to xibosignageltd/xibo-private#539

- Did not need to provide a dedicated preview button for `layout` Event Type, as the current preview button already accommodates both campaign and layout previews.