### PR TITLE
Fixed gnupg extension blocks install on Windows (non-docker)

### DIFF
--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -745,7 +745,8 @@ class ConfigService implements ConfigServiceInterface
 
         $this->testItem($rows, __('GNUPG'),
             Environment::checkGnu(),
-            __('checkGnu is used to verify the integrity of Player Software versions uploaded to the CMS')
+            __('checkGnu is used to verify the integrity of Player Software versions uploaded to the CMS'),
+            false
         );
 
         $this->envTested = true;


### PR DESCRIPTION
## Changes
- This will generate a warning instead of considering it as a fault

Relates to: https://github.com/xibosignage/xibo/issues/3637