### PR TITLE
Layout: set Canvas region default duration to 10s

### DIFF
--- a/db/migrations/20251021074311_update_core_canvas_duration_in_module_table_migration.php
+++ b/db/migrations/20251021074311_update_core_canvas_duration_in_module_table_migration.php
@@ -1,0 +1,38 @@
+<?php
+/*
+ * Copyright (C) 2025 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Migrations for core-canvas module duration
+ * @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+ */
+
+use Phinx\Migration\AbstractMigration;
+
+class UpdateCoreCanvasDurationInModuleTableMigration extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->execute('UPDATE `module` SET `defaultDuration` = 10 WHERE `moduleId` = :moduleId', [
+            'moduleId' => 'core-canvas',
+        ]);
+    }
+}


### PR DESCRIPTION
## Changes

Added migration file to set Canvas region default duration to 10s

Relates to https://github.com/xibosignageltd/xibo-private/issues/1046