### PR TITLE
Fixed Advanced > Logs: Date filter is not working

### DIFF
--- a/views/log-page.twig
+++ b/views/log-page.twig
@@ -82,8 +82,13 @@
                                     {{ inline.dropdown("userId", "single", title, "", null, "userId", "userName", helpText, "pagedSelect", "", "", "", attributes) }}
                                 </div>
                                 <div class="tab-pane" id="advanced">
-                                    {% set title %}{% trans "From Date" %}{% endset %}
-                                    {{ inline.date("fromDt", title) }}
+                                    {% set helpText = "Set the time to start searching for logs based on the interval "
+                                        ~ "filter. Leave empty to start from the current time." %}
+                                    {% set title %}
+                                        {% trans "Date" %}
+                                        <i class="fa fa-info-circle ml-1" title="{% trans helpText %}"></i>
+                                    {% endset %}
+                                    {{ inline.dateTime("fromDt", title, 'now'|date("Y-m-d H:i:s"), "", "", "", "") }}
 
                                     {% set title %}{% trans "Channel" %}{% endset %}
                                     {{ inline.input("channel", title) }}


### PR DESCRIPTION
## Changes
Contains improvements on the current Advanced Filter for Logs: 
- Updated label from `fromDate` to `Date`
- Used `dateTime` for filter instead of `date` only
- Provided help text for user experience 

*Previously, the backend uses `00:00:00` as the default time, thus, the only update needed is for the frontend to use datetime and include the time when sending data to the backend.

Relates to: https://github.com/xibosignage/xibo/issues/3573