### PR TITLE
Library: replace image should handle image based elements and mediaSelectors

### DIFF
--- a/lib/Helper/XiboUploadHandler.php
+++ b/lib/Helper/XiboUploadHandler.php
@@ -211,7 +211,8 @@ class XiboUploadHandler extends BlueImpUploadHandler
                             $widget->unassignAudioById($oldMedia->mediaId);
                             $widget->assignAudioById($media->mediaId);
                             $widget->save();
-                        } else if (count($widget->getPrimaryMedia()) > 0
+                        } else if ($widget->type !== 'global'
+                            && count($widget->getPrimaryMedia()) > 0
                             && $widget->getPrimaryMediaId() == $oldMedia->mediaId
                         ) {
                             // We're only interested in primary media at this point (no audio)


### PR DESCRIPTION
In this PR we extend the element handling further to cover off properties of type mediaSelector. We also cover widgets which may not be the global element, as they can have image elements inside.
 fixes xibosignage/xibo#3614