### PR TITLE
Fixed Report Schedule: API request history fails to generate save report

### DIFF
--- a/lib/Report/ApiRequests.php
+++ b/lib/Report/ApiRequests.php
@@ -179,9 +179,9 @@ class ApiRequests implements ReportInterface
         // --------------------------
         // The report uses a custom range filter that automatically calculates the from/to dates
         // depending on the date range selected.
-        $fromDt = $sanitizedParams->getDate('fromDt');
-        $toDt = $sanitizedParams->getDate('toDt');
         $currentDate = Carbon::now()->startOfDay();
+        $fromDt = $sanitizedParams->getDate('fromDt') ?? $currentDate;
+        $toDt = $sanitizedParams->getDate('toDt') ?? Carbon::now();
 
         // If toDt is current date then make it current datetime
         if ($toDt->format('Y-m-d') == $currentDate->format('Y-m-d')) {

--- a/lib/Report/SessionHistory.php
+++ b/lib/Report/SessionHistory.php
@@ -175,9 +175,9 @@ class SessionHistory implements ReportInterface
         // --------------------------
         // The report uses a custom range filter that automatically calculates the from/to dates
         // depending on the date range selected.
-        $fromDt = $sanitizedParams->getDate('fromDt');
-        $toDt = $sanitizedParams->getDate('toDt');
         $currentDate = Carbon::now()->startOfDay();
+        $fromDt = $sanitizedParams->getDate('fromDt') ?? $currentDate;
+        $toDt = $sanitizedParams->getDate('toDt') ?? Carbon::now();
 
         // If toDt is current date then make it current datetime
         if ($toDt->format('Y-m-d') == $currentDate->format('Y-m-d')) {


### PR DESCRIPTION
## Changes

- Added default `fromDt` and `toDt` in Session History and API Request Reports

Relates to https://github.com/xibosignage/xibo/issues/3691