### PR TITLE
Flip Clock Widget: Shadow appears behind Clock Widget when using RGBA color

### DIFF
--- a/modules/clock-flip.xml
+++ b/modules/clock-flip.xml
@@ -76,7 +76,7 @@
             <title>Flip Card Text Colour</title>
             <default>#ccc</default>
         </property>
-        <property id="flipCardBackgroundColor" type="color">
+        <property id="flipCardBackgroundColor" type="color" format="hex">
             <title>Flip Card Background Colour</title>
             <default>#333</default>
         </property>

--- a/ui/src/core/forms.js
+++ b/ui/src/core/forms.js
@@ -215,6 +215,14 @@ window.forms = {
           property.playlistId = playlistId;
         }
 
+        // Colour format
+        if (
+          property.type === 'color' &&
+          property.format != ''
+        ) {
+          property.colorFormat = property.format;
+        }
+
         // dashboards available services
         if (property.type === 'connectorProperties') {
           property.connectorPropertiesUrl =


### PR DESCRIPTION
relates to xibosignage/xibo#3506