### PR TITLE
Library: Fix for uploader should limit concurrent uploads

### DIFF
--- a/ui/src/core/file-upload.js
+++ b/ui/src/core/file-upload.js
@@ -83,6 +83,7 @@ function openUploadForm(options) {
       maxFileSize: options.templateOptions.upload.maxSize,
       includeTagsInput: options.templateOptions.includeTagsInput,
       uploadTemplateId: options.uploadTemplateId,
+      limitConcurrentUploads: 3
     };
     let refreshSessionInterval;
 


### PR DESCRIPTION
## Changes

- Added `limitConcurrentUploads` option in file-upload.js

Relates to: https://github.com/xibosignage/xibo/issues/3503