### PR TITLE
Permissions: only update permission record in the DB if necessary 

### DIFF
--- a/lib/Entity/Permission.php
+++ b/lib/Entity/Permission.php
@@ -1,8 +1,8 @@
 <?php
 /*
- * Copyright (c) 2022 Xibo Signage Ltd
+ * Copyright (C) 2024 Xibo Signage Ltd
  *
- * Xibo - Digital Signage - http://www.xibo.org.uk
+ * Xibo - Digital Signage - https://xibosignage.com
  *
  * This file is part of Xibo.
  *
@@ -123,21 +123,45 @@ class Permission implements \JsonSerializable
         $this->permissionId = null;
     }
 
-    public function save()
+    /**
+     * Save this permission
+     * @return void
+     */
+    public function save(): void
     {
         if ($this->permissionId == 0) {
             // Check there is something to add
             if ($this->view != 0 || $this->edit != 0 || $this->delete != 0) {
-                $this->getLog()->debug(sprintf('Adding Permission for %s, %d. GroupId: %d - View = %d, Edit = %d, Delete = %d', $this->entity, $this->objectId, $this->groupId, $this->view, $this->edit, $this->delete));
+                $this->getLog()->debug(sprintf(
+                    'save: Adding Permission for %s, %d. GroupId: %d - View = %d, Edit = %d, Delete = %d',
+                    $this->entity,
+                    $this->objectId,
+                    $this->groupId,
+                    $this->view,
+                    $this->edit,
+                    $this->delete,
+                ));
+
                 $this->add();
             }
         } else {
-            $this->getLog()->debug(sprintf('Editing Permission for %s, %d. GroupId: %d - View = %d, Edit = %d, Delete = %d', $this->entity, $this->objectId, $this->groupId, $this->view, $this->edit, $this->delete));
-            // Are we all 0 permissions
-            if ($this->view == 0 && $this->edit == 0 && $this->delete == 0)
+            $this->getLog()->debug(sprintf(
+                'save: Editing Permission for %s, %d. GroupId: %d - View = %d, Edit = %d, Delete = %d',
+                $this->entity,
+                $this->objectId,
+                $this->groupId,
+                $this->view,
+                $this->edit,
+                $this->delete,
+            ));
+
+            // If all permissions are set to 0, then we delete the record to tidy up
+            if ($this->view == 0 && $this->edit == 0 && $this->delete == 0) {
                 $this->delete();
-            else
+            } else if (count($this->getChangedProperties()) > 0) {
+                // Something has changed, so run the update.
                 $this->update();
+            }
         }
     }
 

--- a/lib/Factory/PermissionFactory.php
+++ b/lib/Factory/PermissionFactory.php
@@ -143,15 +143,11 @@ class PermissionFactory extends BaseFactory
         $params = array('entity' => $entity, 'objectId' => $objectId);
 
         foreach ($this->getStore()->select($sql, $params) as $row) {
-            $permission = $this->createEmpty();
-            $permission->permissionId = $row['permissionId'];
-            $permission->groupId = $row['groupId'];
-            $permission->view = $row['view'];
-            $permission->edit = $row['edit'];
-            $permission->delete = $row['delete'];
+            $permission = $this->createEmpty()->hydrate($row, [
+                'intProperties' => ['view', 'edit', 'delete'],
+            ]);
             $permission->objectId = $objectId;
             $permission->entity = $entity;
-            $permission->entityId = $row['entityId'];
 
             $permissions[] = $permission;
         }
@@ -285,23 +281,13 @@ class PermissionFactory extends BaseFactory
 
         $sql = $select . $body . $order . $limit;
 
-
-
         foreach ($this->getStore()->select($sql, $params) as $row) {
-            // TODO Sanitizer?
-            $permission = $this->createEmpty();
-            $permission->permissionId = intval($row['permissionId']);
-            $permission->groupId = intval($row['groupId']);
-            $permission->view = intval($row['view']);
-            $permission->edit = intval($row['edit']);
-            $permission->delete = intval($row['delete']);
-            $permission->objectId = intval($objectId);
-            $permission->entity = $entity;
-            $permission->entityId = intval($entityId);
-            $permission->isUser = intval($row['isuserspecific']);
-            $permission->group = ($row['group']);
-
-            $permissions[] = $permission;
+            $row['entityId'] = $entityId;
+            $row['entity'] = $entity;
+            $row['objectId'] = $objectId;
+            $permissions[] = $this->createEmpty()->hydrate($row, [
+                'intProperties' => ['view', 'edit', 'delete', 'isUser'],
+            ]);
         }
 
         // Paging
@@ -321,10 +307,16 @@ class PermissionFactory extends BaseFactory
      */
     public function getByGroupId($entity, $groupId)
     {
-        $permissions = array();
+        $permissions = [];
 
         $sql = '
-            SELECT `permission`.`permissionId`, `permission`.`groupId`, `permission`.`objectId`, `permission`.`view`, `permission`.`edit`, `permission`.`delete`, permissionentity.entityId
+            SELECT `permission`.`permissionId`,
+                   `permission`.`groupId`,
+                   `permission`.`objectId`,
+                   `permission`.`view`,
+                   `permission`.`edit`,
+                   `permission`.`delete`,
+                   `permissionentity`.`entityId`
               FROM `permission`
                 INNER JOIN `permissionentity`
                 ON `permissionentity`.entityId = permission.entityId
@@ -333,22 +325,13 @@ class PermissionFactory extends BaseFactory
              WHERE entity = :entity
                 AND `permission`.`groupId` = :groupId
         ';
-        $params = array('entity' => 'Xibo\Entity\\' . $entity, 'groupId' => $groupId);
-
-
+        $params = ['entity' => 'Xibo\Entity\\' . $entity, 'groupId' => $groupId];
 
         foreach ($this->getStore()->select($sql, $params) as $row) {
-            $permission = $this->createEmpty();
-            $permission->permissionId = $row['permissionId'];
-            $permission->groupId = $row['groupId'];
-            $permission->view = $row['view'];
-            $permission->edit = $row['edit'];
-            $permission->delete = $row['delete'];
-            $permission->objectId = $row['objectId'];
-            $permission->entity = $entity;
-            $permission->entityId = $row['entityId'];
-
-            $permissions[] = $permission;
+            $row['entity'] = $entity;
+            $permissions[] = $this->createEmpty()->hydrate($row, [
+                'intProperties' => ['view', 'edit', 'delete'],
+            ]);
         }
 
         return $permissions;
@@ -360,7 +343,7 @@ class PermissionFactory extends BaseFactory
      * @param int $userId
      * @return Permission[]
      */
-    public function getByUserId($entity, $userId)
+    public function getByUserId($entity, $userId): array
     {
         $permissions = [];
 
@@ -371,7 +354,7 @@ class PermissionFactory extends BaseFactory
                 `permission`.`view`, 
                 `permission`.`edit`, 
                 `permission`.`delete`, 
-                `permissionentity`.entityId
+                `permissionentity`.`entityId`
               FROM `permission`
                 INNER JOIN `permissionentity`
                 ON `permissionentity`.entityId = permission.entityId
@@ -402,17 +385,10 @@ class PermissionFactory extends BaseFactory
         $params = ['entity' => $entity, 'userId' => $userId];
 
         foreach ($this->getStore()->select($sql, $params) as $row) {
-            $permission = $this->createEmpty();
-            $permission->permissionId = $row['permissionId'];
-            $permission->groupId = $row['groupId'];
-            $permission->view = $row['view'];
-            $permission->edit = $row['edit'];
-            $permission->delete = $row['delete'];
-            $permission->objectId = $row['objectId'];
-            $permission->entity = $entity;
-            $permission->entityId = $row['entityId'];
-
-            $permissions[] = $permission;
+            $row['entity'] = $entity;
+            $permissions[] = $this->createEmpty()->hydrate($row, [
+                'intProperties' => ['view', 'edit', 'delete'],
+            ]);
         }
 
         return $permissions;
@@ -422,7 +398,7 @@ class PermissionFactory extends BaseFactory
      * Get Full Permissions
      * @return Permission
      */
-    public function getFullPermissions()
+    public function getFullPermissions(): Permission
     {
         $permission = $this->createEmpty();
         $permission->view = 1;


### PR DESCRIPTION
This PR tries to reduce the number of unnecessary SQL updates which would run when saving permissions if there are no changes to the existing records.

Inserting new records is unaffected. Inserting existing records only happens if a property has changed.

relates to xibosignageltd/xibo-private#797