### PR TITLE
XMDS: cache bandwidth usage (performance)

### DIFF
--- a/lib/Dependencies/Factories.php
+++ b/lib/Dependencies/Factories.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2024 Xibo Signage Ltd
+ * Copyright (C) 2025 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -73,7 +73,9 @@ class Factories
                 return $repository;
             },
             'bandwidthFactory' => function (ContainerInterface $c) {
-                $repository = new \Xibo\Factory\BandwidthFactory();
+                $repository = new \Xibo\Factory\BandwidthFactory(
+                    $c->get('pool'),
+                );
                 $repository->useBaseDependenciesService($c->get('RepositoryBaseDependenciesService'));
                 return $repository;
             },

--- a/lib/Xmds/Soap.php
+++ b/lib/Xmds/Soap.php
@@ -2771,7 +2771,7 @@ class Soap
 
         $this->display = $this->displayFactory->getById($displayId);
 
-        $xmdsLimit = $this->getConfig()->getSetting('MONTHLY_XMDS_TRANSFER_LIMIT_KB');
+        $xmdsLimit = intval($this->getConfig()->getSetting('MONTHLY_XMDS_TRANSFER_LIMIT_KB'));
         $displayBandwidthLimit = $this->display->bandwidthLimit;
 
         try {


### PR DESCRIPTION
fixes xibosignageltd/xibo-private#1040

This PR introduces a cache to the Bandwidth factory so that we only look up the current bandwidth usage from the database every 10 minutes instead of with each request.