### PR TITLE
docs(LUFE): adicionar README-LUFE no fork

### DIFF
--- a/README-LUFE.md
+++ b/README-LUFE.md
@@ -1,0 +1,25 @@
+# Fork LUFE — Xibo CMS
+
+Este repositório é um fork de transparência do **Xibo CMS** para a LUFE Mídias.
+
+- Upstream: https://github.com/xibosignage/xibo-cms
+- Fork: https://github.com/lufemidias/lufe-xibo-cms (público)
+
+## Objetivo
+
+- Manter transparência e compliance com a licença **AGPL-3.0**
+- Facilitar aplicação de patches eventuais específicos da LUFE
+- Documentar ajustes que extrapolem o escopo de tema
+
+## Política de PR
+
+- Preferência por upstream first: contribuímos com PRs no repositório oficial sempre que possível
+- Patches locais devem:
+  - Ser mínimos e justificados
+  - Ter descrição clara e testes (quando aplicável)
+  - Respeitar padrões de codificação do projeto
+- Branches: use `feature/*`, `fix/*`, `chore/*`
+
+## Nota
+
+Seguimos operando via tema (`lufe-xibo-deploy/theme-lufe`); este fork existe para **transparência/licença** e para **eventuais patches** caso necessário.


### PR DESCRIPTION
Este PR documenta o contexto do fork LUFE (README-LUFE.md).\n\nNotas:\n- Fork: https://github.com/lufemidias/lufe-xibo-cms\n- Objetivo: transparência e conformidade AGPL para eventuais patches.\n\nMarcado como rascunho para discussão.