### PR TITLE
Cast autoApplyTransitions and enableStat to int if read as default from DB

### DIFF
--- a/lib/Controller/Layout.php
+++ b/lib/Controller/Layout.php
@@ -362,7 +362,7 @@ class Layout extends Base
         $name = $sanitizedParams->getString('name');
         $description = $sanitizedParams->getString('description');
         $enableStat = $sanitizedParams->getCheckbox('enableStat');
-        $autoApplyTransitions = $this->getConfig()->getSetting('DEFAULT_TRANSITION_AUTO_APPLY');
+        $autoApplyTransitions = (int)$this->getConfig()->getSetting('DEFAULT_TRANSITION_AUTO_APPLY');
         $code = $sanitizedParams->getString('code', ['defaultOnEmptyString' => true]);
 
         // Folders
@@ -439,7 +439,7 @@ class Layout extends Base
         // Do we have an 'Enable Layout Stats Collection?' checkbox?
         // If not, we fall back to the default Stats Collection setting.
         if (!$sanitizedParams->hasParam('enableStat')) {
-            $enableStat = $this->getConfig()->getSetting('LAYOUT_STATS_ENABLED_DEFAULT');
+            $enableStat = (int)$this->getConfig()->getSetting('LAYOUT_STATS_ENABLED_DEFAULT');
         }
 
         // Set layout enableStat flag


### PR DESCRIPTION
If default values are read from the database, all values are strings. This can produce wrong quoted json results on API-requests, if the swagger definition has type integer for this variable, e.g.

```
  "enableStat": "1",
  "autoApplyTransitions": "0",
```

This fix produces the correct json response according to the swagger entry:

 ```
  "enableStat": 1,
  "autoApplyTransitions": 0,
```