### PR TITLE
Android: WebSocket XMR support from v4 R408

### DIFF
--- a/lib/Entity/Display.php
+++ b/lib/Entity/Display.php
@@ -704,7 +704,7 @@ class Display implements \JsonSerializable
     public function isWebSocketXmrSupported(): bool
     {
         return $this->clientType === 'chromeOS'
-            || ($this->clientType === 'android' && $this->clientVersion >= 408);
+            || ($this->clientType === 'android' && $this->clientCode >= 408);
     }
 
     /**

--- a/lib/Entity/Display.php
+++ b/lib/Entity/Display.php
@@ -699,6 +699,15 @@ class Display implements \JsonSerializable
     }
 
     /**
+     * @return bool true is this display supports WebSocket XMR
+     */
+    public function isWebSocketXmrSupported(): bool
+    {
+        return $this->clientType === 'chromeOS'
+            || ($this->clientType === 'android' && $this->clientVersion >= 408);
+    }
+
+    /**
      * Is this display auditing?
      * return bool
      */

--- a/lib/Service/PlayerActionService.php
+++ b/lib/Service/PlayerActionService.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2024 Xibo Signage Ltd
+ * Copyright (C) 2025 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -99,7 +99,8 @@ class PlayerActionService implements PlayerActionServiceInterface
                 );
             }
 
-            if ($display->clientType !== 'chromeOS') {
+            // If we are using the old ZMQ XMR service, we also need to encrypt the message
+            if (!$display->isWebSocketXmrSupported()) {
                 // We also need a xmrPubKey
                 $isEncrypt = true;
 


### PR DESCRIPTION
As we update our player apps to support web sockets, we will also need to instruct the CMS to send those messages to XMR unencrypted and marked as "web socket". We can do this by version code and type. ChromeOS was already handled.