### PR TITLE
Menu Board Elements: Fix for options doesn't have Font Family property

### DIFF
--- a/modules/templates/product-elements.xml
+++ b/modules/templates/product-elements.xml
@@ -162,6 +162,10 @@ return value;
                 <helpText>Fit to selected area instead of using the font size?</helpText>
                 <default>0</default>
             </property>
+            <property id="fontFamily" type="fontSelector">
+                <title>Font Family</title>
+                <helpText>Select a custom font - leave empty to use the default font.</helpText>
+            </property>
             <property id="fontSize" type="number">
                 <title>Font Size</title>
                 <default>24</default>
@@ -218,6 +222,7 @@ return value;
         {{#if horizontalAlign}}
             justify-content: {{horizontalAlign}};
         {{/if}}
+        {{#if fontFamily}}font-family: {{fontFamily}};{{/if}}
         {{#if fontSize}}font-size: {{fontSize}}px;{{/if}}
         {{#eq horizontalAlign "flex-start"}}text-align: left;{{/eq}}
         {{#eq horizontalAlign "center"}}text-align: center;{{/eq}}
@@ -289,6 +294,10 @@ if(properties.fitToArea) {
                 <helpText>Fit to selected area instead of using the font size?</helpText>
                 <default>0</default>
             </property>
+            <property id="fontFamily" type="fontSelector">
+                <title>Font Family</title>
+                <helpText>Select a custom font - leave empty to use the default font.</helpText>
+            </property>
             <property id="fontSize" type="number">
                 <title>Font Size</title>
                 <default>24</default>
@@ -350,6 +359,7 @@ if(properties.fitToArea) {
         {{#if horizontalAlign}}
             justify-content: {{horizontalAlign}};
         {{/if}}
+        {{#if fontFamily}}font-family: {{fontFamily}};{{/if}}
         {{#if fontSize}}font-size: {{fontSize}}px;{{/if}}
         {{#eq horizontalAlign "flex-start"}}text-align: left;{{/eq}}
         {{#eq horizontalAlign "center"}}text-align: center;{{/eq}}


### PR DESCRIPTION
## Changes
- Menu Board Elements: Fix for options doesn't have Font Family property

Relates to: https://github.com/xibosignage/xibo/issues/3528