### PR TITLE
Fix logic errors in xibo-cms.js

### DIFF
--- a/ui/src/core/xibo-cms.js
+++ b/ui/src/core/xibo-cms.js
@@ -154,7 +154,7 @@ window.XiboInitialise = function(scope, options) {
     .on('mouseenter', function(ev) {
       const formUrl = $(ev.currentTarget).attr('href');
 
-      XiboHoverRender(formUrl, e.pageX, e.pageY);
+      XiboHoverRender(formUrl, env.pageX, env.pageY);
 
       return false;
     }).on('mouseleave', function() {
@@ -853,7 +853,7 @@ window.XiboInitialise = function(scope, options) {
 
                       bodyElements.forEach((element) => {
                         const elementSplit = element.split('=');
-                        if (elementSplit.length = 2) {
+                        if (elementSplit.length == 2) {
                           newParsedElements[elementSplit[0]] = elementSplit[1];
                         }
                       });
@@ -1702,7 +1702,7 @@ window.XiboMultiSelectFormRender = function(button) {
         formOpenCallback = $button.data().formCallback;
 
         // If form needs confirmation
-        formConfirm = $button.data().formConfirm;
+        let formConfirm = $button.data().formConfirm;
       }
     }
   });

--- a/ui/src/core/xibo-cms.js
+++ b/ui/src/core/xibo-cms.js
@@ -154,7 +154,7 @@ window.XiboInitialise = function(scope, options) {
     .on('mouseenter', function(ev) {
       const formUrl = $(ev.currentTarget).attr('href');
 
-      XiboHoverRender(formUrl, env.pageX, env.pageY);
+      XiboHoverRender(formUrl, ev.pageX, ev.pageY);
 
       return false;
     }).on('mouseleave', function() {
@@ -1688,6 +1688,7 @@ window.XiboMultiSelectFormRender = function(button) {
   // Get a list of buttons that match the ID
   const matches = [];
   let formOpenCallback = null;
+  let formConfirm = null;
 
   $('.' + buttonId).each(function(_idx, el) {
     const $button = $(el);
@@ -1701,8 +1702,8 @@ window.XiboMultiSelectFormRender = function(button) {
         // so use the form open hook if one has been provided.
         formOpenCallback = $button.data().formCallback;
 
-        // If form needs confirmation
-        let formConfirm = $button.data().formConfirm;
+      // If form needs confirmation
+      formConfirm = $button.data().formConfirm;
       }
     }
   });


### PR DESCRIPTION
This PR fixes three small logic errors in `ui/src/core/xibo-cms.js`:

1. Assignment operator - Line ~856 uses `=` instead of a comparison (`==` or `===`) inside a conditional.
2. Undefined variable - Line ~157 references `e` although the function parameter is `env`.
3. Undeclared variable - Line ~1705 assigns to `formConfirm` without declaring it, which implicitly creates a global variable.

