### PR TITLE
Do not format storage values in api response

### DIFF
--- a/lib/Controller/Display.php
+++ b/lib/Controller/Display.php
@@ -726,8 +726,6 @@ class Display extends Base
                 $display->auditingUntil = ($display->auditingUntil == 0)
                     ? 0
                     : Carbon::createFromTimestamp($display->auditingUntil)->format(DateFormatHelper::getSystemFormat());
-                $display->storageAvailableSpace = ByteFormatter::format($display->storageAvailableSpace);
-                $display->storageTotalSpace = ByteFormatter::format($display->storageTotalSpace);
                 continue;
             }
 


### PR DESCRIPTION
The swagger spec indicates pure integer for the values of storageAvailableSpace and storageTotalSpace if called as API-call.

Currently the values are formated as in the GUI, e.g.

```
    "storageAvailableSpace": "10.72 GiB",
    "storageTotalSpace": "11.18 GiB",
```

This patch fixes this to

```
    "storageAvailableSpace": 11510005760,
    "storageTotalSpace": 12006490112,
```

by deleting the lines, that call the formatter.