### PR TITLE
Elements need to obey sharing permissions

### DIFF
--- a/ui/src/editor-core/element-group.js
+++ b/ui/src/editor-core/element-group.js
@@ -31,7 +31,12 @@ const ElementGroup = function(data, widgetId, regionId, parentWidget) {
 
   // Set element to have same properties for edit and delete as parent widget
   this.isEditable = (parentWidget) ? parentWidget.isEditable : true;
-  this.isDeletable = (parentWidget) ? parentWidget.isDeletable : true;
+  // For elements to be deletable, the parent widget also needs to be editable
+  this.isDeletable = (parentWidget) ?
+    (
+      parentWidget.isDeletable &&
+      parentWidget.isEditable
+    ) : true;
   this.isViewable = (parentWidget) ? parentWidget.isViewable : true;
   this.effect = data.effect || 'noTransition';
 

--- a/ui/src/editor-core/element.js
+++ b/ui/src/editor-core/element.js
@@ -40,7 +40,12 @@ const Element = function(data, widgetId, regionId, parentWidget) {
 
   // Set element to have same properties for edit and delete as parent widget
   this.isEditable = (parentWidget) ? parentWidget.isEditable : true;
-  this.isDeletable = (parentWidget) ? parentWidget.isDeletable : true;
+  // For elements to be deletable, the parent widget also needs to be editable
+  this.isDeletable = (parentWidget) ?
+    (
+      parentWidget.isDeletable &&
+      parentWidget.isEditable
+    ) : true;
   this.isViewable = (parentWidget) ? parentWidget.isViewable : true;
 
   // Check if the element is visible on rendering ( true by default )

--- a/ui/src/layout-editor/main.js
+++ b/ui/src/layout-editor/main.js
@@ -2245,7 +2245,7 @@ lD.dropItemAdd = function(droppable, draggable, dropPosition) {
 
               // Add element to the new widget
               addToWidget(newWidget);
-            });
+            }).catch(itemAdded);
           };
 
           // Get a target widget

--- a/ui/src/style/layout-editor.scss
+++ b/ui/src/style/layout-editor.scss
@@ -1213,6 +1213,10 @@ body.editor-opened #content-wrapper .page-content>.row {
             }
         }
 
+        &:not(.editable) .group-edit-btn {
+            display: none;
+        }
+
         .group-edit-btn {
             position: absolute;
             top: 2px;


### PR DESCRIPTION
relates to xibosignage/xibo#3516

 - Prevent elements and groups to be deleted if parent widget isn't editable
 - Failed to create widget when adding widget due to permissions lock adding fix
 - Hide element group edit button if it's not editable