### PR TITLE
Schedule Criteria: weather "clear sky" condition does not match

### DIFF
--- a/lib/Connector/OpenWeatherMapConnector.php
+++ b/lib/Connector/OpenWeatherMapConnector.php
@@ -684,6 +684,17 @@ class OpenWeatherMapConnector implements ConnectorInterface
                 ->addValues('number', [])
             ->addMetric('owm_wind_speed', __('Wind Speed'))
                 ->addValues('number', [])
+            ->addMetric('owm_wind_direction', __('Wind Direction'))
+                ->addValues('dropdown', [
+                    'N' => __('North'),
+                    'NE' => __('Northeast'),
+                    'E' => __('East'),
+                    'SE' => __('Southeast'),
+                    'S' => __('South'),
+                    'SW' => __('Southwest'),
+                    'W' => __('West'),
+                    'NW' => __('Northwest'),
+                ])
             ->addMetric('owm_wind_deg', __('Wind Direction (degrees)'))
                 ->addValues('number', [])
             ->addMetric('owm_humidity', __('Humidity (Percent)'))
@@ -709,7 +720,7 @@ class OpenWeatherMapConnector implements ConnectorInterface
         $data = array();
 
         // format the weather condition
-        $data['weather_condition'] = str_replace(' ', '_', strtolower($item['weather'][0]['main']));
+        $data['owm_weather_main'] = str_replace(' ', '_', strtolower($item['weather'][0]['main']));
 
         // Temperature
         // imperial = F
@@ -722,50 +733,50 @@ class OpenWeatherMapConnector implements ConnectorInterface
         $apparentTempMetric = ($apparentTempImperial - 32) * 5 / 9;
 
         // Round those temperature values
-        $data['temperature_imperial'] = round($tempImperial, 0);
-        $data['apparent_temperature_imperial'] = round($apparentTempImperial, 0);
-        $data['temperature_metric'] = round($tempMetric, 0);
-        $data['apparent_temperature_metric'] = round($apparentTempMetric, 0);
+        $data['owm_temp_imperial'] = round($tempImperial, 0);
+        $data['owm_feels_like_imperial'] = round($apparentTempImperial, 0);
+        $data['owm_temp_metric'] = round($tempMetric, 0);
+        $data['owm_feels_like_metric'] = round($apparentTempMetric, 0);
 
 
         // Humidity
-        $data['humidity'] = $item['humidity'];
+        $data['owm_humidity'] = $item['humidity'];
 
         // Pressure
         // received in hPa, display in mB
-        $data['pressure'] = $item['pressure'] / 100;
+        $data['owm_pressure'] = $item['pressure'] / 100;
 
         // Wind
         // metric = meters per second
         // imperial = miles per hour
-        $data['wind_speed'] = $item['wind_speed'] ?? $item['speed'] ?? null;
-        $data['wind_bearing'] = $item['wind_deg'] ?? $item['deg'] ?? null;
+        $data['owm_wind_speed'] = $item['wind_speed'] ?? $item['speed'] ?? null;
+        $data['owm_wind_deg'] = $item['wind_deg'] ?? $item['deg'] ?? null;
 
         if ($requestUnit === 'metric' && $windSpeedUnit !== 'MPS') {
             // We have MPS and need to go to something else
             if ($windSpeedUnit === 'MPH') {
                 // Convert MPS to MPH
-                $data['wind_speed'] = round($data['wind_speed'] * 2.237, 2);
+                $data['owm_wind_deg'] = round($data['owm_wind_deg'] * 2.237, 2);
             } else if ($windSpeedUnit === 'KPH') {
                 // Convert MPS to KPH
-                $data['wind_speed'] = round($data['wind_speed'] * 3.6, 2);
+                $data['owm_wind_deg'] = round($data['owm_wind_deg'] * 3.6, 2);
             }
         } else if ($requestUnit === 'imperial' && $windSpeedUnit !== 'MPH') {
             if ($windSpeedUnit === 'MPS') {
                 // Convert MPH to MPS
-                $data['wind_speed'] = round($data['wind_speed'] / 2.237, 2);
+                $data['owm_wind_deg'] = round($data['owm_wind_deg'] / 2.237, 2);
             } else if ($windSpeedUnit === 'KPH') {
                 // Convert MPH to KPH
-                $data['wind_speed'] = round($data['wind_speed'] * 1.609344, 2);
+                $data['owm_wind_deg'] = round($data['owm_wind_deg'] * 1.609344, 2);
             }
         }
 
         // Wind direction
-        $data['wind_direction'] = '--';
-        if ($data['wind_bearing'] !== null && $data['wind_bearing'] !== 0) {
+        $data['owm_wind_direction'] = '--';
+        if ($data['owm_wind_deg'] !== null && $data['owm_wind_deg'] !== 0) {
             foreach (self::cardinalDirections() as $dir => $angles) {
-                if ($data['wind_bearing'] >= $angles[0] && $data['wind_bearing'] < $angles[1]) {
-                    $data['wind_direction'] = $dir;
+                if ($data['owm_wind_deg'] >= $angles[0] && $data['owm_wind_deg'] < $angles[1]) {
+                    $data['owm_wind_direction'] = $dir;
                     break;
                 }
             }
@@ -774,17 +785,17 @@ class OpenWeatherMapConnector implements ConnectorInterface
         // Visibility
         // metric = meters
         // imperial = meters?
-        $data['visibility'] = $item['visibility'] ?? '--';
+        $data['owm_visibility'] = $item['visibility'] ?? '--';
 
-        if ($data['visibility'] !== '--') {
+        if ($data['owm_visibility'] !== '--') {
             // Always in meters
             if ($visibilityDistanceUnit === 'mi') {
                 // Convert meters to miles
-                $data['visibility'] = $data['visibility'] / 1609;
+                $data['owm_visibility'] = $data['owm_visibility'] / 1609;
             } else {
                 if ($visibilityDistanceUnit === 'km') {
                     // Convert meters to KM
-                    $data['visibility'] = $data['visibility'] / 1000;
+                    $data['owm_visibility'] = $data['owm_visibility'] / 1000;
                 }
             }
         }

--- a/lib/Connector/OpenWeatherMapConnector.php
+++ b/lib/Connector/OpenWeatherMapConnector.php
@@ -664,8 +664,8 @@ class OpenWeatherMapConnector implements ConnectorInterface
     public function onScheduleCriteriaRequest(ScheduleCriteriaRequestInterface $event): void
     {
         // Initialize Open Weather Schedule Criteria parameters
-        $event->addType('openweathermap', __('Weather'))
-            ->addMetric('owm_weather_condition', __('Weather Condition'))
+        $event->addType('weather', __('Weather'))
+            ->addMetric('weather_condition', __('Weather Condition'))
                 ->addValues('dropdown', [
                     'Thunderstorm' => __('Thunderstorm'),
                     'Drizzle' => __('Drizzle'),
@@ -674,17 +674,17 @@ class OpenWeatherMapConnector implements ConnectorInterface
                     'Clear' => __('Clear'),
                     'Clouds' => __('Clouds')
                 ])
-            ->addMetric('owm_temp_imperial', __('Temperature (Imperial)'))
+            ->addMetric('weather_temp_imperial', __('Temperature (Imperial)'))
                 ->addValues('number', [])
-            ->addMetric('owm_temp_metric', __('Temperature (Metric)'))
+            ->addMetric('weather_temp_metric', __('Temperature (Metric)'))
                 ->addValues('number', [])
-            ->addMetric('owm_feels_like_imperial', __('Apparent Temperature (Imperial)'))
+            ->addMetric('weather_feels_like_imperial', __('Apparent Temperature (Imperial)'))
                 ->addValues('number', [])
-            ->addMetric('owm_feels_like_metric', __('Apparent Temperature (Metric)'))
+            ->addMetric('weather_feels_like_metric', __('Apparent Temperature (Metric)'))
                 ->addValues('number', [])
-            ->addMetric('owm_wind_speed', __('Wind Speed'))
+            ->addMetric('weather_wind_speed', __('Wind Speed'))
                 ->addValues('number', [])
-            ->addMetric('owm_wind_direction', __('Wind Direction'))
+            ->addMetric('weather_wind_direction', __('Wind Direction'))
                 ->addValues('dropdown', [
                     'N' => __('North'),
                     'NE' => __('Northeast'),
@@ -695,13 +695,13 @@ class OpenWeatherMapConnector implements ConnectorInterface
                     'W' => __('West'),
                     'NW' => __('Northwest'),
                 ])
-            ->addMetric('owm_wind_degrees', __('Wind Direction (degrees)'))
+            ->addMetric('weather_wind_degrees', __('Wind Direction (degrees)'))
                 ->addValues('number', [])
-            ->addMetric('owm_humidity', __('Humidity (Percent)'))
+            ->addMetric('weather_humidity', __('Humidity (Percent)'))
                 ->addValues('number', [])
-            ->addMetric('owm_pressure', __('Pressure'))
+            ->addMetric('weather_pressure', __('Pressure'))
                 ->addValues('number', [])
-            ->addMetric('owm_visibility', __('Visibility (meters)'))
+            ->addMetric('weather_visibility', __('Visibility (meters)'))
                 ->addValues('number', []);
     }
 
@@ -720,7 +720,7 @@ class OpenWeatherMapConnector implements ConnectorInterface
         $data = array();
 
         // format the weather condition
-        $data['owm_weather_condition'] = str_replace(' ', '_', strtolower($item['weather'][0]['main']));
+        $data['weather_condition'] = str_replace(' ', '_', strtolower($item['weather'][0]['main']));
 
         // Temperature
         // imperial = F
@@ -733,50 +733,50 @@ class OpenWeatherMapConnector implements ConnectorInterface
         $apparentTempMetric = ($apparentTempImperial - 32) * 5 / 9;
 
         // Round those temperature values
-        $data['owm_temp_imperial'] = round($tempImperial, 0);
-        $data['owm_feels_like_imperial'] = round($apparentTempImperial, 0);
-        $data['owm_temp_metric'] = round($tempMetric, 0);
-        $data['owm_feels_like_metric'] = round($apparentTempMetric, 0);
+        $data['weather_temp_imperial'] = round($tempImperial, 0);
+        $data['weather_feels_like_imperial'] = round($apparentTempImperial, 0);
+        $data['weather_temp_metric'] = round($tempMetric, 0);
+        $data['weather_feels_like_metric'] = round($apparentTempMetric, 0);
 
 
         // Humidity
-        $data['owm_humidity'] = $item['humidity'];
+        $data['weather_humidity'] = $item['humidity'];
 
         // Pressure
         // received in hPa, display in mB
-        $data['owm_pressure'] = $item['pressure'] / 100;
+        $data['weather_pressure'] = $item['pressure'] / 100;
 
         // Wind
         // metric = meters per second
         // imperial = miles per hour
-        $data['owm_wind_speed'] = $item['wind_speed'] ?? $item['speed'] ?? null;
-        $data['owm_wind_degrees'] = $item['wind_deg'] ?? $item['deg'] ?? null;
+        $data['weather_wind_speed'] = $item['wind_speed'] ?? $item['speed'] ?? null;
+        $data['weather_wind_degrees'] = $item['wind_deg'] ?? $item['deg'] ?? null;
 
         if ($requestUnit === 'metric' && $windSpeedUnit !== 'MPS') {
             // We have MPS and need to go to something else
             if ($windSpeedUnit === 'MPH') {
                 // Convert MPS to MPH
-                $data['owm_wind_degrees'] = round($data['owm_wind_degrees'] * 2.237, 2);
+                $data['weather_wind_degrees'] = round($data['weather_wind_degrees'] * 2.237, 2);
             } else if ($windSpeedUnit === 'KPH') {
                 // Convert MPS to KPH
-                $data['owm_wind_degrees'] = round($data['owm_wind_degrees'] * 3.6, 2);
+                $data['weather_wind_degrees'] = round($data['weather_wind_degrees'] * 3.6, 2);
             }
         } else if ($requestUnit === 'imperial' && $windSpeedUnit !== 'MPH') {
             if ($windSpeedUnit === 'MPS') {
                 // Convert MPH to MPS
-                $data['owm_wind_degrees'] = round($data['owm_wind_degrees'] / 2.237, 2);
+                $data['weather_wind_degrees'] = round($data['weather_wind_degrees'] / 2.237, 2);
             } else if ($windSpeedUnit === 'KPH') {
                 // Convert MPH to KPH
-                $data['owm_wind_degrees'] = round($data['owm_wind_degrees'] * 1.609344, 2);
+                $data['weather_wind_degrees'] = round($data['weather_wind_degrees'] * 1.609344, 2);
             }
         }
 
         // Wind direction
-        $data['owm_wind_direction'] = '--';
-        if ($data['owm_wind_degrees'] !== null && $data['owm_wind_degrees'] !== 0) {
+        $data['weather_wind_direction'] = '--';
+        if ($data['weather_wind_degrees'] !== null && $data['weather_wind_degrees'] !== 0) {
             foreach (self::cardinalDirections() as $dir => $angles) {
-                if ($data['owm_wind_degrees'] >= $angles[0] && $data['owm_wind_degrees'] < $angles[1]) {
-                    $data['owm_wind_direction'] = $dir;
+                if ($data['weather_wind_degrees'] >= $angles[0] && $data['weather_wind_degrees'] < $angles[1]) {
+                    $data['weather_wind_direction'] = $dir;
                     break;
                 }
             }
@@ -785,17 +785,17 @@ class OpenWeatherMapConnector implements ConnectorInterface
         // Visibility
         // metric = meters
         // imperial = meters?
-        $data['owm_visibility'] = $item['visibility'] ?? '--';
+        $data['weather_visibility'] = $item['visibility'] ?? '--';
 
-        if ($data['owm_visibility'] !== '--') {
+        if ($data['weather_visibility'] !== '--') {
             // Always in meters
             if ($visibilityDistanceUnit === 'mi') {
                 // Convert meters to miles
-                $data['owm_visibility'] = $data['owm_visibility'] / 1609;
+                $data['weather_visibility'] = $data['weather_visibility'] / 1609;
             } else {
                 if ($visibilityDistanceUnit === 'km') {
                     // Convert meters to KM
-                    $data['owm_visibility'] = $data['owm_visibility'] / 1000;
+                    $data['weather_visibility'] = $data['weather_visibility'] / 1000;
                 }
             }
         }

--- a/lib/Connector/OpenWeatherMapConnector.php
+++ b/lib/Connector/OpenWeatherMapConnector.php
@@ -665,7 +665,7 @@ class OpenWeatherMapConnector implements ConnectorInterface
     {
         // Initialize Open Weather Schedule Criteria parameters
         $event->addType('openweathermap', __('Weather'))
-            ->addMetric('owm_weather_main', __('Weather Condition'))
+            ->addMetric('owm_weather_condition', __('Weather Condition'))
                 ->addValues('dropdown', [
                     'Thunderstorm' => __('Thunderstorm'),
                     'Drizzle' => __('Drizzle'),
@@ -695,7 +695,7 @@ class OpenWeatherMapConnector implements ConnectorInterface
                     'W' => __('West'),
                     'NW' => __('Northwest'),
                 ])
-            ->addMetric('owm_wind_deg', __('Wind Direction (degrees)'))
+            ->addMetric('owm_wind_degrees', __('Wind Direction (degrees)'))
                 ->addValues('number', [])
             ->addMetric('owm_humidity', __('Humidity (Percent)'))
                 ->addValues('number', [])
@@ -720,7 +720,7 @@ class OpenWeatherMapConnector implements ConnectorInterface
         $data = array();
 
         // format the weather condition
-        $data['owm_weather_main'] = str_replace(' ', '_', strtolower($item['weather'][0]['main']));
+        $data['owm_weather_condition'] = str_replace(' ', '_', strtolower($item['weather'][0]['main']));
 
         // Temperature
         // imperial = F
@@ -750,32 +750,32 @@ class OpenWeatherMapConnector implements ConnectorInterface
         // metric = meters per second
         // imperial = miles per hour
         $data['owm_wind_speed'] = $item['wind_speed'] ?? $item['speed'] ?? null;
-        $data['owm_wind_deg'] = $item['wind_deg'] ?? $item['deg'] ?? null;
+        $data['owm_wind_degrees'] = $item['wind_deg'] ?? $item['deg'] ?? null;
 
         if ($requestUnit === 'metric' && $windSpeedUnit !== 'MPS') {
             // We have MPS and need to go to something else
             if ($windSpeedUnit === 'MPH') {
                 // Convert MPS to MPH
-                $data['owm_wind_deg'] = round($data['owm_wind_deg'] * 2.237, 2);
+                $data['owm_wind_degrees'] = round($data['owm_wind_degrees'] * 2.237, 2);
             } else if ($windSpeedUnit === 'KPH') {
                 // Convert MPS to KPH
-                $data['owm_wind_deg'] = round($data['owm_wind_deg'] * 3.6, 2);
+                $data['owm_wind_degrees'] = round($data['owm_wind_degrees'] * 3.6, 2);
             }
         } else if ($requestUnit === 'imperial' && $windSpeedUnit !== 'MPH') {
             if ($windSpeedUnit === 'MPS') {
                 // Convert MPH to MPS
-                $data['owm_wind_deg'] = round($data['owm_wind_deg'] / 2.237, 2);
+                $data['owm_wind_degrees'] = round($data['owm_wind_degrees'] / 2.237, 2);
             } else if ($windSpeedUnit === 'KPH') {
                 // Convert MPH to KPH
-                $data['owm_wind_deg'] = round($data['owm_wind_deg'] * 1.609344, 2);
+                $data['owm_wind_degrees'] = round($data['owm_wind_degrees'] * 1.609344, 2);
             }
         }
 
         // Wind direction
         $data['owm_wind_direction'] = '--';
-        if ($data['owm_wind_deg'] !== null && $data['owm_wind_deg'] !== 0) {
+        if ($data['owm_wind_degrees'] !== null && $data['owm_wind_degrees'] !== 0) {
             foreach (self::cardinalDirections() as $dir => $angles) {
-                if ($data['owm_wind_deg'] >= $angles[0] && $data['owm_wind_deg'] < $angles[1]) {
+                if ($data['owm_wind_degrees'] >= $angles[0] && $data['owm_wind_degrees'] < $angles[1]) {
                     $data['owm_wind_direction'] = $dir;
                     break;
                 }

--- a/lib/Connector/OpenWeatherMapConnector.php
+++ b/lib/Connector/OpenWeatherMapConnector.php
@@ -664,56 +664,34 @@ class OpenWeatherMapConnector implements ConnectorInterface
     public function onScheduleCriteriaRequest(ScheduleCriteriaRequestInterface $event): void
     {
         // Initialize Open Weather Schedule Criteria parameters
-        $event->addType('weather', __('Weather'))
-                ->addMetric('weather_condition', __('Weather Condition'))
-                    ->addValues('dropdown', [
-                        'clear_sky' => __('Clear Sky'),
-                        'few_clouds' => __('Few Clouds'),
-                        'scattered_clouds' => __('Scattered Clouds'),
-                        'broken_clouds' => __('Broken Clouds'),
-                        'shower_rain' => __('Shower Rain'),
-                        'rain' => __('Rain'),
-                        'thunderstorm' => __('Thunderstorm'),
-                        'snow' => __('Snow'),
-                        'mist' => __('Mist')
-                    ])
-                ->addMetric('temperature_imperial', __('Temperature (Imperial)'))
-                    ->addValues('number', [])
-                ->addMetric('temperature_metric', __('Temperature (Metric)'))
-                    ->addValues('number', [])
-                ->addMetric('apparent_temperature_imperial', __('Apparent Temperature (Imperial)'))
-                    ->addValues('number', [])
-                ->addMetric('apparent_temperature_metric', __('Apparent Temperature (Metric)'))
-                    ->addValues('number', [])
-                ->addMetric('wind_speed', __('Wind Speed'))
-                    ->addValues('number', [])
-                ->addMetric('wind_direction', __('Wind Direction'))
-                    ->addValues('dropdown', [
-                        'N' => __('North'),
-                        'NNE ' => __('North-Northeast'),
-                        'NE' => __('Northeast'),
-                        'ENE' => __('East-Northeast'),
-                        'E' => __('East'),
-                        'ESE' => __('East-Southeast'),
-                        'SE' => __('Southeast'),
-                        'SSE' => __('South-Southeast'),
-                        'S' => __('South'),
-                        'SSW' => __('South-Southwest'),
-                        'SW' => __('Southwest'),
-                        'WSW' => __('West-Southwest'),
-                        'W' => __('West'),
-                        'WNW' => __('West-Northwest'),
-                        'NW' => __('Northwest'),
-                        'NNW' => __('North-Northwest'),
-                    ])
-                ->addMetric('wind_bearing', __('Wind Bearing'))
-                    ->addValues('number', [])
-                ->addMetric('humidity', __('Humidity (Percent)'))
-                    ->addValues('number', [])
-                ->addMetric('pressure', __('Pressure'))
-                    ->addValues('number', [])
-                ->addMetric('visibility', __('Visibility'))
-                    ->addValues('number', []);
+        $event->addType('openweathermap', __('Weather'))
+            ->addMetric('owm_weather_main', __('Weather Condition'))
+                ->addValues('dropdown', [
+                    'Thunderstorm' => __('Thunderstorm'),
+                    'Drizzle' => __('Drizzle'),
+                    'Rain' => __('Rain'),
+                    'Snow' => __('Snow'),
+                    'Clear' => __('Clear'),
+                    'Clouds' => __('Clouds')
+                ])
+            ->addMetric('owm_temp_imperial', __('Temperature (Imperial)'))
+                ->addValues('number', [])
+            ->addMetric('owm_temp_metric', __('Temperature (Metric)'))
+                ->addValues('number', [])
+            ->addMetric('owm_feels_like_imperial', __('Apparent Temperature (Imperial)'))
+                ->addValues('number', [])
+            ->addMetric('owm_feels_like_metric', __('Apparent Temperature (Metric)'))
+                ->addValues('number', [])
+            ->addMetric('owm_wind_speed', __('Wind Speed'))
+                ->addValues('number', [])
+            ->addMetric('owm_wind_deg', __('Wind Direction (degrees)'))
+                ->addValues('number', [])
+            ->addMetric('owm_humidity', __('Humidity (Percent)'))
+                ->addValues('number', [])
+            ->addMetric('owm_pressure', __('Pressure'))
+                ->addValues('number', [])
+            ->addMetric('owm_visibility', __('Visibility (meters)'))
+                ->addValues('number', []);
     }
 
     /**

--- a/lib/Connector/OpenWeatherMapConnector.php
+++ b/lib/Connector/OpenWeatherMapConnector.php
@@ -665,26 +665,26 @@ class OpenWeatherMapConnector implements ConnectorInterface
     {
         // Initialize Open Weather Schedule Criteria parameters
         $event->addType('weather', __('Weather'))
-            ->addMetric('weather_condition', __('Weather Condition'))
+            ->addMetric('condition', __('Weather Condition'))
                 ->addValues('dropdown', [
-                    'Thunderstorm' => __('Thunderstorm'),
-                    'Drizzle' => __('Drizzle'),
-                    'Rain' => __('Rain'),
-                    'Snow' => __('Snow'),
-                    'Clear' => __('Clear'),
-                    'Clouds' => __('Clouds')
+                    'thunderstorm' => __('Thunderstorm'),
+                    'drizzle' => __('Drizzle'),
+                    'rain' => __('Rain'),
+                    'snow' => __('Snow'),
+                    'clear' => __('Clear'),
+                    'clouds' => __('Clouds')
                 ])
-            ->addMetric('weather_temp_imperial', __('Temperature (Imperial)'))
+            ->addMetric('temp_imperial', __('Temperature (Imperial)'))
                 ->addValues('number', [])
-            ->addMetric('weather_temp_metric', __('Temperature (Metric)'))
+            ->addMetric('temp_metric', __('Temperature (Metric)'))
                 ->addValues('number', [])
-            ->addMetric('weather_feels_like_imperial', __('Apparent Temperature (Imperial)'))
+            ->addMetric('feels_like_imperial', __('Apparent Temperature (Imperial)'))
                 ->addValues('number', [])
-            ->addMetric('weather_feels_like_metric', __('Apparent Temperature (Metric)'))
+            ->addMetric('feels_like_metric', __('Apparent Temperature (Metric)'))
                 ->addValues('number', [])
-            ->addMetric('weather_wind_speed', __('Wind Speed'))
+            ->addMetric('wind_speed', __('Wind Speed'))
                 ->addValues('number', [])
-            ->addMetric('weather_wind_direction', __('Wind Direction'))
+            ->addMetric('wind_direction', __('Wind Direction'))
                 ->addValues('dropdown', [
                     'N' => __('North'),
                     'NE' => __('Northeast'),
@@ -695,13 +695,13 @@ class OpenWeatherMapConnector implements ConnectorInterface
                     'W' => __('West'),
                     'NW' => __('Northwest'),
                 ])
-            ->addMetric('weather_wind_degrees', __('Wind Direction (degrees)'))
+            ->addMetric('wind_degrees', __('Wind Direction (degrees)'))
                 ->addValues('number', [])
-            ->addMetric('weather_humidity', __('Humidity (Percent)'))
+            ->addMetric('humidity', __('Humidity (Percent)'))
                 ->addValues('number', [])
-            ->addMetric('weather_pressure', __('Pressure'))
+            ->addMetric('pressure', __('Pressure'))
                 ->addValues('number', [])
-            ->addMetric('weather_visibility', __('Visibility (meters)'))
+            ->addMetric('visibility', __('Visibility (meters)'))
                 ->addValues('number', []);
     }
 
@@ -737,7 +737,6 @@ class OpenWeatherMapConnector implements ConnectorInterface
         $data['weather_feels_like_imperial'] = round($apparentTempImperial, 0);
         $data['weather_temp_metric'] = round($tempMetric, 0);
         $data['weather_feels_like_metric'] = round($apparentTempMetric, 0);
-
 
         // Humidity
         $data['weather_humidity'] = $item['humidity'];

--- a/lib/Xmds/Soap.php
+++ b/lib/Xmds/Soap.php
@@ -1329,7 +1329,7 @@ class Soap
 
                     foreach ($schedule->criteria as $scheduleCriteria) {
                         $criteriaNode = $scheduleXml->createElement('criteria');
-                        $criteriaNode->setAttribute('metric', $scheduleCriteria->metric);
+                        $criteriaNode->setAttribute('metric', $scheduleCriteria->type . '_' . $scheduleCriteria->metric);
                         $criteriaNode->setAttribute('condition', $scheduleCriteria->condition);
                         $criteriaNode->setAttribute('type', $scheduleCriteria->type);
                         $criteriaNode->textContent = $scheduleCriteria->value;


### PR DESCRIPTION
relates to xibosignage/xibo#3487

- Modified metric IDs to better align with JSON responses from the OWM API.
- Added a prefix to avoid conflicts with other potential weather schedule criteria.
- Removed metrics that are not present in OpenWeather API responses.