### PR TITLE
Reports : API Requests new report type, various adjustments.

### DIFF
--- a/lib/Dependencies/Factories.php
+++ b/lib/Dependencies/Factories.php
@@ -43,6 +43,11 @@ class Factories
                 $repository->useBaseDependenciesService($c->get('RepositoryBaseDependenciesService'));
                 return $repository;
             },
+            'apiRequestsFactory' => function (ContainerInterface $c) {
+                $repository = new \Xibo\Factory\ApplicationRequestsFactory();
+                $repository->useBaseDependenciesService($c->get('RepositoryBaseDependenciesService'));
+                return $repository;
+            },
             'applicationFactory' => function (ContainerInterface $c) {
                 $repository = new \Xibo\Factory\ApplicationFactory(
                     $c->get('user'),

--- a/lib/Entity/ApplicationRequest.php
+++ b/lib/Entity/ApplicationRequest.php
@@ -1,0 +1,94 @@
+<?php
+/*
+ * Copyright (C) 2024 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Xibo\Entity;
+
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Xibo\Service\LogServiceInterface;
+use Xibo\Storage\StorageServiceInterface;
+
+class ApplicationRequest implements \JsonSerializable
+{
+    use EntityTrait;
+
+    /**
+     * @SWG\Property(description="The request ID")
+     * @var int
+     */
+    public $requestId;
+
+    /**
+     * @SWG\Property(description="The user ID")
+     * @var int
+     */
+    public $userId;
+
+    /**
+     * @SWG\Property(description="The application ID")
+     * @var string
+     */
+    public $applicationId;
+
+    /**
+     * @SWG\Property(description="The request route")
+     * @var string
+     */
+    public $url;
+
+    /**
+     * @SWG\Property(description="The request method")
+     * @var string
+     */
+    public $method;
+
+    /**
+     * @SWG\Property(description="The request start time")
+     * @var string
+     */
+    public $startTime;
+
+    /**
+     * @SWG\Property(description="The request end time")
+     * @var string
+     */
+    public $endTime;
+
+    /**
+     * @SWG\Property(description="The request duration")
+     * @var int
+     */
+    public $duration;
+
+    /**
+     * Entity constructor.
+     * @param StorageServiceInterface $store
+     * @param LogServiceInterface $log
+     * @param EventDispatcherInterface $dispatcher
+     */
+    public function __construct(
+        StorageServiceInterface $store,
+        LogServiceInterface $log,
+        EventDispatcherInterface $dispatcher
+    ) {
+        $this->setCommonDependencies($store, $log, $dispatcher);
+    }
+}

--- a/lib/Factory/ApplicationRequestsFactory.php
+++ b/lib/Factory/ApplicationRequestsFactory.php
@@ -1,0 +1,40 @@
+<?php
+/*
+ * Copyright (C) 2024 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Xibo\Factory;
+
+use Xibo\Entity\ApplicationRequest;
+
+/**
+ * Class ApplicationRequestsFactory
+ * @package Xibo\Factory
+ */
+class ApplicationRequestsFactory extends BaseFactory
+{
+    /**
+     * @return ApplicationRequest
+     */
+    public function createEmpty(): ApplicationRequest
+    {
+        return new ApplicationRequest($this->getStore(), $this->getLog(), $this->getDispatcher());
+    }
+}

--- a/lib/Middleware/ApiAuthorization.php
+++ b/lib/Middleware/ApiAuthorization.php
@@ -192,12 +192,14 @@ class ApiAuthorization implements Middleware
         ', [
             'userId' => $user->userId,
             'applicationId' => $validatedRequest->getAttribute('oauth_client_id'),
-            'url' => $resource,
+            'url' => htmlspecialchars($request->getUri()->getPath()),
             'method' => $request->getMethod(),
             'startTime' => Carbon::now(),
             'endTime' => Carbon::now(),
             'duration' => 0
-        ]);
+        ], 'api_requests_history');
+
+        $this->app->getContainer()->get('store')->commitIfNecessary('api_requests_history');
 
         $logger->setUserId($user->userId);
         $this->app->getContainer()->set('user', $user);

--- a/reports/apirequests-email-template.twig
+++ b/reports/apirequests-email-template.twig
@@ -58,7 +58,7 @@
                     <td>{{ item.objectAfter }}</td>
                 </tr>
             {% endfor %}
-        {% else %}
+        {% elseif metadata.logType == 'debug' %}
             <tr>
                 <th>{% trans "Date" %}</th>
                 <th>{% trans "UserName" %}</th>
@@ -81,6 +81,27 @@
                     <td>{{ item.url }}</td>
                     <td>{{ item.type }}</td>
                     <td>{{ item.message }}</td>
+                </tr>
+            {% endfor %}
+        {% else %}
+            <tr>
+                <th>{% trans "Date" %}</th>
+                <th>{% trans "UserName" %}</th>
+                <th>{% trans "User ID" %}</th>
+                <th>{% trans "Application" %}</th>
+                <th>{% trans "Request ID" %}</th>
+                <th>{% trans "Method" %}</th>
+                <th>{% trans "Url" %}</th>
+            </tr>
+            {% for item in tableData %}
+                <tr>
+                    <td>{{ item.startTime }}</td>
+                    <td>{{ item.userName }}</td>
+                    <td>{{ item.userId }}</td>
+                    <td>{{ item.applicationName }}</td>
+                    <td>{{ item.requestId }}</td>
+                    <td>{{ item.method }}</td>
+                    <td>{{ item.url }}</td>
                 </tr>
             {% endfor %}
         {% endif %}

--- a/reports/apirequests-report-form.twig
+++ b/reports/apirequests-report-form.twig
@@ -68,6 +68,7 @@
 
                             {% set title = "Report Type"|trans %}
                             {% set options = [
+                                { id: 'requests', value: "Requests"|trans },
                                 { id: 'audit', value: "Audit"|trans },
                                 { id: 'debug', value: "Debug"|trans },
                             ] %}
@@ -140,6 +141,31 @@
                         </table>
                     </div>
                 </div>
+
+                <div class="card-body api-requests-history d-none">
+                    <!-- DATATABLE -->
+                    <div class="table-container" id="table_wrapper">
+                        <table id="apiRequestsHistoryGrid"
+                               class="table xibo-table table-striped"
+                               style="width: 100%"
+                               data-url="{{ url_for("report.data", {name: 'apirequests'}) }}">
+                            <thead>
+                            <tr>
+                                <th>{% trans "Date" %}</th>
+                                <th>{% trans "UserName" %}</th>
+                                <th>{% trans "User ID" %}</th>
+                                <th>{% trans "Application" %}</th>
+                                <th>{% trans "Request ID" %}</th>
+                                <th>{% trans "Method" %}</th>
+                                <th>{% trans "Url" %}</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
@@ -176,12 +202,15 @@
 
         $('[data-toggle="popover"]').popover();
         let $report = $('#apiRequestsHistoryFilter');
-        let $auditDataTable = $('#apiRequestsHistoryAuditGrid')
+        let $auditDataTable = $('#apiRequestsHistoryAuditGrid');
         let auditTable = createAuditTable($auditDataTable);
-        let $logDataTable = $('#apiRequestsHistoryLogGrid')
-        let logTable = createLogTable($logDataTable)
+        let $logDataTable = $('#apiRequestsHistoryLogGrid');
+        let logTable = createLogTable($logDataTable);
+        let $requestsDataTable = $('#apiRequestsHistoryGrid');
+        let requestsTable = createRequestsTable($requestsDataTable);
 
         let result; // XHR get data result
+        let reportType = $report.find('#type').val();
 
         let imageLoader = $("#imageLoader");
         let $warning = $("#applyWarning");
@@ -198,14 +227,22 @@
               result = data;
               $applyBtn.removeClass('disabled');
               imageLoader.removeClass('fa fa-spinner fa-spin loading-icon');
-              if ($report.find('#type').val() === 'audit') {
+
+              if (reportType === 'audit') {
                 $('.api-requests-history-audit').removeClass('d-none');
                 $('.api-requests-history-log').addClass('d-none');
+                $('.api-requests-history').addClass('d-none');
                 setTabularData(auditTable, result.table);
-              } else {
-                $('.api-requests-history-audit').addClass('d-none');
+              } else if (reportType === 'debug') {
                 $('.api-requests-history-log').removeClass('d-none');
+                $('.api-requests-history-audit').addClass('d-none');
+                $('.api-requests-history').addClass('d-none');
                 setTabularData(logTable, result.table);
+              } else {
+                $('.api-requests-history').removeClass('d-none');
+                $('.api-requests-history-audit').addClass('d-none');
+                $('.api-requests-history-log').addClass('d-none');
+                setTabularData(requestsTable, result.table);
               }
             },
             error: function error(xhr, textStatus, _error) {
@@ -233,16 +270,20 @@
 
         // Apply
         $applyBtn.click(function () {
+          reportType = $report.find('#type').val();
           $(this).addClass('disabled');
           imageLoader.addClass('fa fa-spinner fa-spin loading-icon');
           getData($auditDataTable.data().url);
         });
 
         $("#refreshGrid").click(function () {
-          if ($report.find('#type').val() === 'audit') {
+          reportType = $report.find('#type').val();
+          if (reportType === 'audit') {
             auditTable.ajax.reload();
-          } else {
+          } else if (reportType === 'debug') {
             logTable.ajax.reload();
+          } else {
+            requestsTable.ajax.reload();
           }
         });
 
@@ -319,6 +360,31 @@
               {data: 'url'},
               {data: 'type'},
               {data: 'message'},
+            ]
+          })
+        }
+
+        function createRequestsTable($dataTable) {
+          return $dataTable.DataTable({
+            language: dataTablesLanguage,
+            dom: dataTablesTemplate,
+            searching: false,
+            paging: true,
+            bInfo: false,
+            stateSave: true,
+            bDestroy: true,
+            processing: true,
+            responsive: true,
+            order: [[0, 'desc']],
+            data: {},
+            columns: [
+              {data: 'startTime'},
+              {data: 'userName'},
+              {data: 'userId'},
+              {data: 'applicationName'},
+              {data: 'requestId'},
+              {data: 'method'},
+              {data: 'url'},
             ]
           })
         }

--- a/reports/apirequests-report-preview.twig
+++ b/reports/apirequests-report-preview.twig
@@ -66,7 +66,7 @@
                         </tbody>
                     </table>
                 </div>
-                {% else %}
+                {% elseif metadata.logType == 'debug' %}
                     <div class="XiboData card pt-3">
                         <table id="apiRequestsHistoryDebugReportPreview" class="table table-striped">
                             <thead>
@@ -80,6 +80,25 @@
                                 <th>{% trans "Url" %}</th>
                                 <th>{% trans "Level" %}</th>
                                 <th>{% trans "Details" %}</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+
+                            </tbody>
+                        </table>
+                    </div>
+                {% else %}
+                    <div class="XiboData card pt-3">
+                        <table id="apiRequestsHistoryReportPreview" class="table table-striped">
+                            <thead>
+                            <tr>
+                                <th>{% trans "Date" %}</th>
+                                <th>{% trans "UserName" %}</th>
+                                <th>{% trans "User ID" %}</th>
+                                <th>{% trans "Application" %}</th>
+                                <th>{% trans "Request ID" %}</th>
+                                <th>{% trans "Method" %}</th>
+                                <th>{% trans "Url" %}</th>
                             </tr>
                             </thead>
                             <tbody>
@@ -139,7 +158,7 @@
           auditTable.on('processing.dt', function(e, settings, processing) {
             dataTableProcessing(e, settings, processing);
           });
-        } else {
+        } else if (type === 'debug') {
           const debugTable = $("#apiRequestsHistoryAuditReportPreview").DataTable({
             language: dataTablesLanguage,
             dom: dataTablesTemplate,
@@ -164,6 +183,31 @@
 
           debugTable.on('draw', dataTableDraw);
           debugTable.on('processing.dt', function(e, settings, processing) {
+            dataTableProcessing(e, settings, processing);
+          });
+        } else {
+          const requestsTable = $("#apiRequestsHistoryReportPreview").DataTable({
+            language: dataTablesLanguage,
+            dom: dataTablesTemplate,
+            paging:   false,
+            ordering: false,
+            info:     false,
+            order: [[0, 'desc']],
+            searching: false,
+            data: outputData,
+            columns: [
+              {data: 'startTime'},
+              {data: 'userName'},
+              {data: 'userId'},
+              {data: 'applicationName'},
+              {data: 'requestId'},
+              {data: 'method'},
+              {data: 'url'},
+            ]
+          });
+
+          requestsTable.on('draw', dataTableDraw);
+          requestsTable.on('processing.dt', function(e, settings, processing) {
             dataTableProcessing(e, settings, processing);
           });
         }

--- a/reports/apirequests-schedule-form-add.twig
+++ b/reports/apirequests-schedule-form-add.twig
@@ -72,6 +72,7 @@
 
                 {% set title = "Report Type"|trans %}
                 {% set options = [
+                    { id: 'requests', value: "Requests"|trans },
                     { id: 'audit', value: "Audit"|trans },
                     { id: 'debug', value: "Debug"|trans },
                 ] %}


### PR DESCRIPTION
relates to xibosignage/xibo#3362

- Requests : New API requests report type that does not join on log/audit tables
- Various adjustments to the report, forms etc to suit the new report type
- Change the url added to database to correctly include route parameters ( previously things like `{id}` would be saved)
- Separate sql connection and commit to ensure we get the error requests in the table
- Added small new Factory and Entity for API requests