### PR TITLE
Display: assigning a display to a group from the Display page doesn't clear the cache

### DIFF
--- a/lib/Controller/Display.php
+++ b/lib/Controller/Display.php
@@ -2167,6 +2167,9 @@ class Display extends Base
             $displayGroup->save(['validate' => false]);
         }
 
+        // Queue display to check for cache updates
+        $display->notify();
+
         // Return
         $this->getState()->hydrate([
             'httpStatus' => 204,


### PR DESCRIPTION
relates to xibosignage/xibo#3481