### PR TITLE
Help button: Fix for Help button gets in the way of paging and mobile forms

### DIFF
--- a/views/authed.twig
+++ b/views/authed.twig
@@ -109,7 +109,8 @@
     {% set helpLinks = helpService.getLinksForPage(route) %}
     {% set isXiboThemed = theme.getThemeConfig("app_name") == "Xibo" %}
     {% if helpLinks|length > 0 %}
-        <div id="help-pane" class="help-pane">
+        {# Hide in mobile view (sm/<768px)  #}
+        <div id="help-pane" class="d-none d-md-block help-pane">
             <div class="card help-pane-card border-dark">
                 <div class="card-header">{{ "Help"|trans }} <i class="close-icon fa fa-times"></i></div>
                 <ul class="list-group list-group-flush">


### PR DESCRIPTION
## Changes
FE:
- Help Button: Hide in mobile view

Relates to: https://github.com/xibosignage/xibo/issues/3489