### PR TITLE
Interactivity: Fixed unable to checkout layout for navigate to widget with deleted target

### DIFF
--- a/lib/Entity/Layout.php
+++ b/lib/Entity/Layout.php
@@ -2926,10 +2926,11 @@ class Layout implements \JsonSerializable
      *
      * @param Layout $newLayout
      * @param Layout $originalLayout
+     * @param bool $validate
      * @throws InvalidArgumentException
      * @throws NotFoundException
      */
-    public function copyActions(Layout $newLayout, Layout $originalLayout)
+    public function copyActions(Layout $newLayout, Layout $originalLayout, bool $validate = true)
     {
         $oldRegionIds = [];
         $newRegionIds = [];
@@ -3000,7 +3001,8 @@ class Layout implements \JsonSerializable
                     }
                 }
             }
-            $action->save();
+
+            $action->save(['validate' => $validate]);
         }
 
         // Region Actions
@@ -3045,7 +3047,7 @@ class Layout implements \JsonSerializable
                     }
                 }
 
-                $action->save();
+                $action->save(['validate' => $validate]);
             }
 
             // Widget Actions
@@ -3096,7 +3098,7 @@ class Layout implements \JsonSerializable
                         }
                     }
 
-                    $action->save();
+                    $action->save(['validate' => $validate]);
                 }
             }
         }

--- a/lib/Factory/LayoutFactory.php
+++ b/lib/Factory/LayoutFactory.php
@@ -2822,7 +2822,9 @@ class LayoutFactory extends BaseFactory
 
         /** @var Region[] $allRegions */
         $allRegions = array_merge($draft->regions, $draft->drawers);
-        $draft->copyActions($draft, $layout);
+
+        // Skip the action validation on checkout
+        $draft->copyActions($draft, $layout, false);
 
         // Permissions && Sub-Playlists
         // Layout level permissions are managed on the Campaign entity, so we do not need to worry about that


### PR DESCRIPTION
## Changes

- Remove the action validation when checking out published layout

Relates to https://github.com/xibosignage/xibo/issues/3762