### PR TITLE
Settings > Displays: Enable Stats Collection (set to YES) is not inherited for new layouts

### DIFF
--- a/lib/Controller/Layout.php
+++ b/lib/Controller/Layout.php
@@ -436,6 +436,12 @@ class Layout extends Base
             );
         }
 
+        // Do we have an 'Enable Stats Collection?' checkbox?
+        // If not, we fall back to the default Stats Collection setting.
+        if (!$sanitizedParams->hasParam('enableStat')) {
+            $enableStat = $this->getConfig()->getSetting('DISPLAY_PROFILE_STATS_DEFAULT');
+        }
+
         // Set layout enableStat flag
         $layout->enableStat = $enableStat;
 


### PR DESCRIPTION
relates to xibosignage/xibo#3649