### PR TITLE
Logs: Remove the default filter date NOW() and leave it empty by default

### DIFF
--- a/views/log-page.twig
+++ b/views/log-page.twig
@@ -46,6 +46,14 @@
                         <form class="form-inline">
                             <div class="tab-content">
                                 <div class="tab-pane active" id="general">
+                                    {% set helpText = "Set the time to start searching for logs based on the interval "
+                                        ~ "filter. Leave empty to start from the current time." %}
+                                    {% set title %}
+                                        {% trans "Date" %}
+                                        <i class="fa fa-info-circle ml-1" title="{% trans helpText %}"></i>
+                                    {% endset %}
+                                    {{ inline.dateTime("fromDt", title, "", "", "", "", "") }}
+
                                     {% set title %}{% trans "Level" %}{% endset %}
                                     {{ inline.input("level", title) }}
 
@@ -82,14 +90,6 @@
                                     {{ inline.dropdown("userId", "single", title, "", null, "userId", "userName", helpText, "pagedSelect", "", "", "", attributes) }}
                                 </div>
                                 <div class="tab-pane" id="advanced">
-                                    {% set helpText = "Set the time to start searching for logs based on the interval "
-                                        ~ "filter. Leave empty to start from the current time." %}
-                                    {% set title %}
-                                        {% trans "Date" %}
-                                        <i class="fa fa-info-circle ml-1" title="{% trans helpText %}"></i>
-                                    {% endset %}
-                                    {{ inline.dateTime("fromDt", title, 'now'|date("Y-m-d H:i:s"), "", "", "", "") }}
-
                                     {% set title %}{% trans "Channel" %}{% endset %}
                                     {{ inline.input("channel", title) }}
 


### PR DESCRIPTION
## Changes

- Removed default date NOW() in date filter
- Moved the date filter from `advanced` to `general` tab

Relates to https://github.com/xibosignage/xibo/issues/3709