### PR TITLE
Pixabay: Get 1080p videos by default instead of 4k

### DIFF
--- a/lib/Connector/PixabayConnector.php
+++ b/lib/Connector/PixabayConnector.php
@@ -192,26 +192,31 @@ class PixabayConnector implements ConnectorInterface
                     $searchResult->type = 'video';
                     $searchResult->thumbnail = $result->videos->tiny->url;
                     $searchResult->duration = $result->duration;
-                    if (!empty($result->videos->large)) {
+
+                    if ($this->isDefaultVideoResolution($result, 'large')) {
                         $searchResult->download = $result->videos->large->url;
                         $searchResult->width = $result->videos->large->width;
                         $searchResult->height = $result->videos->large->height;
                         $searchResult->fileSize = $result->videos->large->size;
-                    } else if (!empty($result->videos->medium)) {
+                        $searchResult->videoThumbnailUrl = $result->videos->large->thumbnail;
+                    } else if ($this->isDefaultVideoResolution($result, 'medium')) {
                         $searchResult->download = $result->videos->medium->url;
                         $searchResult->width = $result->videos->medium->width;
                         $searchResult->height = $result->videos->medium->height;
                         $searchResult->fileSize = $result->videos->medium->size;
-                    } else if (!empty($result->videos->small)) {
+                        $searchResult->videoThumbnailUrl = $result->videos->medium->thumbnail;
+                    } else if ($this->isDefaultVideoResolution($result, 'small')) {
                         $searchResult->download = $result->videos->small->url;
                         $searchResult->width = $result->videos->small->width;
                         $searchResult->height = $result->videos->small->height;
                         $searchResult->fileSize = $result->videos->small->size;
+                        $searchResult->videoThumbnailUrl = $result->videos->small->thumbnail;
                     } else {
                         $searchResult->download = $result->videos->tiny->url;
                         $searchResult->width = $result->videos->tiny->width;
                         $searchResult->height = $result->videos->tiny->height;
                         $searchResult->fileSize = $result->videos->tiny->size;
+                        $searchResult->videoThumbnailUrl = $result->videos->tiny->thumbnail;
                     }
 
                     if (!empty($result->picture_id ?? null)) {
@@ -221,10 +226,6 @@ class PixabayConnector implements ConnectorInterface
                             $result->picture_id,
                             'https://i.vimeocdn.com/video/pictureId_960x540.png'
                         );
-                    } else {
-                        // Use the medium thumbnail if we have it, otherwise the tiny one.
-                        $searchResult->videoThumbnailUrl = $result->videos->medium->thumbnail
-                            ?? $result->videos->tiny->thumbnail;
                     }
                 } else {
                     $searchResult->type = 'image';
@@ -270,5 +271,19 @@ class PixabayConnector implements ConnectorInterface
         $providerDetails->mediaTypes = ['image', 'video'];
 
         $event->addProvider($providerDetails);
+    }
+
+    /**
+     * Checks if the Pixabay video size is within the 1080p default resolution
+     * @param $result
+     * @param string $size
+     * @return bool
+     */
+    private function isDefaultVideoResolution($result, string $size) : bool
+    {
+        return (!empty($result->videos->$size)
+            && $result->videos->$size->width <= 1920
+            && $result->videos->$size->height <= 1920
+        );
     }
 }


### PR DESCRIPTION
## Changes
BE:
- Get 1080p videos by default instead of 4k

Relates to: https://github.com/xibosignageltd/xibo-private/issues/840