### PR TITLE
Folders: Fix Folders appear empty but cannot be deleted due to old file revisions remaining

### DIFF
--- a/lib/Controller/Library.php
+++ b/lib/Controller/Library.php
@@ -2731,6 +2731,10 @@ class Library extends Base
 
         $media->save(['saveTags' => false]);
 
+        if ($media->parentId != 0) {
+            $this->updateMediaRevision($media, $folderId);
+        }
+
         // Return
         $this->getState()->hydrate([
             'httpStatus' => 204,
@@ -2900,5 +2904,20 @@ class Library extends Base
     private function hasFullScreenLayout(Media $media): ?int
     {
         return $this->layoutFactory->getLinkedFullScreenLayout('media', $media->mediaId)?->campaignId;
+    }
+
+    /**
+     * Update media files with revisions
+     * @param Media $media
+     * @param $folderId
+     */
+    private function updateMediaRevision(Media $media, $folderId)
+    {
+        $oldMedia = $this->mediaFactory->getParentById($media->mediaId);
+        $oldMedia->folderId = $folderId;
+        $folder = $this->folderFactory->getById($oldMedia->folderId);
+        $folder->permissionsFolderId = ($folder->getPermissionFolderId() == null) ? $folder->id : $folder->getPermissionFolderId();
+
+        $oldMedia->save(['saveTags' => false, 'validate' => false]);
     }
 }


### PR DESCRIPTION
## Changes
- Folders: Fix Folders appear empty but cannot be deleted due to old file revisions remaining
- Add function to update folder location of media files with revisions

Relates to: https://github.com/xibosignage/xibo/issues/3525