### PR TITLE
DataSet: remote data sets have a URI box which has helptext for URL - should they be the same?

### DIFF
--- a/views/dataset-form-add.twig
+++ b/views/dataset-form-add.twig
@@ -101,7 +101,7 @@
                         {{ forms.dropdown("method", "single", title, "", options, "typeid", "type", helpText) }}
 
                         {% set title %}{% trans "URI" %}{% endset %}
-                        {% set helpText %}{% trans "URL to the Remote DataSet for GET and POST." %}{% endset %}
+                        {% set helpText %}{% trans "The URI of the Remote Dataset used for GET and POST." %}{% endset %}
                         {{ forms.input("uri", title, "", helpText, "", "required") }}
 
                         <div class="form-group row">

--- a/views/dataset-form-edit.twig
+++ b/views/dataset-form-edit.twig
@@ -122,7 +122,7 @@
                         {{ forms.dropdown("method", "single", title, dataSet.method, options, "typeid", "type", helpText) }}
 
                         {% set title %}{% trans "URI" %}{% endset %}
-                        {% set helpText %}{% trans "URL to the Remote DataSet for GET and POST." %}{% endset %}
+                        {% set helpText %}{% trans "The URI of the Remote Dataset used for GET and POST." %}{% endset %}
                         {{ forms.input("uri", title, dataSet.uri, helpText, "", "required") }}
 
                         <div class="form-group row">


### PR DESCRIPTION
relates to xibosignage/xibo#3650