### PR TITLE
Menuboard | Renaming a Category does not update in CMS Layout Editor fix

### DIFF
--- a/lib/Controller/MenuBoardCategory.php
+++ b/lib/Controller/MenuBoardCategory.php
@@ -316,6 +316,7 @@ class MenuBoardCategory extends Base
 
         $menuBoardCategory = $this->menuBoardCategoryFactory->create($id, $name, $mediaId, $code, $description);
         $menuBoardCategory->save();
+        $menuBoard->save();
 
         // Return
         $this->getState()->hydrate([
@@ -430,6 +431,7 @@ class MenuBoardCategory extends Base
         $menuBoardCategory->code = $sanitizedParams->getString('code');
         $menuBoardCategory->description = $sanitizedParams->getString('description');
         $menuBoardCategory->save();
+        $menuBoard->save();
 
         // Success
         $this->getState()->hydrate([

--- a/lib/Controller/MenuBoardCategory.php
+++ b/lib/Controller/MenuBoardCategory.php
@@ -316,7 +316,7 @@ class MenuBoardCategory extends Base
 
         $menuBoardCategory = $this->menuBoardCategoryFactory->create($id, $name, $mediaId, $code, $description);
         $menuBoardCategory->save();
-        $menuBoard->save();
+        $menuBoard->save(['audit' => false]);
 
         // Return
         $this->getState()->hydrate([

--- a/lib/Entity/MenuBoard.php
+++ b/lib/Entity/MenuBoard.php
@@ -259,9 +259,12 @@ class MenuBoard implements \JsonSerializable
     {
         $options = array_merge([
             'validate' => true,
+            'audit' => true
         ], $options);
 
-        $this->getLog()->debug('Saving ' . $this);
+        if ($options['audit']) {
+            $this->getLog()->debug('Saving ' . $this);
+        }
 
         if ($options['validate']) {
             $this->validate();

--- a/lib/Widget/MenuBoardCategoryProvider.php
+++ b/lib/Widget/MenuBoardCategoryProvider.php
@@ -24,6 +24,7 @@ namespace Xibo\Widget;
 
 use Carbon\Carbon;
 use Xibo\Event\MenuBoardCategoryRequest;
+use Xibo\Event\MenuBoardModifiedDtRequest;
 use Xibo\Widget\Provider\DataProviderInterface;
 use Xibo\Widget\Provider\DurationProviderInterface;
 use Xibo\Widget\Provider\WidgetProviderInterface;
@@ -55,6 +56,18 @@ class MenuBoardCategoryProvider implements WidgetProviderInterface
 
     public function getDataModifiedDt(DataProviderInterface $dataProvider): ?Carbon
     {
+        $this->getLog()->debug('fetchData: MenuBoardCategoryProvider passing to modifiedDt request event');
+
+        $menuId = $dataProvider->getProperty('menuId');
+
+        if ($menuId !== null) {
+            // Raise an event to get the modifiedDt of this dataSet
+            $event = new MenuBoardModifiedDtRequest($menuId);
+            $this->getDispatcher()->dispatch($event, MenuBoardModifiedDtRequest::$NAME);
+
+            return max($event->getModifiedDt(), $dataProvider->getWidgetModifiedDt());
+        }
+
         return null;
     }
 }


### PR DESCRIPTION
## Changes
- Fixed Menuboard | Renaming a Category does not update in CMS Layout Editor

Relates to: https://github.com/xibosignage/xibo/issues/3596