### PR TITLE
Fixed All Players do not display layout after it is unretired

### DIFF
--- a/lib/Controller/Layout.php
+++ b/lib/Controller/Layout.php
@@ -1306,12 +1306,12 @@ class Layout extends Base
         }
 
         $layout->retired = 0;
+
         $layout->save([
             'saveLayout' => true,
             'saveRegions' => false,
             'saveTags' => false,
             'setBuildRequired' => false,
-            'notify' => false
         ]);
 
         // Return


### PR DESCRIPTION
## Changes

- Enable notify when a layout is unretired 

Relates to https://github.com/xibosignage/xibo/issues/3716