### PR TITLE
Delete User: Unexpected error when deleting a user with assigned layouts fix

### DIFF
--- a/lib/Entity/Layout.php
+++ b/lib/Entity/Layout.php
@@ -891,7 +891,7 @@ class Layout implements \JsonSerializable
             'import' => false,
             'appendCountOnDuplicate' => false,
             'setModifiedDt' => true,
-            'auditMessage' => null,
+            'auditMessage' => 'Saved',
         ], $options);
 
         if ($options['validate']) {


### PR DESCRIPTION
## Changes
- Error was caused by missing message value on 'Audit' log, hence, adding a default value solves the issue

Relates to: https://github.com/xibosignage/xibo/issues/3608