### PR TITLE
Player logging: Fix not possible to get audit logging from the player

### DIFF
--- a/lib/Entity/Display.php
+++ b/lib/Entity/Display.php
@@ -735,7 +735,7 @@ class Display implements \JsonSerializable
         $restingLogLevel = $this->getSetting('logLevel', 'error');
         $isElevated = $this->isElevatedLogging();
 
-        return $isElevated ? 'debug' : $restingLogLevel;
+        return $isElevated ? 'audit' : $restingLogLevel;
     }
 
     /**


### PR DESCRIPTION
## Changes
- Fix not possible to get audit logging from the player (updated `debug` to `audit`)

Relates to: https://github.com/xibosignage/xibo/issues/3493