### PR TITLE
XMDS: catch errors with sync group in register display

### DIFF
--- a/lib/Xmds/Soap5.php
+++ b/lib/Xmds/Soap5.php
@@ -491,34 +491,39 @@ class Soap5 extends Soap4
         }
 
         if (!empty($display->syncGroupId)) {
-            $syncGroup = $this->syncGroupFactory->getById($display->syncGroupId);
+            try {
+                $syncGroup = $this->syncGroupFactory->getById($display->syncGroupId);
 
-            if ($syncGroup->leadDisplayId === $display->displayId) {
-                $syncNodeValue = 'lead';
-            } else {
-                $leadDisplay = $this->syncGroupFactory->getLeadDisplay($syncGroup->leadDisplayId);
-                $syncNodeValue = $leadDisplay->lanIpAddress;
+                if ($syncGroup->leadDisplayId === $display->displayId) {
+                    $syncNodeValue = 'lead';
+                } else {
+                    $leadDisplay = $this->syncGroupFactory->getLeadDisplay($syncGroup->leadDisplayId);
+                    $syncNodeValue = $leadDisplay->lanIpAddress;
+                }
+
+                $syncNode = $return->createElement('syncGroup');
+                $value = $return->createTextNode($syncNodeValue ?? '');
+                $syncNode->appendChild($value);
+                $displayElement->appendChild($syncNode);
+
+                $syncPublisherPortNode = $return->createElement('syncPublisherPort');
+                $value = $return->createTextNode($syncGroup->syncPublisherPort ?? 9590);
+                $syncPublisherPortNode->appendChild($value);
+                $displayElement->appendChild($syncPublisherPortNode);
+
+                $syncSwitchDelayNode = $return->createElement('syncSwitchDelay');
+                $value = $return->createTextNode($syncGroup->syncSwitchDelay ?? 750);
+                $syncSwitchDelayNode->appendChild($value);
+                $displayElement->appendChild($syncSwitchDelayNode);
+
+                $syncVideoPauseDelayNode = $return->createElement('syncVideoPauseDelay');
+                $value = $return->createTextNode($syncGroup->syncVideoPauseDelay ?? 100);
+                $syncVideoPauseDelayNode->appendChild($value);
+                $displayElement->appendChild($syncVideoPauseDelayNode);
+            } catch (GeneralException $exception) {
+                $this->getLog()->error('registerDisplay: cannot get sync group information, e = '
+                    . $exception->getMessage());
             }
-
-            $syncNode = $return->createElement('syncGroup');
-            $value = $return->createTextNode($syncNodeValue ?? '');
-            $syncNode->appendChild($value);
-            $displayElement->appendChild($syncNode);
-
-            $syncPublisherPortNode = $return->createElement('syncPublisherPort');
-            $value = $return->createTextNode($syncGroup->syncPublisherPort ?? 9590);
-            $syncPublisherPortNode->appendChild($value);
-            $displayElement->appendChild($syncPublisherPortNode);
-
-            $syncSwitchDelayNode = $return->createElement('syncSwitchDelay');
-            $value = $return->createTextNode($syncGroup->syncSwitchDelay ?? 750);
-            $syncSwitchDelayNode->appendChild($value);
-            $displayElement->appendChild($syncSwitchDelayNode);
-
-            $syncVideoPauseDelayNode = $return->createElement('syncVideoPauseDelay');
-            $value = $return->createTextNode($syncGroup->syncVideoPauseDelay ?? 100);
-            $syncVideoPauseDelayNode->appendChild($value);
-            $displayElement->appendChild($syncVideoPauseDelayNode);
         }
 
         $display->save(Display::$saveOptionsMinimum);

--- a/tests/http-client.env.json
+++ b/tests/http-client.env.json
@@ -1,7 +1,7 @@
 {
   "dev": {
     "url": "http://localhost",
-    "serverKey": "6v4RduQhaw5Q",
+    "serverKey": "test",
     "hardwareKey": "phpstorm",
     "displayName": "PHPStorm",
     "clientType": "windows",

--- a/views/display-form-edit.twig
+++ b/views/display-form-edit.twig
@@ -147,8 +147,10 @@
                         {% set helpText %}{% trans "The timezone for this display, or empty to use the CMS timezone" %}{% endset %}
                         {{ forms.dropdown("timeZone", "single", title, display.timeZone, [{id:"", value:""}]|merge(timeZones), "id", "value", helpText, "selectPicker", "", "", "", attributes) }}
 
+                        {{ forms.message("Configure further details for integration with 3rd parties such as DOOH providers:") }}
+
                         {% set title %}{% trans "Languages" %}{% endset %}
-                        {% set helpText %}{% trans "The Languages supported in this display location" %}{% endset %}
+                        {% set helpText %}{% trans "The languages that the audience viewing this Display are likely to understand" %}{% endset %}
                         {{ forms.dropdown("languages[]", "dropdownmulti", title, display.getLanguages(), languages, "id", "value", helpText, "selectPicker") }}
 
                         {% set title %}{% trans "Display Type" %}{% endset %}


### PR DESCRIPTION
In this PR we catch errors in Register where we try to get the Sync Group configuration. If there are errors they will be logged and the display will not be in a sync group until they are resolved.

This PR also updated the Display Edit form to make it clearer what those details are used for.