### PR TITLE
Schedule Page: Custom dates don’t show after refresh

### DIFF
--- a/ui/bundle_xibo.js
+++ b/ui/bundle_xibo.js
@@ -28,11 +28,11 @@ require('./src/core/forms.js');
 require('./src/core/help-pane.js');
 require('./src/style/help-pane.scss');
 
-// Xibo calendar
-require('./src/core/xibo-calendar.js');
-
 // Xibo datatables and folders
 require('./src/core/xibo-datatables.js');
+
+// Xibo calendar
+require('./src/core/xibo-calendar.js');
 
 // Xibo core
 require('./src/core/xibo-cms.js');

--- a/ui/src/pages/schedule/schedule-page.js
+++ b/ui/src/pages/schedule/schedule-page.js
@@ -1,6 +1,4 @@
 $(function() {
-  $('.custom-date-range').addClass('d-none');
-
   // Select lists
   const dialog = 'body';
 


### PR DESCRIPTION
relates to xibosignageltd/xibo-private#918