### PR TITLE
Bandwidth Report: Fixed data calculation error for displays with same name

### DIFF
--- a/lib/Report/Bandwidth.php
+++ b/lib/Report/Bandwidth.php
@@ -255,7 +255,7 @@ class Bandwidth implements ReportInterface
             $params['displayid'] = $displayId;
         }
 
-        $SQL .= 'GROUP BY display.display ';
+        $SQL .= 'GROUP BY display.displayId, display.display ';
 
         if ($displayId != 0) {
             $SQL .= ' , bandwidthtype.name ';


### PR DESCRIPTION
## Changes
- Fixed data calculation error for duplicate display names

Relates to: https://github.com/xibosignage/xibo/issues/3462