### PR TITLE
Images: fix content-type on thumbnails (library), previews (library,layout editor) and screenshots (display)

### DIFF
--- a/lib/Controller/Display.php
+++ b/lib/Controller/Display.php
@@ -2222,7 +2222,7 @@ class Display extends Base
         $file = 'screenshots/' . $id . '_screenshot.jpg';
 
         // File upload directory.. get this from the settings object
-        $library = $this->getConfig()->getSetting("LIBRARY_LOCATION");
+        $library = $this->getConfig()->getSetting('LIBRARY_LOCATION');
         $fileName = $library . $file;
 
         if (!file_exists($fileName)) {
@@ -2243,16 +2243,17 @@ class Display extends Base
         }
 
         // Cache headers
-        header("Cache-Control: no-store, no-cache, must-revalidate");
-        header("Pragma: no-cache");
-        header("Expires: 0");
+        header('Cache-Control: no-store, no-cache, must-revalidate');
+        header('Pragma: no-cache');
+        header('Expires: 0');
 
         // Disable any buffering to prevent OOM errors.
         while (ob_get_level() > 0) {
             ob_end_clean();
         }
 
-        echo $img->encode();
+        $response->write($img->encode());
+        $response = $response->withHeader('Content-Type', $img->mime());
         return $this->render($request, $response);
     }
 

--- a/lib/Controller/Library.php
+++ b/lib/Controller/Library.php
@@ -1684,7 +1684,7 @@ class Library extends Base
             // Output a 1px image if we're not allowed to see the media.
             if (!$this->getUser()->checkViewable($media)) {
                 echo Img::make($this->getConfig()->uri('img/1x1.png', true))->encode();
-                return $this->render($request, $response);
+                return $this->render($request, $response->withHeader('Content-Type', 'image/png'));
             }
 
             // Various different behaviours for the different types of file.


### PR DESCRIPTION
This PR ensures that the content type is set correctly for images output via the CMS (thumbnails and the like). The key here is setting the content type, but also ensuring we do not `echo` out directly.

@nadzpogi you should be able to pull this locally to test with the Canva thing you are working on.

fixes xibosignage/xibo#3712