### PR TITLE
Fixed default report type option in API Requests/Session History reports

### DIFF
--- a/reports/apirequests-report-form.twig
+++ b/reports/apirequests-report-form.twig
@@ -72,7 +72,7 @@
                                 { id: 'audit', value: "Audit"|trans },
                                 { id: 'debug', value: "Debug"|trans },
                             ] %}
-                            {{ inline.dropdown("type", "single", title, "audit", options, "id", "value", helpText) }}
+                            {{ inline.dropdown("type", "single", title, "requests", options, "id", "value", helpText) }}
 
                             <div class="w-100">
                                 <a id="applyBtn" class="btn btn-success">

--- a/reports/sessionhistory-report-form.twig
+++ b/reports/sessionhistory-report-form.twig
@@ -72,7 +72,7 @@
                                 { id: 'debug', value: "Debug"|trans },
                                 { id: 'sessions', value: "Sessions"|trans },
                             ] %}
-                            {{ inline.dropdown("type", "single", title, "audit", options, "id", "value", helpText) }}
+                            {{ inline.dropdown("type", "single", title, "sessions", options, "id", "value", helpText) }}
 
                             <div class="w-100">
                                 <a id="applyBtn" class="btn btn-success">


### PR DESCRIPTION
## Changes
- Fixed default report type option in API Requests/Session History reports

Relates to: https://github.com/xibosignageltd/xibo-private/issues/894