### PR TITLE
Enhanced usage metrics

### DIFF
--- a/db/migrations/20250430164700_anonymous_usage_enhanced_migration.php
+++ b/db/migrations/20250430164700_anonymous_usage_enhanced_migration.php
@@ -1,0 +1,47 @@
+<?php
+/*
+ * Copyright (C) 2025 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Migrations for schedule criteria
+ * @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+ */
+class AnonymousUsageEnhancedMigration extends AbstractMigration
+{
+    public function change(): void
+    {
+        $task = $this->table('task');
+        $task->insert([
+            'name' => 'Anonymous Usage Reporting',
+            'class' => '\Xibo\XTR\AnonymousUsageTask',
+            'options' => '[]',
+            'schedule' => '0 * * * *',
+            'isActive' => '1',
+            'configFile' => '/tasks/anonymous-usage.task'
+        ])
+            ->save();
+
+        // Delete some settings we don't use anymore.
+        $this->execute('DELETE FROM `setting` WHERE `setting` = \'PHONE_HOME_URL\'');
+    }
+}

--- a/db/migrations/20250430164700_anonymous_usage_enhanced_migration.php
+++ b/db/migrations/20250430164700_anonymous_usage_enhanced_migration.php
@@ -30,12 +30,18 @@ class AnonymousUsageEnhancedMigration extends AbstractMigration
 {
     public function change(): void
     {
+        try {
+            $myHour = random_int(0, 23);
+        } catch (Exception) {
+            $myHour = 0;
+        }
+
         $task = $this->table('task');
         $task->insert([
             'name' => 'Anonymous Usage Reporting',
             'class' => '\Xibo\XTR\AnonymousUsageTask',
             'options' => '[]',
-            'schedule' => '0 * * * *',
+            'schedule' => $myHour . ' * * * *',
             'isActive' => '1',
             'configFile' => '/tasks/anonymous-usage.task'
         ])

--- a/lib/XTR/AnonymousUsageTask.php
+++ b/lib/XTR/AnonymousUsageTask.php
@@ -143,9 +143,19 @@ class AnonymousUsageTask implements TaskInterface
              WHERE `widget`.`type` = \'subplaylist\'
         ');
         $data['countOfAdCampaigns'] =
-            $this->runQuery('SELECT COUNT(*) AS countOf FROM `campaign` WHERE `type` = \'ad\'');
+            $this->runQuery('
+                SELECT COUNT(*) AS countOf
+                  FROM `campaign`
+                WHERE `type` = \'ad\'
+                  AND `isLayoutSpecific` = 0
+            ');
         $data['countOfListCampaigns'] =
-            $this->runQuery('SELECT COUNT(*) AS countOf FROM `campaign` WHERE `type` = \'list\'');
+            $this->runQuery('
+                SELECT COUNT(*) AS countOf 
+                  FROM `campaign`
+                 WHERE `type` = \'list\'
+                  AND `isLayoutSpecific` = 0
+            ');
         $data['countOfMedia'] =
             $this->runQuery('SELECT COUNT(*) AS countOf FROM `media`');
         $data['countOfPlaylists'] =

--- a/lib/XTR/AnonymousUsageTask.php
+++ b/lib/XTR/AnonymousUsageTask.php
@@ -120,7 +120,7 @@ class AnonymousUsageTask implements TaskInterface
             $this->runQuery('SELECT COUNT(*) AS countOf FROM `user` WHERE `lastAccessed` > :recently', [
                 'recently' => Carbon::now()->subHours(24)->format('Y-m-d H:i:s'),
             ]);
-        $data['countOfUserGroups '] =
+        $data['countOfUserGroups'] =
             $this->runQuery('SELECT COUNT(*) AS countOf FROM `group` WHERE isUserSpecific = 0');
         $data['countOfUsersWithStatusDashboard'] =
             $this->runQuery('SELECT COUNT(*) AS countOf FROM `user` WHERE homePageId = \'statusdashboard.view\'');

--- a/lib/XTR/AnonymousUsageTask.php
+++ b/lib/XTR/AnonymousUsageTask.php
@@ -1,0 +1,158 @@
+<?php
+/*
+ * Copyright (C) 2025 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Xibo\XTR;
+
+use Carbon\Carbon;
+use GuzzleHttp\Client;
+use Xibo\Helper\Environment;
+use Xibo\Storage\StorageServiceInterface;
+
+/**
+ * Collects anonymous usage stats
+ */
+class AnonymousUsageTask implements TaskInterface
+{
+    use TaskTrait;
+
+    private readonly string $url;
+
+    private StorageServiceInterface $db;
+
+    public function __construct()
+    {
+        $this->url = 'https://xibosignage.com/api/stats/usage';
+    }
+
+    /** @inheritdoc */
+    public function setFactories($container)
+    {
+        $this->db = $container->get('store');
+        return $this;
+    }
+
+    /** @inheritdoc */
+    public function run()
+    {
+        $isCollectUsage = $this->getConfig()->getSetting('PHONE_HOME') == 1;
+        if (!$isCollectUsage) {
+            $this->appendRunMessage('Anonymous usage disabled');
+            return;
+        }
+
+        // Is this my "hour of the day" to run?
+        // Task runs hourly, but we only do something once every 24 hours
+
+
+        // Make sure we have a key
+        $key = $this->getConfig()->getSetting('PHONE_HOME_KEY');
+        if (empty($key)) {
+            $this->getConfig()->changeSetting('PHONE_HOME_KEY', bin2hex(random_bytes(16)));
+        }
+
+        // Set PHONE_HOME_TIME to NOW.
+        $this->getConfig()->changeSetting('PHONE_HOME_DATE', Carbon::now()->format('U'));
+
+        // Collect the data and report it.
+        $data = [
+            'id' => $key,
+            'version' => Environment::$WEBSITE_VERSION_NAME,
+            'accountId' => defined('ACCOUNT_ID') ? constant('ACCOUNT_ID') : null,
+        ];
+
+        // What type of install are we?
+        $data['installType'] = 'custom';
+        if (isset($_SERVER['INSTALL_TYPE'])) {
+            $data['installType'] = $_SERVER['INSTALL_TYPE'];
+        } else if ($this->getConfig()->getSetting('cloud_demo') !== null) {
+            $data['installType'] = 'cloud';
+        }
+
+        $data = array_merge($data, $this->displayStats());
+        $data['countOfDisplays'] = $this->runQuery(
+            'SELECT COUNT(*) AS countOf FROM `display` WHERE `lastaccessed` > :recently',
+            [
+                'recently' => Carbon::now()->subDays(7)->format('U'),
+            ]
+        );
+        $data['countOfDisplaysTotal'] = $this->runQuery('SELECT COUNT(*) AS countOf FROM `display`');
+        $data['countOfDisplaysUnAuthorised'] = $this->runQuery('SELECT COUNT(*) AS countOf FROM `display`');
+        $data['countOfUsers'] = $this->runQuery('SELECT COUNT(*) AS countOf FROM `user`');
+
+        $this->getLogger()->debug('Sending stats: ' . json_encode($data));
+
+        (new Client())->post(
+            $this->url,
+            $this->getConfig()->getGuzzleProxy([
+                'json' => $data,
+            ])
+        );
+    }
+
+    private function displayStats(): array
+    {
+        // Retrieve number of displays
+        $stats = $this->db->select('
+                        SELECT client_type, COUNT(*) AS cnt
+                          FROM `display`
+                         WHERE licensed = 1
+                        GROUP BY client_type
+                    ', []);
+
+        $counts = [
+            'total' => 0,
+            'android' => 0,
+            'windows' => 0,
+            'linux' => 0,
+            'lg' => 0,
+            'sssp' => 0,
+            'chromeOS' => 0,
+        ];
+        foreach ($stats as $stat) {
+            $counts['total'] += intval($stat['cnt']);
+            $counts[$stat['client_type']] += intval($stat['cnt']);
+        }
+
+        return [
+            'countOfDisplaysAuthorised' => $counts['total'],
+            'countOfAndroid' => $counts['android'],
+            'countOfLinux' => $counts['linux'],
+            'countOfWebos' => $counts['lg'],
+            'countOfWindows' => $counts['windows'],
+            'countOfTizen' => $counts['sssp'],
+            'countOfChromeOS' => $counts['chromeOS'],
+        ];
+    }
+
+    /**
+     * Run a query and return the value of a property
+     * @param string $sql
+     * @param string $property
+     * @param array $params
+     * @return string|null
+     */
+    private function runQuery(string $sql, array $params = [], string $property = 'countOf'): ?string
+    {
+        $record = $this->db->select($sql, $params);
+        return $record[0][$property] ?? null;
+    }
+}

--- a/lib/XTR/AnonymousUsageTask.php
+++ b/lib/XTR/AnonymousUsageTask.php
@@ -40,7 +40,7 @@ class AnonymousUsageTask implements TaskInterface
 
     public function __construct()
     {
-        $this->url = 'https://test.xibo.org.uk/api/stats/usage';
+        $this->url = 'https://xibosignage.com/api/stats/usage';
     }
 
     /** @inheritdoc */
@@ -133,8 +133,20 @@ class AnonymousUsageTask implements TaskInterface
 
         // Other objects
         $data['countOfFolders'] = $this->runQuery('SELECT COUNT(*) AS countOf FROM `folder`');
-        $data['countOfLayouts'] =
-            $this->runQuery('SELECT COUNT(*) AS countOf FROM `campaign` WHERE isLayoutSpecific = 1');
+        $data['countOfLayouts'] = $this->runQuery('
+            SELECT COUNT(*) AS countOf
+              FROM `campaign`
+             WHERE `isLayoutSpecific` = 1
+                AND `campaignId` NOT IN (
+                    SELECT `lkcampaignlayout`.`campaignId`
+                      FROM `lkcampaignlayout`
+                        INNER JOIN `lktaglayout`
+                        ON `lktaglayout`.`layoutId` = `lkcampaignlayout`.`layoutId`
+                        INNER JOIN `tag`
+                        ON `lktaglayout`.tagId = `tag`.tagId
+                      WHERE `tag`.`tag` = \'template\'
+                )
+        ');
         $data['countOfLayoutsWithPlaylists'] = $this->runQuery('
             SELECT COUNT(DISTINCT `region`.`layoutId`) AS countOf 
               FROM `widget`

--- a/lib/Xmds/Soap3.php
+++ b/lib/Xmds/Soap3.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2024 Xibo Signage Ltd
+ * Copyright (C) 2025 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -89,12 +89,8 @@ class Soap3 extends Soap
             $this->logBandwidth($display->displayId, Bandwidth::$REGISTER, strlen($active));
 
             $this->getLog()->debug($active, $display->displayId);
-            
-            // Phone Home?
-            $this->phoneHome();
 
             return $active;
-
         } catch (NotFoundException $e) {
             $this->getLog()->error('Attempt to register a Version 3 Display with key %s.', $hardwareKey);
 

--- a/lib/Xmds/Soap4.php
+++ b/lib/Xmds/Soap4.php
@@ -293,9 +293,6 @@ class Soap4 extends Soap
         // Audit our return
         $this->getLog()->debug($returnXml);
 
-        // Phone Home?
-        $this->phoneHome();
-
         return $returnXml;
     }
 

--- a/lib/Xmds/Soap5.php
+++ b/lib/Xmds/Soap5.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2024 Xibo Signage Ltd
+ * Copyright (C) 2025 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -541,9 +541,6 @@ class Soap5 extends Soap4
 
         // Audit our return
         $this->getLog()->debug($returnXml);
-
-        // Phone Home?
-        $this->phoneHome();
 
         return $returnXml;
     }

--- a/tasks/anonymous-usage.task
+++ b/tasks/anonymous-usage.task
@@ -1,0 +1,5 @@
+{
+  "name": "Anonymous Usage",
+  "class": "\\Xibo\\XTR\\AnonymousUsageTask",
+  "options": {}
+}

--- a/views/settings-page.twig
+++ b/views/settings-page.twig
@@ -558,8 +558,8 @@
                                 {% endif %}
 
                                 {% if theme.isSettingVisible("PHONE_HOME") %}
-                                    {% set title %}{% trans "Allow usage tracking?" %}{% endset %}
-                                    {% set helpText %}{% trans "Should the CMS send anonymous statistics to help improve the software?" %}{% endset %}
+                                    {% set title %}{% trans "Should the CMS send anonymous statistics to help improve the software?" %}{% endset %}
+                                    {% set helpText %}{% trans "When this is enabled the CMS will periodically send usage information to the software authors so that improvements can be made to the product." %}{% endset %}
 
                                     {{ forms.checkbox("PHONE_HOME", title, theme.getSetting("PHONE_HOME"), helpText, "", "", not theme.isSettingEditable("PHONE_HOME")) }}
                                 {% endif %}


### PR DESCRIPTION
Issue: https://github.com/xibosignageltd/xibo-private/issues/961

This PR adds a task which is responsible for collecting and reporting anonymous usage metrics, assuming they are enabled. It removes the same from the XMDS calls.

Note: the URL needs to change once testing is complete and ahead of PR merge.