### PR TITLE
Layout: Uploading multiple media directly into the editor issue

### DIFF
--- a/ui/src/layout-editor/main.js
+++ b/ui/src/layout-editor/main.js
@@ -3029,6 +3029,7 @@ lD.addModuleToPlaylist = function(
               {
                 refreshEditor: true,
                 resetPropertiesPanelOpenedTab: true,
+                reloadToolbar: true,
               }).catch(console.debug);
 
             resolve();
@@ -3039,6 +3040,7 @@ lD.addModuleToPlaylist = function(
             {
               refreshEditor: true,
               resetPropertiesPanelOpenedTab: true,
+              reloadToolbar: true,
             }).catch(console.debug);
 
           resolve();
@@ -3257,6 +3259,7 @@ lD.openUploadForm = function({
       currentWorkingFolderId: lD.folderId,
       showWidgetDates: false,
       folderSelector: true,
+      multi: false,
     },
     uploadDoneEvent: function(data) {
       // If the upload is successful, increase the number of uploads

--- a/views/globalTranslations.twig
+++ b/views/globalTranslations.twig
@@ -27,6 +27,7 @@
     translations.tagInputValueHelpText = "{{ "Provide an optional Value for this Tag. If no Value is required, this field can be left blank"|trans }}";
     translations.tagInputValueRequiredHelpText = "{{ "Please provide the value for this Tag and confirm by pressing enter on your keyboard."|trans }}";
     translations.videoImageCoverHelpText = "{{ "Before Uploading, scroll through the progress bar or play and pause to select a still to be used as the video file thumbnail."|trans }}";
+    translations.canOnlyUploadMax = "{{ "You can only upload a maximum of %s files."|trans }}";
     translations.folderTreeCreate = "{{ "Create"|trans }}";
     translations.folderTreeEdit = "{{ "Rename"|trans }}";
     translations.folderTreeDelete = "{{ "Remove"|trans }}";

--- a/views/include-file-upload.twig
+++ b/views/include-file-upload.twig
@@ -250,7 +250,7 @@
                 </div>
             </div>
         </td>
-        <td class="btn-group">
+        <td class="btn-group text-right">
             {% if (!i && !o.options.autoUpload) { %}
                 <button class="btn btn-primary start" disabled>
                     <i class="fa fa-upload"></i>
@@ -306,7 +306,7 @@
                 </div>
             </div>
         </td>
-        <td>
+        <td class="text-right">
             <div class="btn-group">
                 {% if (!i && !o.options.autoUpload) { %}
                     <button class="btn btn-primary start" disabled>
@@ -341,6 +341,17 @@
         <td colspan="2">
             <span class="size">{%=o.formatFileSize(file.size)%}</span>
         </td>
+        {% if (file.error) { %}
+            <td class="text-right">
+                <div class="btn-group">
+                    {% if (!i) { %}
+                        <button class="btn btn-warning cancel">
+                            <i class="fa fa-times"></i>
+                        </button>
+                    {% } %}
+                </div>
+            </td>
+        {% } %}
     </tr>
 {% } %}
 </script>


### PR DESCRIPTION
relates to xibosignage/xibo#3606

- Limit upload to a single media for the Layout Editor
- Allow removing a media that failed to upload to allow new one
- Reload toolbar after upload to show the new media