### PR TITLE
Fixed Player: still not possible to get audit logging from the player

### DIFF
--- a/lib/Service/LogService.php
+++ b/lib/Service/LogService.php
@@ -328,6 +328,7 @@ class LogService implements LogServiceInterface
                 return Logger::INFO;
 
             case 'debug':
+            case 'audit' :
                 return Logger::DEBUG;
 
             case 'error':


### PR DESCRIPTION
## Changes
- Fixed not possible to get audit logging from the player with auditing enabled

Relates to: https://github.com/xibosignage/xibo/issues/3571