### PR TITLE
Fixed Menu board: "Option Value" Prefix and Suffix properties wrongly shared between multiple elements

### DIFF
--- a/lib/Controller/Widget.php
+++ b/lib/Controller/Widget.php
@@ -1830,7 +1830,9 @@ class Widget extends Base
                     if ($property->type === 'message') {
                         continue;
                     }
-                    $property->setValueByType($elementProperties);
+
+                    // Isolate properties per element
+                    $property->setValueByType($elementProperties, null, true);
 
                     // Process properties from the mediaSelector component
                     if ($property->type === 'mediaSelector') {


### PR DESCRIPTION
## Changes
Implemented property isolation per element

Fixes multiple issues:
- Fixed Menu board: "Option Value" Prefix and Suffix properties wrongly shared between multiple elements
- Fixed [Weather: Temperature element font size issue after adding Stencils](https://github.com/xibosignage/xibo/issues/3635)
- Fixed [Layout Editor [Text]: Vertical Align and Text to Wrap formatting are not working as expected](https://github.com/xibosignage/xibo/issues/3663)

Relates to: https://github.com/xibosignage/xibo/issues/3667