### PR TITLE
Update the instance suspended setting to have 3 options.

### DIFF
--- a/lib/Controller/Settings.php
+++ b/lib/Controller/Settings.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2024 Xibo Signage Ltd
+ * Copyright (C) 2025 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -511,8 +511,8 @@ class Settings extends Base
         }
 
         if ($this->getConfig()->isSettingEditable('INSTANCE_SUSPENDED')) {
-            $this->handleChangedSettings('INSTANCE_SUSPENDED', $this->getConfig()->getSetting('INSTANCE_SUSPENDED'), $sanitizedParams->getCheckbox('INSTANCE_SUSPENDED'), $changedSettings);
-            $this->getConfig()->changeSetting('INSTANCE_SUSPENDED', $sanitizedParams->getCheckbox('INSTANCE_SUSPENDED'));
+            $this->handleChangedSettings('INSTANCE_SUSPENDED', $this->getConfig()->getSetting('INSTANCE_SUSPENDED'), $sanitizedParams->getString('INSTANCE_SUSPENDED'), $changedSettings);
+            $this->getConfig()->changeSetting('INSTANCE_SUSPENDED', $sanitizedParams->getString('INSTANCE_SUSPENDED'));
         }
 
         if ($this->getConfig()->isSettingEditable('LATEST_NEWS_URL')) {

--- a/lib/Middleware/State.php
+++ b/lib/Middleware/State.php
@@ -75,7 +75,7 @@ class State implements Middleware
         $request = State::setState($app, $request);
 
         // Check to see if the instance has been suspended, if so call the special route
-        if ($container->get('configService')->getSetting('INSTANCE_SUSPENDED') == 1) {
+        if ($container->get('configService')->getSetting('INSTANCE_SUSPENDED') == 'yes') {
             throw new InstanceSuspendedException();
         }
 

--- a/views/authed.twig
+++ b/views/authed.twig
@@ -95,7 +95,7 @@
                         {% block actionMenu %}{% endblock %}
 
                         {% if settings.INSTANCE_SUSPENDED == "partial" %}
-                            <div class="alert alert-warning">{{ "CMS suspended. Displays will showed cached content. Please contact your administrator."|trans }}</div>
+                            <div class="alert alert-warning">{{ "CMS suspended. Displays will show cached content. Please contact your administrator."|trans }}</div>
                         {% endif %}
 
                         {% block pageContent %}{% endblock %}

--- a/views/authed.twig
+++ b/views/authed.twig
@@ -1,6 +1,6 @@
 {#
 /**
- * Copyright (C) 2020-2024 Xibo Signage Ltd
+ * Copyright (C) 2020-2025 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -93,6 +93,11 @@
                 <div class="row">
                     <div class="col-sm-12">
                         {% block actionMenu %}{% endblock %}
+
+                        {% if settings.INSTANCE_SUSPENDED == "partial" %}
+                            <div class="alert alert-warning">{{ "CMS suspended. Displays will showed cached content. Please contact your administrator."|trans }}</div>
+                        {% endif %}
+
                         {% block pageContent %}{% endblock %}
                     </div>
                 </div>

--- a/views/settings-page.twig
+++ b/views/settings-page.twig
@@ -643,9 +643,21 @@
 
                                 {% if theme.isSettingVisible("INSTANCE_SUSPENDED") %}
                                     {% set title %}{% trans "Instance Suspended" %}{% endset %}
-                                    {% set helpText %}{% trans "Is this instance suspended?" %}{% endset %}
+                                    {% set helpText %}{% trans "Is this instance suspended? Warning: direct database access will be required to reactive the CMS if you select Yes" %}{% endset %}
 
-                                    {{ forms.checkbox("INSTANCE_SUSPENDED", title, theme.getSetting("INSTANCE_SUSPENDED", 0), helpText, "", "", not theme.isSettingEditable("INSTANCE_SUSPENDED")) }}
+                                    {% set noOption %}{% trans "No" %}{% endset %}
+                                    {% set partialOption %}{% trans "Partially" %}{% endset %}
+                                    {% set yesOption %}{% trans "Yes" %}{% endset %}
+                                    {% set options = [
+                                        { id: "no", value: noOption },
+                                        { id: "partial", value: partialOption },
+                                        { id: "yes", value: yesOption }
+                                    ] %}
+                                    {% if theme.isSettingEditable("INSTANCE_SUSPENDED") %}
+                                        {{ forms.dropdown("INSTANCE_SUSPENDED", "single", title, theme.getSetting("INSTANCE_SUSPENDED", "No"), options, "id", "value", helpText) }}
+                                    {% else %}
+                                        {{ forms.disabled("INSTANCE_SUSPENDED", title, theme.getSetting("INSTANCE_SUSPENDED", "No"), helpText) }}
+                                    {% endif %}
                                 {% endif %}
 
                                 {% if theme.isSettingVisible("LATEST_NEWS_URL") %}

--- a/web/xmds.php
+++ b/web/xmds.php
@@ -83,6 +83,15 @@ $startTime = microtime(true);
 
 // Configure
 $container->get('configService')->setDependencies($container->get('store'), '/');
+
+// Check to see if the instance has been suspended
+$instanceSuspended = $container->get('configService')->getSetting('INSTANCE_SUSPENDED');
+if ($instanceSuspended == 'yes' || $instanceSuspended == 'partial') {
+    header('HTTP/1.0 503 Service Unavailable');
+    die('CMS suspended');
+}
+
+// Load the theme
 $container->get('configService')->loadTheme();
 
 // Register Middleware Dispatchers


### PR DESCRIPTION
This PR expands the INSTANCE_SUSPENDED setting so that it has 3 options: yes, no, partial.

When it is set to partial, the XMDS and XTR should be disabled, and a banner shown in the CMS. When set to yes, the CMS UI should also be disabled.

fixes to xibosignageltd/xibo-private#1048
