### PR TITLE
XMDS: spread collection interval with a small offset

### DIFF
--- a/lib/Xmds/Soap.php
+++ b/lib/Xmds/Soap.php
@@ -3205,4 +3205,17 @@ class Soap
                 : $displayEvent->eventEndByReference($this->display->displayId, $eventTypeId, $refId, $detail);
         }
     }
+
+    /**
+     * Collection Interval with offset
+     *  calculates an offset for the collection interval based on the displayId and returns it
+     *  the offset is plus or minus 10 seconds and will always be the same when given the same displayId
+     * @param int $collectionInterval
+     * @return int
+     */
+    protected function collectionIntervalWithOffset(int $collectionInterval): int
+    {
+        $offset = $this->display->displayId % 20;
+        return $collectionInterval + ($offset < 10 ? ($offset * -1) : $offset);
+    }
 }

--- a/lib/Xmds/Soap.php
+++ b/lib/Xmds/Soap.php
@@ -3217,10 +3217,10 @@ class Soap
     {
         if ($collectionInterval <= 60) {
             $offset = $this->display->displayId % 10;
-            return $collectionInterval + ($offset < 5 ? (($offset * -1) - 5) : $offset);
+            return $collectionInterval + ($offset < 5 ? $offset * -1 : $offset - 5);
         } else {
             $offset = $this->display->displayId % 20;
-            return $collectionInterval + ($offset < 10 ? (($offset * -1) -10) : $offset);
+            return $collectionInterval + ($offset < 10 ? $offset * -1 : $offset - 10);
         }
     }
 }

--- a/lib/Xmds/Soap.php
+++ b/lib/Xmds/Soap.php
@@ -3217,10 +3217,10 @@ class Soap
     {
         if ($collectionInterval <= 60) {
             $offset = $this->display->displayId % 10;
-            return $collectionInterval + ($offset < 5 ? $offset * -1 : $offset - 5);
+            return $collectionInterval + ($offset <= 5 ? $offset * -1 : $offset - 5);
         } else {
             $offset = $this->display->displayId % 20;
-            return $collectionInterval + ($offset < 10 ? $offset * -1 : $offset - 10);
+            return $collectionInterval + ($offset <= 10 ? $offset * -1 : $offset - 10);
         }
     }
 }

--- a/lib/Xmds/Soap.php
+++ b/lib/Xmds/Soap.php
@@ -3215,7 +3215,12 @@ class Soap
      */
     protected function collectionIntervalWithOffset(int $collectionInterval): int
     {
-        $offset = $this->display->displayId % 20;
-        return $collectionInterval + ($offset < 10 ? ($offset * -1) : $offset);
+        if ($collectionInterval <= 60) {
+            $offset = $this->display->displayId % 10;
+            return $collectionInterval + ($offset < 5 ? (($offset * -1) - 5) : $offset);
+        } else {
+            $offset = $this->display->displayId % 20;
+            return $collectionInterval + ($offset < 10 ? (($offset * -1) -10) : $offset);
+        }
     }
 }

--- a/lib/Xmds/Soap4.php
+++ b/lib/Xmds/Soap4.php
@@ -155,9 +155,9 @@ class Soap4 extends Soap
                         }
                     }
 
-                    // Apply an offset to the collectionInterval
+                    // Apply an offset to the collectInterval
                     // https://github.com/xibosignage/xibo/issues/3530
-                    if (strtolower($arrayItem['name']) == 'collectioninterval') {
+                    if (strtolower($arrayItem['name']) == 'collectinterval') {
                         $arrayItem['value'] = $this->collectionIntervalWithOffset($arrayItem['value']);
                     }
 

--- a/lib/Xmds/Soap4.php
+++ b/lib/Xmds/Soap4.php
@@ -138,12 +138,6 @@ class Soap4 extends Soap
                     // Upper case the setting name for windows
                     $settingName = ($clientType == 'windows') ? ucfirst($arrayItem['name']) : $arrayItem['name'];
 
-                    $node = $return->createElement($settingName, (isset($arrayItem['value']) ? $arrayItem['value'] : $arrayItem['default']));
-
-                    if (isset($arrayItem['type'])) {
-                        $node->setAttribute('type', $arrayItem['type']);
-                    }
-
                     // Patch download and update windows to make sure they are unix time stamps
                     // XMDS schema 4 sent down unix time
                     // https://github.com/xibosignage/xibo/issues/1791
@@ -161,7 +155,13 @@ class Soap4 extends Soap
                         }
                     }
 
-                    $node = $return->createElement($arrayItem['name'], (isset($arrayItem['value']) ? $arrayItem['value'] : $arrayItem['default']));
+                    // Apply an offset to the collectionInterval
+                    // https://github.com/xibosignage/xibo/issues/3530
+                    if (strtolower($arrayItem['name']) == 'collectioninterval') {
+                        $arrayItem['value'] = $this->collectionIntervalWithOffset($arrayItem['value']);
+                    }
+
+                    $node = $return->createElement($arrayItem['name'], $arrayItem['value'] ?? $arrayItem['default']);
                     $node->setAttribute('type', $arrayItem['type']);
                     $displayElement->appendChild($node);
                 }

--- a/lib/Xmds/Soap5.php
+++ b/lib/Xmds/Soap5.php
@@ -208,6 +208,12 @@ class Soap5 extends Soap4
                         $value = $timeParts[0] . ':' . $timeParts[1];
                     }
 
+                    // Apply an offset to the collectionInterval
+                    // https://github.com/xibosignage/xibo/issues/3530
+                    if (strtolower($arrayItem['name']) == 'collectioninterval') {
+                        $value = $this->collectionIntervalWithOffset($value);
+                    }
+
                     $node = $return->createElement($settingName, $value);
 
                     if (isset($arrayItem['type'])) {

--- a/lib/Xmds/Soap5.php
+++ b/lib/Xmds/Soap5.php
@@ -208,9 +208,9 @@ class Soap5 extends Soap4
                         $value = $timeParts[0] . ':' . $timeParts[1];
                     }
 
-                    // Apply an offset to the collectionInterval
+                    // Apply an offset to the collectInterval
                     // https://github.com/xibosignage/xibo/issues/3530
-                    if (strtolower($arrayItem['name']) == 'collectioninterval') {
+                    if (strtolower($arrayItem['name']) == 'collectinterval') {
                         $value = $this->collectionIntervalWithOffset($value);
                     }
 


### PR DESCRIPTION
This PR applies a small offset (+/- 10 seconds) to the collection interval so that displays which are started at the same time, i.e. at the start of day, or rebooted via command) do not keep connecting concurrently. Instead they spread out after the first connection.

 fixes to xibosignage/xibo#3530