### PR TITLE
Editor: Layout duration not matched with Layer Manager

### DIFF
--- a/ui/src/editor-core/layer-manager.js
+++ b/ui/src/editor-core/layer-manager.js
@@ -198,18 +198,18 @@ LayerManager.prototype.createStructure = function() {
       duration: parseDuration(canvas.duration),
       layers: canvasObject.subLayers,
     });
+  }
 
-    // If we have a background image for the layout
-    // Add it to structure
-    if (
-      self.parent.layout.backgroundImage &&
-      self.parent.layout.backgroundzIndex != null
-    ) {
-      addToLayerStructure(self.parent.layout.backgroundzIndex, {
-        type: 'layoutBackground',
-        name: 'Layout Background',
-      });
-    }
+  // If we have a background image for the layout
+  // Add it to structure
+  if (
+    self.parent.layout.backgroundImage &&
+    self.parent.layout.backgroundzIndex != null
+  ) {
+    addToLayerStructure(self.parent.layout.backgroundzIndex, {
+      type: 'layoutBackground',
+      name: 'Layout Background',
+    });
   }
 
   // Get static widgets and playlists

--- a/ui/src/editor-core/properties-panel.js
+++ b/ui/src/editor-core/properties-panel.js
@@ -304,11 +304,11 @@ PropertiesPanel.prototype.save = function(
             },
           );
         } else if (target.type === 'layout') {
-          // Update resolution id
-          app.layout.resolutionId = resolutionId;
-
           // Update layout
           app.layout.updateData(data.data);
+
+          // Update resolution id
+          app.layout.resolutionId = resolutionId;
 
           // Render top bar to update layout changes
           app.topbar.render();

--- a/ui/src/editor-core/widget.js
+++ b/ui/src/editor-core/widget.js
@@ -283,18 +283,11 @@ const Widget = function(id, data, regionId = null, layoutObject = null) {
   };
 
   /**
-   * Get widget calculated duration with the transition out value if exists
+   * Get widget calculated duration
    * @return {number} - Widget duration in seconds
    */
   this.getTotalDuration = function() {
-    let totalDuration = this.getDuration();
-
-    // Extend with transition out duration if exists
-    if (this.transitionDurationOut != undefined) {
-      totalDuration += parseFloat(this.transitionDurationOut) / 1000;
-    }
-
-    return totalDuration;
+    return this.getDuration();
   };
 
   /**

--- a/ui/src/layout-editor/main.js
+++ b/ui/src/layout-editor/main.js
@@ -1555,6 +1555,9 @@ lD.deleteObject = function(
       // Check layout status
       lD.checkLayoutStatus();
 
+      // Reload layer manager
+      lD.viewer.layerManager.render();
+
       lD.common.hideLoadingScreen();
     }).catch((error) => { // Fail/error
       lD.common.hideLoadingScreen();


### PR DESCRIPTION
relates to xibosignageltd/xibo-private#1045

- Transition duration removed from Widget
- Minor fix for Layer Manager not updating when deleting Static widget
- Layer manager not updating when image added to Layout