### PR TITLE
Fixed Layout duration not updating correctly with Global Element/Image

### DIFF
--- a/db/migrations/20251001125431_update_core_canvas_duration_in_module_table_migration.php
+++ b/db/migrations/20251001125431_update_core_canvas_duration_in_module_table_migration.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ * Copyright (C) 2025 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Migrations for core-canvas module duration
+ * @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+ */
+
+use Phinx\Migration\AbstractMigration;
+
+class UpdateCoreCanvasDurationInModuleTableMigration extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->execute('UPDATE `module` SET `defaultDuration` = 10 WHERE `moduleId` = :moduleId', [
+            'moduleId' => 'core-canvas',
+        ]);
+    }
+}

--- a/lib/Controller/Widget.php
+++ b/lib/Controller/Widget.php
@@ -478,7 +478,12 @@ class Widget extends Base
 
         // Handle common parameters.
         $widget->useDuration = $params->getCheckbox('useDuration');
-        $widget->duration = $params->getInt('duration', ['default' => $module->defaultDuration]);
+
+        // If we enabled useDuration, then use the provided duration
+        $widget->duration = ($widget->useDuration == 1)
+            ? $params->getInt('duration', ['default' => $module->defaultDuration])
+            : $module->defaultDuration;
+
         $widget->setOptionValue('name', 'attrib', $params->getString('name'));
         $widget->setOptionValue('enableStat', 'attrib', $params->getString('enableStat'));
 

--- a/lib/Entity/Layout.php
+++ b/lib/Entity/Layout.php
@@ -1315,8 +1315,10 @@ class Layout implements \JsonSerializable
         // merge regions and drawers into one array and go through it.
         $allRegions = array_merge($this->regions, $this->drawers);
 
-        // Used to identify Layouts which only have Canvas with global elements
-        $isCanvasOnlyRegion = true;
+        // Used to identify layouts with canvas-only region and global elements without custom duration
+        // If there's more than 1 region, then we can assume that the layout doesn't have a canvas-only region
+        $isCanvasOnlyRegion = count($allRegions) <= 1;
+        $minLayoutDuration = 10;
 
         foreach ($allRegions as $region) {
             /* @var Region $region */
@@ -1379,6 +1381,15 @@ class Layout implements \JsonSerializable
                     // Pull out the global widget, if we have one (we should)
                     if ($item->type === 'global') {
                         $widget = $item;
+
+                        // If this widget has a custom duration or if the current duration is already greater than
+                        // the minimum layout duration for canvas-only regions, then use that duration
+                        if ($widget->useDuration == 1
+                            || $widget->duration > $minLayoutDuration
+                            || $widget->calculatedDuration > $minLayoutDuration
+                        ) {
+                            $isCanvasOnlyRegion = false;
+                        }
                     } else {
                         $isCanvasOnlyRegion = false;
                     }
@@ -1457,13 +1468,9 @@ class Layout implements \JsonSerializable
                     $widgetDuration = Widget::$widgetMinDuration;
                 }
 
-                // Layouts which only have Canvas with global elements
-                if ($region->type == 'canvas'
-                    && $widget->type == 'global'
-                    && $isCanvasOnlyRegion
-                ) {
-                    $widget->calculatedDuration = 10;
-                    $widgetDuration = $widget->calculatedDuration;
+                // Special case for layouts with canvas-only region containing global elements without custom duration
+                if ($isCanvasOnlyRegion) {
+                    $widgetDuration = $minLayoutDuration;
                 }
 
                 if ($region->isDrawer === 0) {

--- a/lib/Entity/Layout.php
+++ b/lib/Entity/Layout.php
@@ -1315,11 +1315,6 @@ class Layout implements \JsonSerializable
         // merge regions and drawers into one array and go through it.
         $allRegions = array_merge($this->regions, $this->drawers);
 
-        // Used to identify layouts with canvas-only region and global elements without custom duration
-        // If there's more than 1 region, then we can assume that the layout doesn't have a canvas-only region
-        $isCanvasOnlyRegion = count($allRegions) <= 1;
-        $minLayoutDuration = 10;
-
         foreach ($allRegions as $region) {
             /* @var Region $region */
 
@@ -1382,16 +1377,6 @@ class Layout implements \JsonSerializable
                     if ($item->type === 'global') {
                         $widget = $item;
 
-                        // If this widget has a custom duration or if the current duration is already greater than
-                        // the minimum layout duration for canvas-only regions, then use that duration
-                        if ($widget->useDuration == 1
-                            || $widget->duration > $minLayoutDuration
-                            || $widget->calculatedDuration > $minLayoutDuration
-                        ) {
-                            $isCanvasOnlyRegion = false;
-                        }
-                    } else {
-                        $isCanvasOnlyRegion = false;
                     }
 
                     // Get the highest duration.
@@ -1414,8 +1399,6 @@ class Layout implements \JsonSerializable
                     $widgets = [$widget];
                 }
             } else {
-                $isCanvasOnlyRegion = false;
-
                 $widgets = $region->getPlaylist()->setModuleFactory($this->moduleFactory)->expandWidgets();
             }
 
@@ -1466,11 +1449,6 @@ class Layout implements \JsonSerializable
                     // Make sure this Widget expires immediately so that the other Regions can be the leaders when
                     // it comes to expiring the Layout
                     $widgetDuration = Widget::$widgetMinDuration;
-                }
-
-                // Special case for layouts with canvas-only region containing global elements without custom duration
-                if ($isCanvasOnlyRegion) {
-                    $widgetDuration = $minLayoutDuration;
                 }
 
                 if ($region->isDrawer === 0) {

--- a/ui/src/editor-core/widget.js
+++ b/ui/src/editor-core/widget.js
@@ -91,6 +91,8 @@ const Widget = function(id, data, regionId = null, layoutObject = null) {
   // playlist id
   this.playlistId = data.playlistId;
 
+  this.useDuration = data.useDuration;
+
   // check if audio can be attached to it
   const typesThatCantHaveAudio = ['subplaylist'];
   this.canAttachAudio = !typesThatCantHaveAudio.includes(this.subType);
@@ -282,11 +284,13 @@ const Widget = function(id, data, regionId = null, layoutObject = null) {
     // If this widget does not have a set duration, then use the region duration
     if (this.useDuration !== 1 || this.duration == null) {
       const app = this.editorObject;
-      const region = app.getObjectByTypeAndId('region', this.parent.regionId);
+      const region = (this.parent.subType == 'canvas') ?
+        app.getObjectByTypeAndId('canvas') :
+        app.getObjectByTypeAndId('region', this.parent.regionId);
 
-      return (region && region.duration)
-        ? parseFloat(region.duration)
-        : parseFloat(this.calculatedDuration);
+      return (region && region.duration) ?
+        parseFloat(region.duration) :
+        parseFloat(this.calculatedDuration);
     }
 
     return parseFloat(this.calculatedDuration);

--- a/ui/src/editor-core/widget.js
+++ b/ui/src/editor-core/widget.js
@@ -91,8 +91,6 @@ const Widget = function(id, data, regionId = null, layoutObject = null) {
   // playlist id
   this.playlistId = data.playlistId;
 
-  this.useDuration = data.useDuration;
-
   // check if audio can be attached to it
   const typesThatCantHaveAudio = ['subplaylist'];
   this.canAttachAudio = !typesThatCantHaveAudio.includes(this.subType);
@@ -281,18 +279,6 @@ const Widget = function(id, data, regionId = null, layoutObject = null) {
    * @return {number} - Widget duration in seconds
    */
   this.getDuration = function() {
-    // If this widget does not have a set duration, then use the region duration
-    if (this.useDuration !== 1 || this.duration == null) {
-      const app = this.editorObject;
-      const region = (this.parent.subType == 'canvas') ?
-        app.getObjectByTypeAndId('canvas') :
-        app.getObjectByTypeAndId('region', this.parent.regionId);
-
-      return (region && region.duration) ?
-        parseFloat(region.duration) :
-        parseFloat(this.calculatedDuration);
-    }
-
     return parseFloat(this.calculatedDuration);
   };
 

--- a/ui/src/layout-editor/layout.js
+++ b/ui/src/layout-editor/layout.js
@@ -268,13 +268,18 @@ Layout.prototype.createDataStructure = function(data) {
         }
       }
 
-      // Set region duration
-      newRegion.duration = regionDuration;
-
       // If it's a canvas, save region as a canvas
       if (isCanvas) {
+        // For canvas, if region in data is longer than
+        // the longest widget, set as data instead
+        newRegion.duration =
+          Math.max(regionDuration ?? 0, data.regions[region]?.duration ?? 0);
+
         this.canvas = newRegion;
       } else {
+        // Set region duration
+        newRegion.duration = regionDuration;
+
         // Push Region to the Layout region array
         this.regions[newRegion.id] = newRegion;
       }

--- a/ui/src/layout-editor/layout.js
+++ b/ui/src/layout-editor/layout.js
@@ -268,18 +268,13 @@ Layout.prototype.createDataStructure = function(data) {
         }
       }
 
+      // Set region duration
+      newRegion.duration = regionDuration;
+
       // If it's a canvas, save region as a canvas
       if (isCanvas) {
-        // For canvas, if region in data is longer than
-        // the longest widget, set as data instead
-        newRegion.duration =
-          Math.max(regionDuration ?? 0, data.regions[region]?.duration ?? 0);
-
         this.canvas = newRegion;
       } else {
-        // Set region duration
-        newRegion.duration = regionDuration;
-
         // Push Region to the Layout region array
         this.regions[newRegion.id] = newRegion;
       }

--- a/ui/src/layout-editor/main.js
+++ b/ui/src/layout-editor/main.js
@@ -3362,9 +3362,8 @@ lD.getObjectByTypeAndId = function(type, id, auxId) {
     }
 
     // Verify that the region exists before checking the unique id
-    targetObject = (lD.layout && lD.layout.regions) ?
-      lD.layout.regions[id] :
-      {};
+    targetObject = lD.layout.regions[id];
+
   } else if (type === 'drawer') {
     targetObject = lD.layout.drawer;
   } else if (type === 'canvas') {

--- a/ui/src/layout-editor/main.js
+++ b/ui/src/layout-editor/main.js
@@ -3362,7 +3362,9 @@ lD.getObjectByTypeAndId = function(type, id, auxId) {
     }
 
     // Verify that the region exists before checking the unique id
-    targetObject = (lD.layout && lD.layout.regions) ? lD.layout.regions[id] : {};
+    targetObject = (lD.layout && lD.layout.regions) ?
+      lD.layout.regions[id] :
+      {};
   } else if (type === 'drawer') {
     targetObject = lD.layout.drawer;
   } else if (type === 'canvas') {


### PR DESCRIPTION
## Changes

- Removed previous FE changes on widget duration calculation (the calculation should be from bottom to top)
- Added migration file to set the minimum canvas widget duration to 10s instead of forcing the BE to implement this
- Added a validation when changing the widget duration. The user-provided widget duration should only be used when use duration option is checked

Relates to https://github.com/xibosignage/xibo/issues/3725