### PR TITLE
Widget: fallback data not added when generated by WidgetSync

### DIFF
--- a/lib/XTR/WidgetSyncTask.php
+++ b/lib/XTR/WidgetSyncTask.php
@@ -298,6 +298,8 @@ class WidgetSyncTask implements TaskInterface
                             }
                         }
 
+                        $dataProvider->addItem($item->data);
+
                         // Indicate we've been handled by fallback data
                         $isFallback = true;
                     }


### PR DESCRIPTION
 fixes to xibosignage/xibo#3510