### PR TITLE
Logging: XMDS logs showing 1-hour timestamp offset

### DIFF
--- a/lib/Middleware/State.php
+++ b/lib/Middleware/State.php
@@ -193,9 +193,6 @@ class State implements Middleware
 
         date_default_timezone_set($defaultTimezone);
 
-        // Update logger containers to use the CMS default timezone
-        $container->get('logger')->setTimezone(new \DateTimeZone($defaultTimezone));
-
         $container->set('session', function (ContainerInterface $container) use ($app) {
             if ($container->get('name') == 'web' || $container->get('name') == 'auth') {
                 $sessionHandler = new Session($container->get('logService'));
@@ -272,6 +269,10 @@ class State implements Middleware
             $container->get('logService')->setLevel($level);
         }
 
+
+        // Update logger containers to use the CMS default timezone
+        $container->get('logger')->setTimezone(new \DateTimeZone($defaultTimezone));
+
         // Configure any extra log handlers
         // we do these last so that they can provide their own log levels independent of the system settings
         if ($container->get('configService')->logHandlers != null && is_array($container->get('configService')->logHandlers)) {
@@ -289,15 +290,6 @@ class State implements Middleware
                 $container->get('logger')->pushProcessor($processor);
             }
         }
-
-        if ($container->get('configService')->logProcessors != null && is_array($container->get('configService')->logProcessors)) {
-            $container->get('logService')->debug('Configuring %d additional log processors from Config', count($container->get('configService')->logProcessors));
-            foreach ($container->get('configService')->logProcessors as $processor) {
-                $container->get('logger')
-                    ->setTimezone(new \DateTimeZone($container->get('configService')->getSetting('defaultTimezone')));
-            }
-        }
-
 
         // Add additional validation rules
         Factory::setDefaultInstance(

--- a/lib/Middleware/State.php
+++ b/lib/Middleware/State.php
@@ -189,7 +189,7 @@ class State implements Middleware
         Carbon::setLocale(Translate::GetLocale(2));
 
         // Default timezone
-        $defaultTimezone = $container->get('configService')->getSetting('defaultTimezone');
+        $defaultTimezone = $container->get('configService')->getSetting('defaultTimezone') ?? 'UTC';
 
         date_default_timezone_set($defaultTimezone);
 

--- a/lib/Middleware/State.php
+++ b/lib/Middleware/State.php
@@ -189,7 +189,12 @@ class State implements Middleware
         Carbon::setLocale(Translate::GetLocale(2));
 
         // Default timezone
-        date_default_timezone_set($container->get('configService')->getSetting('defaultTimezone'));
+        $defaultTimezone = $container->get('configService')->getSetting('defaultTimezone');
+
+        date_default_timezone_set($defaultTimezone);
+
+        // Update logger containers to use the CMS default timezone
+        $container->get('logger')->setTimezone(new \DateTimeZone($defaultTimezone));
 
         $container->set('session', function (ContainerInterface $container) use ($app) {
             if ($container->get('name') == 'web' || $container->get('name') == 'auth') {
@@ -284,6 +289,15 @@ class State implements Middleware
                 $container->get('logger')->pushProcessor($processor);
             }
         }
+
+        if ($container->get('configService')->logProcessors != null && is_array($container->get('configService')->logProcessors)) {
+            $container->get('logService')->debug('Configuring %d additional log processors from Config', count($container->get('configService')->logProcessors));
+            foreach ($container->get('configService')->logProcessors as $processor) {
+                $container->get('logger')
+                    ->setTimezone(new \DateTimeZone($container->get('configService')->getSetting('defaultTimezone')));
+            }
+        }
+
 
         // Add additional validation rules
         Factory::setDefaultInstance(

--- a/web/xmds.php
+++ b/web/xmds.php
@@ -405,8 +405,12 @@ try {
     }
 
     // logProcessor
+    // Get the default time zone based on the CMS settings and add a fallback value
+    $defaultTimezone = $container->get('configService')->getSetting('defaultTimezone') ?? 'UTC';
     $logProcessor = new \Xibo\Xmds\LogProcessor($container->get('logger'), $uidProcessor->getUid());
-    $container->get('logger')->pushProcessor($logProcessor);
+    $container->get('logger')
+        ->pushProcessor($logProcessor)
+        ->setTimezone(new \DateTimeZone($defaultTimezone));
 
     // Create a SoapServer
     // explicitly define caching.

--- a/web/xmds.php
+++ b/web/xmds.php
@@ -405,7 +405,6 @@ try {
     }
 
     // logProcessor
-    // Get the default time zone based on the CMS settings and add a fallback value
     $logProcessor = new \Xibo\Xmds\LogProcessor($container->get('logger'), $uidProcessor->getUid());
     $container->get('logger')->pushProcessor($logProcessor);
 

--- a/web/xmds.php
+++ b/web/xmds.php
@@ -406,11 +406,8 @@ try {
 
     // logProcessor
     // Get the default time zone based on the CMS settings and add a fallback value
-    $defaultTimezone = $container->get('configService')->getSetting('defaultTimezone') ?? 'UTC';
     $logProcessor = new \Xibo\Xmds\LogProcessor($container->get('logger'), $uidProcessor->getUid());
-    $container->get('logger')
-        ->pushProcessor($logProcessor)
-        ->setTimezone(new \DateTimeZone($defaultTimezone));
+    $container->get('logger')->pushProcessor($logProcessor);
 
     // Create a SoapServer
     // explicitly define caching.


### PR DESCRIPTION
## Changes

- Get the default timezone based on the CMS settings when logging XMDS values

Relates to https://github.com/xibosignage/xibo/issues/3739