### PR TITLE
Fixed Schedule Video/Image: Media with long names cannot be scheduled

### DIFF
--- a/lib/Controller/Layout.php
+++ b/lib/Controller/Layout.php
@@ -3539,7 +3539,7 @@ class Layout extends Base
         $layout->schemaVersion = Environment::$XLF_VERSION;
         $layout->folderId = ($type === 'media') ? $media->folderId : $playlist->folderId;
 
-        $layout->save();
+        $layout->save(['type' => $type]);
 
         $draft = $this->layoutFactory->checkoutLayout($layout);
 

--- a/lib/Entity/Layout.php
+++ b/lib/Entity/Layout.php
@@ -892,6 +892,7 @@ class Layout implements \JsonSerializable
             'appendCountOnDuplicate' => false,
             'setModifiedDt' => true,
             'auditMessage' => 'Saved',
+            'type' => null
         ], $options);
 
         if ($options['validate']) {
@@ -1099,7 +1100,9 @@ class Layout implements \JsonSerializable
         }
 
         // Validation
-        if (empty($this->layout) || strlen($this->layout) > 50 || strlen($this->layout) < 1) {
+        // Layout created from media follows the media character limit
+        if ((empty($this->layout) || strlen($this->layout) > 50 || strlen($this->layout) < 1)
+            && $options['type'] !== 'media') {
             throw new InvalidArgumentException(
                 __('Layout Name must be between 1 and 50 characters'),
                 'name'


### PR DESCRIPTION
## Changes
- Fixed Schedule Video/Image: Media with long names cannot be scheduled

Relates to: https://github.com/xibosignage/xibo/issues/3618