### PR TITLE
Widget: allow tags inside the URL of web page widget

### DIFF
--- a/modules/webpage.xml
+++ b/modules/webpage.xml
@@ -39,9 +39,8 @@
             <helpText>The Location (URL) of the webpage</helpText>
             <default></default>
             <rule>
-                <test type="and">
+                <test>
                     <condition type="required"></condition>
-                    <condition type="uri"></condition>
                 </test>
             </rule>
         </property>


### PR DESCRIPTION
## Changes
Changed validation to allow tags inside URL of web page widget

Relates to: https://github.com/xibosignageltd/xibo-private/issues/964