### PR TITLE
Parsedown library: Pinned commit to fix PHP 8.4 deprecation warnings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,7 @@
     "akrabat/ip-address-middleware" : "2.6.*",
     "apereo/phpcas": "dev-master#6ef19a1e636303bda2f05f46b08035d53a8b602d",
     "dragonmantank/cron-expression": "^3.4",
-    "erusev/parsedown": "~1.5",
+    "erusev/parsedown": "dev-master#26cfde9dbffa43a77bfd45c87b0394df0dfcba85",
     "flynsarmy/slim-monolog": "~1.0",
     "gettext/gettext": "~4.0",
     "guzzlehttp/guzzle": "7.9.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1b0a1ab408c0e12615470dac96ed8422",
+    "content-hash": "66b8c6f75806d19cb4967aaf3d04f8f9",
     "packages": [
         {
             "name": "akrabat/ip-address-middleware",
@@ -760,25 +760,26 @@
         },
         {
             "name": "erusev/parsedown",
-            "version": "1.7.4",
+            "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/erusev/parsedown.git",
-                "reference": "cb17b6477dfff935958ba01325f2e8a2bfa6dab3"
+                "reference": "26cfde9dbffa43a77bfd45c87b0394df0dfcba85"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/erusev/parsedown/zipball/cb17b6477dfff935958ba01325f2e8a2bfa6dab3",
-                "reference": "cb17b6477dfff935958ba01325f2e8a2bfa6dab3",
+                "url": "https://api.github.com/repos/erusev/parsedown/zipball/26cfde9dbffa43a77bfd45c87b0394df0dfcba85",
+                "reference": "26cfde9dbffa43a77bfd45c87b0394df0dfcba85",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "php": ">=5.3.0"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35"
+                "phpunit/phpunit": "^7.5|^8.5|^9.6"
             },
+            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-0": {
@@ -804,9 +805,9 @@
             ],
             "support": {
                 "issues": "https://github.com/erusev/parsedown/issues",
-                "source": "https://github.com/erusev/parsedown/tree/1.7.x"
+                "source": "https://github.com/erusev/parsedown/tree/master"
             },
-            "time": "2019-12-30T22:54:17+00:00"
+            "time": "2025-08-31T07:57:44+00:00"
         },
         {
             "name": "flynsarmy/slim-monolog",
@@ -9167,6 +9168,7 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "apereo/phpcas": 20,
+        "erusev/parsedown": 20,
         "infostars/picofeed": 20,
         "xibosignage/oauth2-xibo-cms": 20,
         "xibosignage/support": 20


### PR DESCRIPTION
## Changes

- Updated Parsedown library to fix deprecated PHP8.4 call

Relates to https://github.com/xibosignage/xibo/issues/3745