### PR TITLE
Fixes for API scope checking and the default scope

### DIFF
--- a/db/migrations/20250702145100_fix_oauth_routes_table_migration.php
+++ b/db/migrations/20250702145100_fix_oauth_routes_table_migration.php
@@ -1,0 +1,64 @@
+<?php
+/*
+ * Copyright (C) 2025 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Add some additional fields to menu boards
+ * @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+ */
+class FixOauthRoutesTableMigration extends AbstractMigration
+{
+    public function change(): void
+    {
+        // Remove the Regex column
+        $this->table('oauth_scopes')
+            ->removeColumn('useRegex')
+            ->save();
+
+        // Update the table
+        $oauthRouteScopes = $this->table('oauth_scope_routes');
+        $oauthRouteScopes->truncate();
+
+        $oauthRouteScopes->insert([
+            ['scopeId' => 'datasets', 'route' => '#^/dataset#', 'method' => 'GET,POST,PUT'],
+            ['scopeId' => 'datasetsDelete', 'route' => '#^/dataset#', 'method' => 'DELETE'],
+            ['scopeId' => 'design', 'route' => '#^/library#', 'method' => 'GET,POST,PUT'],
+            ['scopeId' => 'design', 'route' => '#^/layout#', 'method' => 'GET,POST,PUT'],
+            ['scopeId' => 'design', 'route' => '#^/playlist#', 'method' => 'GET,POST,PUT'],
+            ['scopeId' => 'design', 'route' => '#^/resolution#', 'method' => 'GET,POST,PUT'],
+            ['scopeId' => 'designDelete', 'route' => '#^/library#', 'method' => 'DELETE'],
+            ['scopeId' => 'designDelete', 'route' => '#^/layout#', 'method' => 'DELETE'],
+            ['scopeId' => 'designDelete', 'route' => '#^/playlist#', 'method' => 'DELETE'],
+            ['scopeId' => 'designDelete', 'route' => '#^/resolution#', 'method' => 'DELETE'],
+            ['scopeId' => 'displays', 'route' => '#^/display#', 'method' => 'GET,POST,PUT'],
+            ['scopeId' => 'displays', 'route' => '#^/displaygroup#', 'method' => 'GET,POST,PUT'],
+            ['scopeId' => 'displaysDelete', 'route' => '#^/display/{id}#', 'method' => 'DELETE'],
+            ['scopeId' => 'displaysDelete', 'route' => '#^/displaygroup/{id}#', 'method' => 'DELETE'],
+            ['scopeId' => 'mcaas', 'route' => '#^/$#', 'method' => 'GET'],
+            ['scopeId' => 'mcaas', 'route' => '#^/library/download/{id}#', 'method' => 'GET'],
+            ['scopeId' => 'mcaas', 'route' => '#^/library/mcaas/{id}#', 'method' => 'POST'],
+            ['scopeId' => 'schedule', 'route' => '#^/schedule#', 'method' => 'GET,POST,PUT'],
+            ['scopeId' => 'scheduleDelete', 'route' => '#^/schedule#', 'method' => 'DELETE'],
+        ])->saveData();
+    }
+}

--- a/lib/Factory/ApplicationScopeFactory.php
+++ b/lib/Factory/ApplicationScopeFactory.php
@@ -1,8 +1,8 @@
 <?php
 /*
- * Copyright (c) 2022 Xibo Signage Ltd
+ * Copyright (C) 2025 Xibo Signage Ltd
  *
- * Xibo - Digital Signage - http://www.xibo.org.uk
+ * Xibo - Digital Signage - https://xibosignage.com
  *
  * This file is part of Xibo.
  *
@@ -150,19 +150,32 @@ class ApplicationScopeFactory extends BaseFactory implements ScopeRepositoryInte
     /**
      * {@inheritdoc}
      */
-    public function finalizeScopes(array $scopes, $grantType, ClientEntityInterface $clientEntity, $userIdentifier = null)
-    {
-        $this->getLog()->debug('finalizeScopes: provided scopes count = ' . count($scopes));
+    public function finalizeScopes(
+        array $scopes,
+        $grantType,
+        ClientEntityInterface $clientEntity,
+        $userIdentifier = null
+    ): array {
+        /** @var \Xibo\Entity\Application $clientEntity */
+        $countOfScopesRequested = count($scopes);
+        $this->getLog()->debug('finalizeScopes: provided scopes count = ' . $countOfScopesRequested);
 
+        // No scopes have been requested
+        // in this case we should return all scopes configured for the application
+        // this is to maintain backwards compatibility with older implementations which do not
+        // request scopes.
+        if ($countOfScopesRequested <= 0) {
+            return $clientEntity->getScopes();
+        }
+
+        // Scopes have been provided
         $finalScopes = [];
 
-        // $clientEntity->scopes are the valid scopes for this client.
-        // make sure all of the requested scopes are valid
+        // The client entity contains the scopes which are valid for this client
         foreach ($scopes as $scope) {
             // See if we can find it
             $found = false;
 
-            /** @var \Xibo\Entity\Application $clientEntity */
             foreach ($clientEntity->getScopes() as $validScope) {
                 if ($validScope->getIdentifier() === $scope->getIdentifier()) {
                     $found = true;

--- a/lib/Factory/ApplicationScopeFactory.php
+++ b/lib/Factory/ApplicationScopeFactory.php
@@ -82,8 +82,7 @@ class ApplicationScopeFactory extends BaseFactory implements ScopeRepositoryInte
         $entries = [];
         $params = [];
 
-        $select = 'SELECT `oauth_scopes`.id, `oauth_scopes`.description, `oauth_scopes`.useRegex';
-
+        $select = 'SELECT `oauth_scopes`.id, `oauth_scopes`.description ';
         $body = '  FROM `oauth_scopes`';
 
         if ($sanitizedFilter->getString('clientId') != null) {
@@ -110,8 +109,12 @@ class ApplicationScopeFactory extends BaseFactory implements ScopeRepositoryInte
         }
         $limit = '';
         // Paging
-        if ($filterBy !== null && $sanitizedFilter->getInt('start') !== null && $sanitizedFilter->getInt('length') !== null) {
-            $limit = ' LIMIT ' . $sanitizedFilter->getInt('start', ['default' => 0]) . ', ' . $sanitizedFilter->getInt('length', ['default' => 10]);
+        if ($filterBy !== null
+            && $sanitizedFilter->getInt('start') !== null
+            && $sanitizedFilter->getInt('length') !== null
+        ) {
+            $limit = ' LIMIT ' . $sanitizedFilter->getInt('start', ['default' => 0]) . ', '
+                . $sanitizedFilter->getInt('length', ['default' => 10]);
         }
 
         // The final statements

--- a/lib/Middleware/ApiAuthentication.php
+++ b/lib/Middleware/ApiAuthentication.php
@@ -1,8 +1,8 @@
 <?php
-/**
- * Copyright (C) 2022 Xibo Signage Ltd
+/*
+ * Copyright (C) 2025 Xibo Signage Ltd
  *
- * Xibo - Digital Signage - http://www.xibo.org.uk
+ * Xibo - Digital Signage - https://xibosignage.com
  *
  * This file is part of Xibo.
  *
@@ -80,10 +80,6 @@ class ApiAuthentication implements Middleware
                     $privateKey,
                     $encryptionKey
                 );
-
-                // Default scope
-                // must be set before we enable any grant types.
-                $server->setDefaultScope('all');
 
                 // Grant Types
                 $server->enableGrantType(

--- a/lib/Middleware/ApiAuthorization.php
+++ b/lib/Middleware/ApiAuthorization.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2024 Xibo Signage Ltd
+ * Copyright (C) 2025 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -124,6 +124,13 @@ class ApiAuthorization implements Middleware
             /** @var ApplicationScopeFactory $applicationScopeFactory */
             $applicationScopeFactory = $this->app->getContainer()->get('applicationScopeFactory');
             $scopes = $validatedRequest->getAttribute('oauth_scopes');
+
+            // If there are no scopes in the JWT, we should not authorise
+            // An older client which makes a request with no scopes should get an access token with
+            // all scopes configured for the application
+            if (count($scopes) <= 0) {
+                throw new AccessDeniedException();
+            }
 
             $logger->debug('Scopes provided with request: ' . count($scopes));
 


### PR DESCRIPTION
This PR updates the way we check route access against the scopes granted to the access token.

It also grants the configured scopes to applications which do not request scopes (for backwards compatibility). It also ensures that the right scopes are granted based on the request.