### PR TITLE
Fixed Reporting: time connected summary report does not work with Today as the range

### DIFF
--- a/lib/Report/ApiRequests.php
+++ b/lib/Report/ApiRequests.php
@@ -181,6 +181,12 @@ class ApiRequests implements ReportInterface
         // depending on the date range selected.
         $fromDt = $sanitizedParams->getDate('fromDt');
         $toDt = $sanitizedParams->getDate('toDt');
+        $currentDate = Carbon::now()->startOfDay();
+
+        // If toDt is current date then make it current datetime
+        if ($toDt->format('Y-m-d') == $currentDate->format('Y-m-d')) {
+            $toDt = Carbon::now();
+        }
 
         $type = $sanitizedParams->getString('type');
 

--- a/lib/Report/DisplayAlerts.php
+++ b/lib/Report/DisplayAlerts.php
@@ -171,6 +171,12 @@ class DisplayAlerts implements ReportInterface
         // depending on the date range selected.
         $fromDt = $sanitizedParams->getDate('fromDt');
         $toDt = $sanitizedParams->getDate('toDt');
+        $currentDate = Carbon::now()->startOfDay();
+
+        // If toDt is current date then make it current datetime
+        if ($toDt->format('Y-m-d') == $currentDate->format('Y-m-d')) {
+            $toDt = Carbon::now();
+        }
 
         $metadata = [
             'periodStart' => Carbon::createFromTimestamp($fromDt->toDateTime()->format('U'))

--- a/lib/Report/SessionHistory.php
+++ b/lib/Report/SessionHistory.php
@@ -177,6 +177,12 @@ class SessionHistory implements ReportInterface
         // depending on the date range selected.
         $fromDt = $sanitizedParams->getDate('fromDt');
         $toDt = $sanitizedParams->getDate('toDt');
+        $currentDate = Carbon::now()->startOfDay();
+
+        // If toDt is current date then make it current datetime
+        if ($toDt->format('Y-m-d') == $currentDate->format('Y-m-d')) {
+            $toDt = Carbon::now();
+        }
 
         $metadata = [
             'periodStart' => Carbon::createFromTimestamp($fromDt->toDateTime()->format('U'))

--- a/lib/Report/TimeDisconnectedSummary.php
+++ b/lib/Report/TimeDisconnectedSummary.php
@@ -200,8 +200,6 @@ class TimeDisconnectedSummary implements ReportInterface
         $onlyLoggedIn = $sanitizedParams->getCheckbox('onlyLoggedIn') == 1;
         $groupBy = $sanitizedParams->getString('groupBy');
 
-        $currentDate = Carbon::now()->startOfDay();
-
         //
         // From and To Date Selection
         // --------------------------
@@ -209,6 +207,12 @@ class TimeDisconnectedSummary implements ReportInterface
         // depending on the date range selected.
         $fromDt = $sanitizedParams->getDate('fromDt');
         $toDt = $sanitizedParams->getDate('toDt');
+        $currentDate = Carbon::now()->startOfDay();
+
+        // If toDt is current date then make it current datetime
+        if ($toDt->format('Y-m-d') == $currentDate->format('Y-m-d')) {
+            $toDt = Carbon::now();
+        }
 
         // Get an array of display groups this user has access to
         $displayGroupIds = [];


### PR DESCRIPTION
## Changes
- Fixed data calculation for today as date range option in specific reports listed below. Previous behavior uses current datetime as the $toDt when 'today' is selected, hence, will retain this behavior instead of calculating the whole day

Reports affected:
- API Requests
- Display Alerts
- Session History
- Time Disconnected

Relates to: https://github.com/xibosignageltd/xibo-private/issues/893