### PR TITLE
Scheduling: Deprecate the API for returning events to the calendar

### DIFF
--- a/lib/Controller/Schedule.php
+++ b/lib/Controller/Schedule.php
@@ -173,7 +173,9 @@ class Schedule extends Base
      * @SWG\Get(
      *  path="/schedule/data/events",
      *  operationId="scheduleCalendarData",
+     *  description="⚠️ This endpoint is deprecated and will be removed in v5.0.",
      *  tags={"schedule"},
+     *  deprecated=true,
      *  @SWG\Parameter(
      *      name="displayGroupIds",
      *      description="The DisplayGroupIds to return the schedule for. [-1] for All.",

--- a/lib/Controller/Schedule.php
+++ b/lib/Controller/Schedule.php
@@ -216,7 +216,6 @@ class Schedule extends Base
     public function eventData(Request $request, Response $response)
     {
         $response = $response
-            ->withHeader('Content-Type', 'application/json')
             ->withHeader(
             'Warning',
             '299 - "Deprecated API: /schedule/data/events will be removed in v5.0"'

--- a/lib/Controller/Schedule.php
+++ b/lib/Controller/Schedule.php
@@ -169,7 +169,7 @@ class Schedule extends Base
 
     /**
      * Generates the calendar that we draw events on
-     *
+     * @deprecated - Deprecated API: This endpoint will be removed in v5.0
      * @SWG\Get(
      *  path="/schedule/data/events",
      *  operationId="scheduleCalendarData",
@@ -215,7 +215,15 @@ class Schedule extends Base
      */
     public function eventData(Request $request, Response $response)
     {
-        $response = $response->withHeader('Content-Type', 'application/json');
+        $response = $response
+            ->withHeader('Content-Type', 'application/json')
+            ->withHeader(
+            'Warning',
+            '299 - "Deprecated API: /schedule/data/events will be removed in v5.0"'
+        );
+
+        $this->getLog()->error('Deprecated API called: /schedule/data/events');
+
         $this->setNoOutput();
         $sanitizedParams = $this->getSanitizer($request->getParams());
 

--- a/lib/routes.php
+++ b/lib/routes.php
@@ -95,7 +95,9 @@ $app->post('/tfa', ['\Xibo\Controller\Login' , 'twoFactorAuthValidate'])->setNam
  * )
  */
 $app->get('/schedule', ['\Xibo\Controller\Schedule','grid'])->setName('schedule.search');
+// ⚠️ Deprecated: This route will be removed in v5.0
 $app->get('/schedule/data/events', ['\Xibo\Controller\Schedule','eventData'])->setName('schedule.calendar.data');
+
 $app->get('/schedule/{id}/events', ['\Xibo\Controller\Schedule','eventList'])->setName('schedule.events');
 
 $app->post('/schedule', ['\Xibo\Controller\Schedule','add'])

--- a/web/swagger.json
+++ b/web/swagger.json
@@ -8717,7 +8717,9 @@
                     "schedule"
                 ],
                 "summary": "Generates the calendar that we draw events on",
+                "deprecated": true,
                 "operationId": "scheduleCalendarData",
+                "description": "⚠️ This endpoint is deprecated and will be removed in version 5.0.",
                 "parameters": [
                     {
                         "name": "displayGroupIds",
@@ -11922,7 +11924,6 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "WidgetDataOrder"
                             }
                         }
                     }

--- a/web/swagger.json
+++ b/web/swagger.json
@@ -8717,9 +8717,8 @@
                     "schedule"
                 ],
                 "summary": "Generates the calendar that we draw events on",
-                "deprecated": true,
+                "description": "\u26a0\ufe0f This endpoint is deprecated and will be removed in v5.0.",
                 "operationId": "scheduleCalendarData",
-                "description": "⚠️ This endpoint is deprecated and will be removed in version 5.0.",
                 "parameters": [
                     {
                         "name": "displayGroupIds",
@@ -8756,7 +8755,8 @@
                             }
                         }
                     }
-                }
+                },
+                "deprecated": true
             }
         },
         "/schedule/{displayGroupId}/events": {


### PR DESCRIPTION
## Changes

- Deprecates the API for returning events to the calendar 

Relates to https://github.com/xibosignageltd/xibo-private/issues/1044