### PR TITLE
DataSet: widgets not showing 0 values due to empty check.

### DIFF
--- a/lib/Listener/DataSetDataProviderListener.php
+++ b/lib/Listener/DataSetDataProviderListener.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2023 Xibo Signage Ltd
+ * Copyright (C) 2025 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -236,10 +236,8 @@ class DataSetDataProviderListener
                 $item = [];
                 foreach ($mappings as $mapping) {
                     // This column is selected
-                    $cellValue = $row[$mapping['heading']];
-                    if (empty($cellValue)) {
-                        $item[$mapping['heading']] = null;
-                    } else if ($mapping['dataTypeId'] === 4) {
+                    $cellValue = $row[$mapping['heading']] ?? null;
+                    if ($mapping['dataTypeId'] === 4) {
                         // Grab the external image
                         $item[$mapping['heading']] = $dataProvider->addImage(
                             'dataset_' . md5($dataSet->dataSetId . $mapping['dataSetColumnId'] . $cellValue),


### PR DESCRIPTION
This PR removes the empty check when parsing out dataset data. It is not clear why the empty check was introduced (in 2023) and there isn't any notes in the commit history or code. My best guess is that it was missing index handling and so I have replaced it with `??`.

 fixes xibosignage/xibo#3564