### PR TITLE
XMDS: use a sub-query to filter out draft layouts before outer join

### DIFF
--- a/lib/Factory/ScheduleFactory.php
+++ b/lib/Factory/ScheduleFactory.php
@@ -273,10 +273,15 @@ class ScheduleFactory extends BaseFactory
                 ON `schedule`.CampaignID = campaign.CampaignID
                 LEFT OUTER JOIN `lkcampaignlayout`
                 ON lkcampaignlayout.CampaignID = campaign.CampaignID
-                LEFT OUTER JOIN `layout`
-                ON lkcampaignlayout.LayoutID = layout.LayoutID
-                  AND layout.retired = 0
-                  AND layout.parentId IS NULL
+                LEFT OUTER JOIN (
+                    SELECT `layout`.`layoutId`,
+                        `layout`.`status`, 
+                        `layout`.`duration`
+                      FROM `layout`
+                     WHERE `layout`.`retired` = 0
+                        AND `layout`.`parentId` IS NULL
+                ) `layout`
+                ON `lkcampaignlayout`.LayoutID = `layout`.layoutId  
                 LEFT OUTER JOIN `command`
                 ON `command`.commandId = `schedule`.commandId
                 LEFT OUTER JOIN `schedule_sync`


### PR DESCRIPTION
This PR updates the query for returning the schedule to XMDS so that layouts which have an associated draft are not returned twice in the schedule.

fixes to xibosignage/xibo#3437