### PR TITLE
XTR: fix install type

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -246,6 +246,7 @@ then
         /usr/bin/env | sed 's/^\(.*\)$/export \1/g' | grep -E "^export MYSQL" >> /var/www/maintenance.sh
         /usr/bin/env | sed 's/^\(.*\)$/export \1/g' | grep -E "^export MEMCACHED" >> /var/www/maintenance.sh
         echo "export CMS_USE_MEMCACHED=$CMS_USE_MEMCACHED" >> /var/www/maintenance.sh
+        echo "export INSTALL_TYPE=$INSTALL_TYPE" >> /var/www/maintenance.sh
         echo "cd /var/www/cms && /usr/bin/php bin/xtr.php" >> /var/www/maintenance.sh
         chmod 755 /var/www/maintenance.sh
 


### PR DESCRIPTION
Anon usage stats are being run via XTR which did not have the INSTALL_TYPE environment variable set. During initial testing this came from manually running the CI/Dev container via the command line, which did have this set.
xibosignageltd/xibo-private#961