### PR TITLE
Content-Length header check with newer Apache versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ tests/http-client.private.env.json
 
 # Hide module/template translate file
 locale/moduletranslate.php
+/nbproject/private/

--- a/lib/Factory/MediaFactory.php
+++ b/lib/Factory/MediaFactory.php
@@ -271,12 +271,17 @@ class MediaFactory extends BaseFactory
                                 $this->getLog()->debug('processDownloads: successful, headers = '
                                     . var_export($response->getHeaders(), true));
 
-                                // Get the content length
-                                $contentLength = $response->getHeaderLine('Content-Length');
-                                if (empty($contentLength)
-                                    || intval($contentLength) > ByteFormatter::toBytes(Environment::getMaxUploadSize())
-                                ) {
-                                    throw new \Exception(__('File too large'));
+                                // Apache 2.4.44 and newer removed header Content-Length (at least with cgi php)
+                                // https://bz.apache.org/bugzilla/show_bug.cgi?id=68973
+                                // https://bz.apache.org/bugzilla/show_bug.cgi?id=68907
+                                if($response->hasHeader('Content-Length')){
+                                    // Get the content length
+                                    $contentLength = $response->getHeaderLine('Content-Length');
+                                    if (empty($contentLength)
+                                        || intval($contentLength) > ByteFormatter::toBytes(Environment::getMaxUploadSize())
+                                    ) {
+                                        throw new \Exception(__('File too large'));
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
Apache 2.4.44 and newer removed the Content-Length header.

So third party media via the ticker module for example can't be loaded, and throws an exception from guzzlehttp 'An error was encountered during the on_headers event'

this is just a quick and dirty fix. maybe there is a better solution.