### PR TITLE
Player Version: fix uploading ChromeOS packages in WL or sub-folder

### DIFF
--- a/lib/Controller/Display.php
+++ b/lib/Controller/Display.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2024 Xibo Signage Ltd
+ * Copyright (C) 2025 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -2938,7 +2938,7 @@ class Display extends Base
         $sanitizedParams = $this->getSanitizer($request->getParams());
 
         $user_code = $sanitizedParams->getString('user_code');
-        $cmsAddress = (new HttpsDetect())->getUrl();
+        $cmsAddress = (new HttpsDetect())->getBaseUrl($request);
         $cmsKey = $this->getConfig()->getSetting('SERVER_KEY');
 
         if ($user_code == '') {

--- a/lib/Controller/PlayerSoftware.php
+++ b/lib/Controller/PlayerSoftware.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2024 Xibo Signage Ltd
+ * Copyright (C) 2025 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -596,7 +596,7 @@ class PlayerSoftware extends Base
         $uploadService = new UploadService($libraryFolder . 'temp/', $options, $this->getLog(), $this->getState());
         $uploadHandler = $uploadService->createUploadHandler();
 
-        $uploadHandler->setPostProcessor(function ($file, $uploadHandler) use ($libraryFolder) {
+        $uploadHandler->setPostProcessor(function ($file, $uploadHandler) use ($libraryFolder, $request) {
             // Return right away if the file already has an error.
             if (!empty($file->error)) {
                 $this->getState()->setCommitState(false);
@@ -638,7 +638,7 @@ class PlayerSoftware extends Base
             rename($filePath, $libraryFolder . 'playersoftware/' . $playerSoftware->fileName);
 
             // Unpack if necessary
-            $playerSoftware->unpack($libraryFolder);
+            $playerSoftware->unpack($libraryFolder, $request);
 
             // return
             $file->id = $playerSoftware->versionId;

--- a/lib/Xmds/Wsdl.php
+++ b/lib/Xmds/Wsdl.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2024 Xibo Signage Ltd
+ * Copyright (C) 2025 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -68,21 +68,6 @@ class Wsdl
      */
     public static function getRoot(): string
     {
-        # Check REQUEST_URI is set. IIS doesn't set it, so we need to build it
-        # Attribution:
-        # Code snippet from http://support.ecenica.com/web-hosting/scripting/troubleshooting-scripting-errors/how-to-fix-server-request_uri-php-error-on-windows-iis/
-        # Released under BSD License
-        # Copyright (c) 2009, Ecenica Limited All rights reserved.
-        if (!isset($_SERVER['REQUEST_URI'])) {
-            $_SERVER['REQUEST_URI'] = $_SERVER['PHP_SELF'];
-            if (isset($_SERVER['QUERY_STRING'])) {
-                $_SERVER['REQUEST_URI'] .= '?' . $_SERVER['QUERY_STRING'];
-            }
-        }
-        ## End Code Snippet
-
-        $request = explode('?', htmlentities($_SERVER['REQUEST_URI'], ENT_QUOTES, 'UTF-8'));
-
-        return ((new HttpsDetect())->getUrl()) . '/' . ltrim($request[0], '/');
+        return (new HttpsDetect())->getBaseUrl();
     }
 }


### PR DESCRIPTION
When unpacking a ChromeOS package, fully replace the manifest. This requires detecting the base url, so that if we're running in a sub-folder we get the right values.

 fixes xibosignage/xibo#3632