### PR TITLE
Connectors: Fix duplicate data on dropdown option

### DIFF
--- a/ui/src/core/xibo-cms.js
+++ b/ui/src/core/xibo-cms.js
@@ -3241,6 +3241,9 @@ function makePagedSelect(element, parent, dataFormatter, addRandomId = false) {
                     data = dataFormatter(data);
                 }
 
+                // Check if we have a display all option
+                var displayAll = $element.data('displayAll') ?? false;
+
                 $.each(data.data, function(index, el) {
                     var result = {
                         "id": el[$element.data("idProperty")],
@@ -3267,7 +3270,7 @@ function makePagedSelect(element, parent, dataFormatter, addRandomId = false) {
                 return {
                     results: results,
                     pagination: {
-                        more: (page * 10 < data.recordsTotal)
+                        more: !displayAll && (page * 10 < data.recordsTotal)
                     }
                 };
             }

--- a/ui/src/templates/forms/inputs/connectorProperties.hbs
+++ b/ui/src/templates/forms/inputs/connectorProperties.hbs
@@ -7,7 +7,7 @@
             )
     }}
 {{else}}
-    {{> dropdown id=id name=name value=value title=title selectType="pagedSelect"
+    {{> dropdown id=id name=name value=value title=title selectType="localSelect"
             options=(arr (obj name='' title='')) optionsTitle="title" optionsValue="name"
             customData=(arr
                     (obj name='width' value='100%')

--- a/ui/src/templates/forms/inputs/connectorProperties.hbs
+++ b/ui/src/templates/forms/inputs/connectorProperties.hbs
@@ -7,7 +7,7 @@
             )
     }}
 {{else}}
-    {{> dropdown id=id name=name value=value title=title selectType="localSelect"
+    {{> dropdown id=id name=name value=value title=title selectType="pagedSelect"
             options=(arr (obj name='' title='')) optionsTitle="title" optionsValue="name"
             customData=(arr
                     (obj name='width' value='100%')
@@ -21,6 +21,7 @@
                     (obj name='selected-property' value='selected')
                     (obj name='initial-value' value=initialValue)
                     (obj name='initial-key' value=initialKey)
+                    (obj name='display-all' value=true)
             )
             helpText=helpText
     }}


### PR DESCRIPTION
## Changes
- Connectors: Fix for issue on using `pagedSelect` dropdown 
- Used `localSelect` instead to display all options at once 

Relates to: https://github.com/xibosignage/xibo/issues/3505