### PR TITLE
Calendar widget issues with triggers and number of items

### DIFF
--- a/modules/calendar.xml
+++ b/modules/calendar.xml
@@ -185,6 +185,10 @@
 // meta: Metadata
 // properties: The properties for the widget
 
+// Track whether there is an event currently ongoing
+window.ongoingEvent = false;
+
+// Process events
 var now = moment();
 
 for(var idx = 0; idx < items.length; idx++) {
@@ -194,9 +198,7 @@ for(var idx = 0; idx < items.length; idx++) {
     var endDate = moment(item.endDate);
 
     // Check if there is an event ongoing and change it if the variable isn't set or is false
-    if ((typeof ongoingEvent != 'undefined' || !window.ongoingEvent) && startDate.isBefore(now) && endDate.isAfter(now)) {
-        window.ongoingEvent = true;
-    }
+    window.ongoingEvent = window.ongoingEvent || (startDate.isBefore(now) && endDate.isAfter(now));
 
     if (endDate.isAfter(now)) {
         if (moment(items[idx].startDate).isBefore(now)) {
@@ -206,7 +208,7 @@ for(var idx = 0; idx < items.length; idx++) {
         }
     }
 
-    if(endDate.isBefore(now)) {
+    if (endDate.isBefore(now)) {
         items[idx].pastEvent = true;
     } else {
         items[idx].pastEvent = false;
@@ -234,12 +236,14 @@ return {dataItems: items};
 // id: The id of the widget
 // target: The target element to render
 // properties: The properties for the <widget></widget>
-if(typeof ongoingEvent != 'undefined' && ongoingEvent && properties.currentEventTrigger) {
-    // If there is an event now, send the Current Event trigger ( if exists )
-    xiboIC.trigger(properties.currentEventTrigger);
-} else if(properties.noEventTrigger) {
+
+// Event triggers
+if (properties.currentEventTrigger && window.ongoingEvent) {
+    // If there is an event now, send the Current Event trigger (if exists)
+    xiboIC.trigger(properties.currentEventTrigger, {targetId: 0});
+} else if (properties.noEventTrigger) {
     // If there is no event now, send the No Event trigger
-    xiboIC.trigger(properties.noEventTrigger);
+    xiboIC.trigger(properties.noEventTrigger, {targetId: 0});
 }
     ]]></onRender>
     <sampleData><![CDATA[

--- a/modules/calendar.xml
+++ b/modules/calendar.xml
@@ -228,7 +228,12 @@ for(var idx = 0; idx < items.length; idx++) {
     }
 }
 
-return {dataItems: items};
+// If we have numItems, send only that number
+var numItems = properties.numItems && properties.numItems < items.length
+  ? properties.numItems
+  : items.length;
+
+return {dataItems: items.slice(0, (numItems - 1))};
     ]]></onDataLoad>
     <onRender>
         <![CDATA[

--- a/modules/calendar.xml
+++ b/modules/calendar.xml
@@ -233,7 +233,7 @@ var numItems = properties.numItems && properties.numItems < items.length
   ? properties.numItems
   : items.length;
 
-return {dataItems: items.slice(0, (numItems - 1))};
+return {dataItems: items.slice(0, numItems)};
     ]]></onDataLoad>
     <onRender>
         <![CDATA[

--- a/modules/templates/event-static.xml
+++ b/modules/templates/event-static.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (C) 2023 Xibo Signage Ltd
+  ~ Copyright (C) 2024 Xibo Signage Ltd
   ~
   ~ Xibo - Digital Signage - https://xibosignage.com
   ~
@@ -112,13 +112,7 @@ if (items.length <= 0 && properties.noDataMessage && properties.noDataMessage !=
 $(target).find('#content').empty();
 
 // Add items to container
-// If we have numItems, send only that number
-var numItems =
-  properties.numItems && properties.numItems < items.length ?
-  properties.numItems :
-  items.length;
-
-for (var index = 0; index < numItems; index++) {
+for (var index = 0; index < items.length; index++) {
   var $newItem = $('<div>').addClass('event').html(items[index]).appendTo('body');
   $(target).find('#content').append($newItem);
 }


### PR DESCRIPTION
This PR addresses two issues:
 - https://github.com/xibosignage/xibo/issues/3509
 - https://github.com/xibosignage/xibo/issues/3515

I don't think it was strictly necessary to remove the `typeof` check,  but the new version does make it easier to understand what is happening, so I kept it in. Triggering using xiboIC with a target of 0 disables the source checking for the trigger.

onDataLoad handles numItems and that has been removed from the one static template that referenced it. The provider always returns all items, so we handle it client side.