### PR TITLE
Fixed Unable to Schedule a Playlist

### DIFF
--- a/lib/Controller/Layout.php
+++ b/lib/Controller/Layout.php
@@ -3539,7 +3539,8 @@ class Layout extends Base
         $layout->schemaVersion = Environment::$XLF_VERSION;
         $layout->folderId = ($type === 'media') ? $media->folderId : $playlist->folderId;
 
-        $layout->save(['type' => $type]);
+        // Media files have their own validation so we can skip
+        $layout->save(['validate' => false]);
 
         $draft = $this->layoutFactory->checkoutLayout($layout);
 

--- a/lib/Entity/Layout.php
+++ b/lib/Entity/Layout.php
@@ -1101,8 +1101,7 @@ class Layout implements \JsonSerializable
 
         // Validation
         // Layout created from media follows the media character limit
-        if ((empty($this->layout) || strlen($this->layout) > 50 || strlen($this->layout) < 1)
-            && $options['type'] !== 'media') {
+        if (empty($this->layout) || strlen($this->layout) > 50 || strlen($this->layout) < 1) {
             throw new InvalidArgumentException(
                 __('Layout Name must be between 1 and 50 characters'),
                 'name'


### PR DESCRIPTION
## Changes
- Skip layout validation when creating from a media file or playlist since media files and playlists have their own validation process

Relates to: https://github.com/xibosignage/xibo/issues/3651