### PR TITLE
Fixed Media Filters: Clear filters in media grid should set Retired to No

### DIFF
--- a/views/library-page.twig
+++ b/views/library-page.twig
@@ -104,7 +104,7 @@
                             {{ inline.dropdown("type", "single", title, "", [{"type": none, "name": ""}]|merge(modules), "type", "name") }}
 
                             {% set title %}{% trans "Retired" %}{% endset %}
-                            {% set values = [{id: 1, value: "Yes"}, {id: 0, value: "No"}] %}
+                            {% set values = [{id: 0, value: "No"}, {id: 1, value: "Yes"}] %}
                             {{ inline.dropdown("retired", "single", title, 0, values, "id", "value") }}
 
                             {{ inline.hidden("folderId") }}


### PR DESCRIPTION
## Changes
- Resetting the datatables defaults the selection to the first option, hence changing the option index would solve the issue

Relates to: https://github.com/xibosignageltd/xibo-private/issues/954