### PR TITLE
Fixed Welcome page opens docs links in the same tab, navigating you away from the CMS

### DIFF
--- a/views/welcome-page.twig
+++ b/views/welcome-page.twig
@@ -35,8 +35,10 @@
                         You can upload images and videos, design layouts, schedule content timing and location, 
                         and control the whole display network.{% endtrans %}</p>
                     <div class="d-flex" style="column-gap: 8px;">
-                        <a href="{{ helpService.getLandingPage() }}" type="button" class="btn-rounded btn-orange">Documentation</a>
-                        <a href="https://xibosignage.com/training" type="button" class="btn-rounded btn-outlined">Training</a>
+                        <a href="{{ helpService.getLandingPage() }}" type="button" target="_blank"
+                           class="btn-rounded btn-orange">Documentation</a>
+                        <a href="https://xibosignage.com/training" type="button" target="_blank"
+                           class="btn-rounded btn-outlined">Training</a>
                     </div>
                 </div>
                 <div class="header-image-box">


### PR DESCRIPTION
## Changes
- Added blank target to documentation links in Welcome Page

Relates to: https://github.com/xibosignageltd/xibo-private/issues/942