### PR TITLE
Do not display "Private Folder"

### DIFF
--- a/lib/Controller/Folder.php
+++ b/lib/Controller/Folder.php
@@ -200,8 +200,7 @@ class Folder extends Base
                 }
 
                 if (!$this->getUser()->checkViewable($child)) {
-                    $child->text = __('Private Folder');
-                    $child->type = 'disabled';
+                    continue;
                 }
 
                 if ($homeFolderId === $child->id) {


### PR DESCRIPTION
In the layout editor, for each folder users don't have access to "Private Folder" will be displayed, making accessible folders harder to identify.