### PR TITLE
Remote Dataset - Authentication - Usernames and Passwords cannot exceed 250 characters

### DIFF
--- a/db/migrations/20250909081522_update_password_column_limit_in_dataset.php
+++ b/db/migrations/20250909081522_update_password_column_limit_in_dataset.php
@@ -1,0 +1,41 @@
+<?php
+/*
+ * Copyright (C) 2025 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use Phinx\Migration\AbstractMigration;
+
+/**
+ * Migrations for dataset
+ * @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+ */
+
+class UpdatePasswordColumnLimitInDataset extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('dataset')
+            ->changeColumn('password', 'string', [
+                'limit' => 1000,
+                'null' => true,
+            ])
+            ->save();
+    }
+}


### PR DESCRIPTION
## Changes

- Updated the character limit for `password` from `250` to `1000`.

Relates to https://github.com/xibosignage/xibo/issues/3726