### PR TITLE
Quick Switcher for navigation and search

### DIFF
--- a/lib/Controller/QuickSwitcher.php
+++ b/lib/Controller/QuickSwitcher.php
@@ -1,0 +1,323 @@
+<?php
+namespace Xibo\Controller;
+
+use Slim\Http\Response as Response;
+use Slim\Http\ServerRequest as Request;
+use Xibo\Controller\Base;
+use Xibo\Factory\CampaignFactory;
+use Xibo\Factory\DisplayFactory;
+use Xibo\Factory\LayoutFactory;
+use Xibo\Factory\MediaFactory;
+use Xibo\Factory\PlaylistFactory;
+use Xibo\Support\Exception\GeneralException;
+
+/**
+ * Class QuickSwitcher
+ * Controller placed under lib/Controller so it behaves like other first-class controllers
+ */
+class QuickSwitcher extends Base
+{
+    /** @var LayoutFactory */
+    private $layoutFactory;
+
+    /** @var MediaFactory */
+    private $mediaFactory;
+
+    /** @var DisplayFactory */
+    private $displayFactory;
+
+    /** @var PlaylistFactory */
+    private $playlistFactory;
+
+    /** @var CampaignFactory */
+    private $campaignFactory;
+
+    /** @var \Xibo\Factory\FolderFactory */
+    private $folderFactory;
+
+    public function __construct(
+        $layoutFactory,
+        $mediaFactory,
+        $displayFactory,
+        $playlistFactory,
+        $campaignFactory,
+        $folderFactory = null
+    ) {
+        $this->layoutFactory = $layoutFactory;
+        $this->mediaFactory = $mediaFactory;
+        $this->displayFactory = $displayFactory;
+        $this->playlistFactory = $playlistFactory;
+        $this->campaignFactory = $campaignFactory;
+        $this->folderFactory = $folderFactory;
+    }
+
+    /**
+     * Search endpoint for the QuickSwitcher frontend.
+     * @param Request $request
+     * @param Response $response
+     * @return Response
+     * @throws GeneralException
+     */
+    public function search(Request $request, Response $response): Response
+    {
+        $sanitizedParams = $this->getSanitizer($request->getParams());
+        $query = trim($sanitizedParams->getString('q', ['default' => '', 'defaultOnEmptyString' => true]));
+
+        $results = [];
+
+        if ($query === '') {
+            return $response->withJson(['results' => $results]);
+        }
+
+        $searchFilter = str_replace(' ', ',', preg_replace('/\s+/', ' ', trim($query)));
+
+        $navCandidates = [];
+        $currentUser = $this->getUser();
+
+        $addNav = function ($featureCheck, $label, $routeName, $hint = 'Navigation') use (&$navCandidates, $request, $currentUser) {
+            try {
+                if ($featureCheck === null || ($currentUser && $currentUser->featureEnabled($featureCheck))) {
+                    $navCandidates[] = [
+                        'type' => 'Navigation',
+                        'label' => $label,
+                        'hint' => $hint,
+                        'route' => $routeName,
+                    ];
+                }
+            } catch (\Throwable $e) {
+            }
+        };
+
+        $addNav(null, 'Dashboard', 'home');
+        $addNav('schedule.view', 'Schedule', 'schedule.view');
+        $addNav('daypart.view', 'Dayparting', 'daypart.view');
+
+        $addNav('campaign.view', 'Campaigns', 'campaign.view');
+        $addNav('layout.view', 'Layouts', 'layout.view');
+        $addNav('template.view', 'Templates', 'template.view');
+        $addNav('resolution.view', 'Resolutions', 'resolution.view');
+
+        $addNav('playlist.view', 'Playlists', 'playlist.view');
+        $addNav('library.view', 'Media', 'library.view');
+        $addNav('dataset.view', 'DataSets', 'dataset.view');
+        $addNav('menuBoard.view', 'Menu Boards', 'menuBoard.view');
+
+        $addNav('displays.view', 'Displays', 'display.view');
+        $addNav('displaygroup.view', 'Display Groups', 'displaygroup.view');
+        $addNav('display.syncView', 'Sync Groups', 'syncgroup.view');
+        $addNav('displayprofile.view', 'Display Settings', 'displayprofile.view');
+        $addNav('playersoftware.view', 'Player Versions', 'playersoftware.view');
+        $addNav('command.view', 'Commands', 'command.view');
+
+        $userMenuViewable = ($currentUser && $currentUser->featureEnabled('users.view') && ($currentUser->isGroupAdmin() || $currentUser->isSuperAdmin()));
+        if ($userMenuViewable) {
+            $addNav(null, 'Users', 'user.view');
+        }
+        $addNav('usergroup.view', 'User Groups', 'group.view');
+        $addNav(null, 'Settings', 'admin.view');
+        $addNav(null, 'Applications', 'application.view');
+        $addNav('module.view', 'Modules', 'module.view');
+        $addNav('transition.view', 'Transitions', 'transition.view');
+        $addNav('task.view', 'Tasks', 'task.view');
+        $addNav('tag.view', 'Tags', 'tag.view');
+        $addNav('folders.view', 'Folders', 'folders.view');
+        $addNav('font.view', 'Fonts', 'font.view');
+
+        $addNav('report.view', 'All Reports', 'report.view');
+        $addNav('report.scheduling', 'Report Schedules', 'reportschedule.view');
+        $addNav('report.saving', 'Saved Reports', 'savedreport.view');
+        $addNav('log.view', 'Log', 'log.view');
+        $addNav('sessions.view', 'Sessions', 'sessions.view');
+        $addNav('auditlog.view', 'Audit Trail', 'auditlog.view');
+        $addNav('fault.view', 'Report Fault', 'fault.view');
+
+        $addNav('developer.edit', 'Module Templates', 'developer.templates.view');
+
+        $typeParam = $sanitizedParams->getString('type', ['default' => 'all']);
+        $types = array_values(array_filter(
+            array_map('trim', explode(',', strtolower($typeParam))),
+            function ($t) {
+                return $t !== '';
+            }
+        ));
+        if (empty($types)) {
+            $types = ['all'];
+        }
+
+        if ((in_array('all', $types) || in_array('navigation', $types)) && !empty($navCandidates)) {
+            foreach ($navCandidates as $nav) {
+                if ($query !== '' && stripos($nav['label'], $query) !== false) {
+                    try {
+                        $url = $this->urlFor($request, $nav['route']);
+                    } catch (\Throwable $e) {
+                        $url = '#';
+                    }
+                    $results[] = [
+                        'type' => $nav['type'],
+                        'label' => $nav['label'],
+                        'hint' => $nav['hint'],
+                        'url' => $url,
+                    ];
+                }
+            }
+        }
+
+        $maxResults = 30;
+        $perType = 10;
+
+        if ((in_array('all', $types) || in_array('layout', $types)) && $this->layoutFactory !== null) {
+            try {
+                $layouts = $this->layoutFactory->query(null, [
+                    'layout' => $searchFilter,
+                    'start' => 0,
+                    'length' => $perType
+                ]);
+
+                foreach ($layouts as $layout) {
+                    $folderName = '';
+                    if ($this->folderFactory !== null && !empty($layout->folderId)) {
+                        try {
+                            $f = $this->folderFactory->getById($layout->folderId);
+                            $folderName = $f->folderName ?? ($f->text ?? '');
+                        } catch (\Throwable $e) {
+                            $folderName = '';
+                        }
+                    }
+
+                    $results[] = [
+                        'type' => 'Layout',
+                        'label' => $layout->layout,
+                        'hint' => $folderName ?: ($layout->owner ?? ''),
+                        'url' => $this->urlFor($request, 'layout.view')
+                            . '?layout=' . urlencode($layout->layout)
+                            . '&folderId=' . urlencode((string)($layout->folderId ?? '')),
+                    ];
+                }
+            } catch (\Throwable $e) {
+                $this->getLog()->error('QuickSwitcher: Layout search failed. Error: ' . $e->getMessage());
+            }
+        }
+
+        if ((in_array('all', $types) || in_array('display', $types)) && $this->displayFactory !== null) {
+            try {
+                $displays = $this->displayFactory->query(null, [
+                    'display' => $searchFilter,
+                    'start' => 0,
+                    'length' => $perType
+                ]);
+
+                foreach ($displays as $display) {
+                    $label = $display->display ?? '';
+                    $hint = $display->deviceName ?? $display->address ?? '';
+                    $results[] = [
+                        'type' => 'Display',
+                        'label' => $label,
+                        'hint' => $hint,
+                        'url' => $this->urlFor($request, 'display.view')
+                            . '?display=' . urlencode($label)
+                            . '&folderId=' . urlencode((string)($display->folderId ?? '')),
+                        'id' => $display->displayId
+                    ];
+                }
+            } catch (\Throwable $e) {
+                $this->getLog()->error('QuickSwitcher: Display search failed. Error: ' . $e->getMessage());
+            }
+        }
+
+        if ((in_array('all', $types) || in_array('media', $types)) && $this->mediaFactory !== null) {
+            try {
+                $mediaItems = $this->mediaFactory->query(null, [
+                    'name' => $searchFilter,
+                    'start' => 0,
+                    'length' => $perType
+                ]);
+
+                foreach ($mediaItems as $media) {
+                    $label = $media->name ?? '';
+                    $hint = $media->mediaType ?? $media->fileName ?? '';
+                    $results[] = [
+                        'type' => 'Media',
+                        'label' => $label,
+                        'hint' => $hint,
+                        'url' => $this->urlFor($request, 'library.view')
+                            . '?media=' . urlencode($label)
+                            . '&folderId=' . urlencode((string)($media->folderId ?? '')),
+                        'id' => $media->mediaId
+                    ];
+                }
+            } catch (\Throwable $e) {
+                $this->getLog()->error('QuickSwitcher: Media search failed. Error: ' . $e->getMessage());
+            }
+        }
+
+        if ((in_array('all', $types) || in_array('campaign', $types)) && $this->campaignFactory !== null) {
+            try {
+                $campaigns = $this->campaignFactory->query(null, [
+                    'name' => $searchFilter,
+                    'start' => 0,
+                    'length' => $perType,
+                    'isLayoutSpecific' => 0
+                ]);
+
+                foreach ($campaigns as $campaign) {
+                    $label = $campaign->campaign ?? '';
+                    $hint = $campaign->type ?? '';
+                    $results[] = [
+                        'type' => 'Campaign',
+                        'label' => $label,
+                        'hint' => ucfirst($hint),
+                        'url' => $this->urlFor($request, 'campaign.view')
+                            . '?name=' . urlencode($label)
+                            . '&folderId=' . urlencode((string)($campaign->folderId ?? '')),
+                        'id' => $campaign->campaignId
+                    ];
+                }
+            } catch (\Throwable $e) {
+                $this->getLog()->error('QuickSwitcher: Campaign search failed. Error: ' . $e->getMessage());
+            }
+        }
+
+        if ((in_array('all', $types) || in_array('playlist', $types)) && $this->playlistFactory !== null) {
+            try {
+                $playlists = $this->playlistFactory->query(null, [
+                    'name' => $searchFilter,
+                    'start' => 0,
+                    'length' => $perType,
+                    'regionSpecific' => 0
+                ]);
+
+                foreach ($playlists as $playlist) {
+                    $label = $playlist->name ?? '';
+
+                    $folderName = '';
+                    if ($this->folderFactory !== null && !empty($playlist->folderId)) {
+                        try {
+                            $f = $this->folderFactory->getById($playlist->folderId);
+                            $folderName = $f->folderName ?? ($f->text ?? '');
+                        } catch (\Throwable $e) {
+                            $folderName = '';
+                        }
+                    }
+
+                    $results[] = [
+                        'type' => 'Playlist',
+                        'label' => $label,
+                        'hint' => $folderName ?: ($playlist->owner ?? ''),
+                        'url' => $this->urlFor($request, 'playlist.view')
+                            . '?name=' . urlencode($label)
+                            . '&folderId=' . urlencode((string)($playlist->folderId ?? '')),
+                        'id' => $playlist->playlistId
+                    ];
+                }
+            } catch (\Throwable $e) {
+                $this->getLog()->error('QuickSwitcher: Playlist search failed. Error: ' . $e->getMessage());
+            }
+        }
+
+        if (count($results) > $maxResults) {
+            $results = array_slice($results, 0, $maxResults);
+        }
+
+        return $response->withJson(['results' => $results]);
+    }
+}

--- a/lib/Dependencies/Controllers.php
+++ b/lib/Dependencies/Controllers.php
@@ -642,6 +642,18 @@ class Controllers
                 $controller->useBaseDependenciesService($c->get('ControllerBaseDependenciesService'));
                 return $controller;
             },
+            '\Xibo\Controller\QuickSwitcher' => function (ContainerInterface $c) {
+                $controller = new \Xibo\Controller\QuickSwitcher(
+                    $c->get('layoutFactory'),
+                    $c->get('mediaFactory'),
+                    $c->get('displayFactory'),
+                    $c->get('playlistFactory'),
+                    $c->get('campaignFactory'),
+                    $c->get('folderFactory')
+                );
+                $controller->useBaseDependenciesService($c->get('ControllerBaseDependenciesService'));
+                return $controller;
+            },
         ];
     }
 }

--- a/lib/routes.php
+++ b/lib/routes.php
@@ -875,3 +875,7 @@ $app->group('', function (RouteCollectorProxy $group) {
 $app->group('', function (RouteCollectorProxy $group) {
     $group->post('/schedule/sync/add', ['\Xibo\Controller\Schedule', 'syncAdd'])->setName('schedule.add.sync');
 })->addMiddleware(new FeatureAuth($app->getContainer(), ['schedule.sync']));
+
+// Quick Switcher
+$app->get('/quickswitcher/search', ['\\Xibo\\Controller\\QuickSwitcher', 'search'])
+    ->setName('quickswitcher.search');

--- a/ui/bundle_tools.js
+++ b/ui/bundle_tools.js
@@ -3,3 +3,4 @@ window.ArrayHelper = require('./src/helpers/array.js');
 window.formHelpers = require('./src/helpers/form-helpers.js');
 window.transformer = require('./src/helpers/transformer.js');
 window.DateFormatHelper = require('./src/helpers/date-format-helper.js');
+require('./src/helpers/quickswitcher.js');

--- a/ui/src/helpers/quickswitcher.js
+++ b/ui/src/helpers/quickswitcher.js
@@ -1,0 +1,239 @@
+require('../style/quickswitcher.scss');
+
+(function () {
+  'use strict';
+
+  const STR_PLACEHOLDER = 'Search layouts, media, displays…';
+  const STR_NO_RESULTS = 'No results found';
+  const STR_FILTER_TIP = 'Tip: use the checkboxes to filter which item types are returned.';
+
+  const isMac = navigator.platform && /Mac/.test(navigator.platform);
+  const HOTKEY = (e) => (isMac ? e.metaKey : e.ctrlKey) && e.key && e.key.toLowerCase() === 'k';
+
+  let overlay = null;
+  let box = null;
+  let input = null;
+  let list = null;
+  let items = [];
+  let idx = 0;
+  let aborter = null;
+
+  const createElement = (tag, className) => {
+    const el = document.createElement(tag);
+    if (className) el.className = className;
+    return el;
+  };
+
+  const debounce = (fn, ms) => {
+    let t = null;
+    return (...args) => {
+      if (t) clearTimeout(t);
+      t = setTimeout(() => fn(...args), ms);
+    };
+  };
+
+  function openQuickSwitcher() {
+    if (box) return;
+
+    overlay = createElement('div', 'quickswitcher-overlay');
+    box = createElement('div', 'quickswitcher');
+
+    input = createElement('input');
+    input.type = 'search';
+    input.placeholder = STR_PLACEHOLDER;
+    input.setAttribute('aria-label', 'Quick switcher search');
+
+    const top = createElement('div', 'quickswitcher-top');
+    top.appendChild(input);
+
+    const filters = createElement('div', 'quickswitcher-filters');
+    const types = [
+      ['all', 'All'],
+      ['layout', 'Layouts'],
+      ['campaign', 'Campaigns'],
+      ['playlist', 'Playlists'],
+      ['display', 'Displays'],
+      ['media', 'Media'],
+      ['navigation', 'Navigation']
+    ];
+
+    types.forEach(([value, labelText]) => {
+      const id = `quickswitcher-type-${value}`;
+      const label = createElement('label', 'quickswitcher-filter-label');
+      const cb = createElement('input');
+      cb.type = 'checkbox';
+      cb.className = 'quickswitcher-type-checkbox';
+      cb.value = value;
+      cb.id = id;
+      cb.checked = true;
+
+      const span = createElement('span', 'quickswitcher-filter-text');
+      span.textContent = labelText;
+
+      label.appendChild(cb);
+      label.appendChild(span);
+      filters.appendChild(label);
+    });
+
+    const foldersNote = createElement('div', 'quickswitcher-folders-note');
+    foldersNote.textContent = STR_FILTER_TIP;
+
+    list = createElement('div', 'quickswitcher-list');
+    list.setAttribute('role', 'listbox');
+
+    box.appendChild(top);
+    box.appendChild(filters);
+    box.appendChild(foldersNote);
+    box.appendChild(list);
+
+    document.body.appendChild(overlay);
+    document.body.appendChild(box);
+
+    overlay.addEventListener('click', closeQuickSwitcher);
+    input.addEventListener('input', debounce(fetchResults, 120));
+
+    filters.addEventListener('change', (e) => {
+      const checkboxes = Array.from(box.querySelectorAll('.quickswitcher-type-checkbox'));
+      const master = checkboxes.find(cb => cb.value === 'all');
+      if (!master) return;
+      const others = checkboxes.filter(cb => cb.value !== 'all');
+      const target = e && e.target;
+
+      if (target && target.value === 'all') {
+        if (target.checked) others.forEach(cb => cb.checked = true);
+        else others.forEach(cb => cb.checked = false);
+      } else if (target) {
+        if (!target.checked) master.checked = false;
+        else if (others.every(cb => cb.checked)) master.checked = true;
+      }
+
+      debounce(fetchResults, 50)();
+    });
+
+    document.addEventListener('keydown', navHandler, true);
+    setTimeout(() => input.focus(), 0);
+    fetchResults();
+  }
+
+  function closeQuickSwitcher() {
+    if (aborter) try { aborter.abort(); } catch (e) {}
+    document.removeEventListener('keydown', navHandler, true);
+    if (overlay && overlay.parentNode) overlay.parentNode.removeChild(overlay);
+    if (box && box.parentNode) box.parentNode.removeChild(box);
+    overlay = box = input = list = null;
+    items = [];
+    idx = 0;
+  }
+
+  function navHandler(e) {
+    if (!box) return;
+    if (e.key === 'Escape') { e.preventDefault(); closeQuickSwitcher(); return; }
+    if (e.key === 'ArrowDown') { e.preventDefault(); move(1); return; }
+    if (e.key === 'ArrowUp') { e.preventDefault(); move(-1); return; }
+    if (e.key === 'Enter') {
+      e.preventDefault(); if (items[idx]) openItem(items[idx]);
+    }
+  }
+
+  function move(delta) {
+    if (!list) return;
+    idx = Math.max(0, Math.min(items.length - 1, idx + delta));
+    updateSelection();
+    const row = list.children[idx];
+    if (row && typeof row.scrollIntoView === 'function') row.scrollIntoView({ block: 'nearest' });
+  }
+
+  function updateSelection() {
+    if (!list) return;
+    Array.from(list.children).forEach((row, i) => {
+      const selected = i === idx;
+      row.setAttribute('aria-selected', selected ? 'true' : 'false');
+      row.classList.toggle('quickswitcher-active', selected);
+    });
+  }
+
+  function render() {
+    if (!list) return;
+    list.innerHTML = '';
+    const q = input && input.value ? input.value.trim() : '';
+
+    if (!items || items.length === 0) {
+      if (q !== '') {
+        const none = createElement('div', 'quickswitcher-no-results');
+        none.setAttribute('role', 'status');
+        none.textContent = STR_NO_RESULTS;
+        list.appendChild(none);
+      }
+      updateSelection();
+      return;
+    }
+
+    items.forEach((r, i) => {
+      const row = createElement('div', 'quickswitcher-item');
+      row.setAttribute('role', 'option');
+      row.setAttribute('aria-selected', i === idx ? 'true' : 'false');
+
+      const typeSpan = createElement('span', 'quickswitcher-type');
+      typeSpan.textContent = r.type || '';
+      const labelSpan = createElement('span', 'quickswitcher-label');
+      labelSpan.innerHTML = escapeHtml(r.label || '');
+
+      row.appendChild(typeSpan);
+      row.appendChild(labelSpan);
+
+      if (r.hint) {
+        const hintSpan = createElement('span', 'quickswitcher-hint');
+        hintSpan.innerHTML = escapeHtml(r.hint);
+        row.appendChild(hintSpan);
+      }
+
+      row.addEventListener('mouseenter', () => { idx = i; updateSelection(); });
+      row.addEventListener('click', (e) => { e.preventDefault(); openItem(r); });
+
+      list.appendChild(row);
+    });
+
+    updateSelection();
+  }
+
+  function escapeHtml(s) {
+    return String(s || '').replace(/[&<>"']/g, m => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#039;' }[m]));
+  }
+
+  function openItem(item) {
+    if (!item || !item.url) return;
+    window.location.href = item.url;
+  }
+
+  async function fetchResults() {
+    const q = (input && input.value) ? input.value.trim() : '';
+    if (aborter) try { aborter.abort(); } catch (e) {}
+    aborter = new AbortController();
+
+    try {
+      const checked = box ? Array.from(box.querySelectorAll('.quickswitcher-type-checkbox')).filter(c => c.checked).map(c => c.value) : ['all'];
+      const typeParam = (!checked.includes('all')) ? checked.join(',') : 'all';
+
+      const url = `/quickswitcher/search?q=${encodeURIComponent(q)}&type=${encodeURIComponent(typeParam)}`;
+      const res = await fetch(url, { signal: aborter.signal, credentials: 'same-origin' });
+      if (!res.ok) throw new Error('Network error');
+      const json = await res.json();
+      items = json.results || [];
+      idx = 0;
+      render();
+    } catch (err) {
+      if (err && err.name === 'AbortError') return;
+      items = [];
+      render();
+      if (window && window.location && window.location.hostname === 'localhost') console.warn('quickswitcher fetch error', err);
+    }
+  }
+
+  window.addEventListener('keydown', (e) => {
+    const tag = (e.target && e.target.tagName || '').toLowerCase();
+    if ((tag === 'input' || tag === 'textarea' || (e.target && e.target.isContentEditable)) && !(e.metaKey || e.ctrlKey)) return;
+    if (HOTKEY(e)) { e.preventDefault(); openQuickSwitcher(); }
+  });
+
+  window.__xiboquickswitcher = { open: openQuickSwitcher, close: closeQuickSwitcher };
+})();

--- a/ui/src/style/quickswitcher.scss
+++ b/ui/src/style/quickswitcher.scss
@@ -1,0 +1,159 @@
+:root {
+  --xibo-qs-bg: #ffffff;
+  --xibo-qs-shadow: 0 10px 40px rgba(0, 0, 0, 0.20);
+  --xibo-qs-accent: #0070ff;
+  --xibo-qs-muted: #6c757d;
+  --xibo-qs-row-hover: #f0f6ff;
+  --xibo-qs-gap: 10px;
+  --xibo-qs-border: #eeeeee;
+}
+
+.quickswitcher-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.20);
+  z-index: 9998;
+}
+
+.quickswitcher {
+  position: fixed;
+  left: 50%;
+  top: 12%;
+  transform: translateX(-50%);
+  width: min(800px, 92vw);
+  background: var(--xibo-qs-bg);
+  border-radius: 10px;
+  box-shadow: var(--xibo-qs-shadow);
+  z-index: 9999;
+  overflow: hidden;
+  font-family: inherit;
+  line-height: 1.3;
+}
+
+.quickswitcher input {
+  width: 100%;
+  border: 0;
+  border-bottom: 1px solid var(--xibo-qs-border);
+  padding: 14px 16px;
+  font-size: 16px;
+  outline: none;
+  background: transparent;
+  transition: box-shadow 120ms ease;
+}
+
+.quickswitcher input:focus {
+  box-shadow: inset 0 -2px 0 var(--xibo-qs-accent);
+}
+
+.quickswitcher-list {
+  max-height: 60vh;
+  overflow: auto;
+}
+
+.quickswitcher-top {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px 12px;
+}
+
+.quickswitcher-filters {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+  padding: 8px 12px 0 12px;
+}
+
+.quickswitcher-filter-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: #333;
+}
+
+.quickswitcher-filter-label input {
+  width: 16px;
+  height: 16px;
+}
+
+.quickswitcher-filter-text {
+  font-size: 13px;
+}
+
+.quickswitcher-item {
+  padding: 10px 16px;
+  display: flex;
+  gap: var(--xibo-qs-gap);
+  align-items: center;
+  cursor: pointer;
+  transition: background-color 120ms ease;
+}
+
+.quickswitcher-item[aria-selected="true"],
+.quickswitcher-item:hover {
+  background: var(--xibo-qs-row-hover);
+}
+
+.quickswitcher-item:focus-visible {
+  outline: 2px solid rgba(0, 112, 255, 0.18);
+  outline-offset: 2px;
+}
+
+.quickswitcher-type {
+  font-size: 12px;
+  opacity: 0.7;
+  min-width: 88px;
+}
+
+.quickswitcher-label {
+  font-weight: 600;
+}
+
+.quickswitcher-hint {
+  font-size: 12px;
+  opacity: 0.6;
+  margin-left: auto;
+}
+
+.quickswitcher-no-results {
+  padding: 10px 16px;
+  display: flex;
+  align-items: center;
+  gap: var(--xibo-qs-gap);
+  color: var(--xibo-qs-muted);
+}
+
+.quickswitcher-item-link {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  text-decoration: none;
+  color: inherit;
+}
+
+.quickswitcher-item-link:focus {
+  outline: 2px solid rgba(0, 112, 255, 0.2);
+  outline-offset: 2px;
+}
+
+.quickswitcher-folders-note {
+  padding: 8px 12px;
+  font-size: 13px;
+  color: var(--xibo-qs-muted);
+  border-top: 1px solid #f0f0f0;
+  margin: 6px 0 8px 0;
+  background: transparent;
+}
+
+@media (max-width: 420px) {
+  .quickswitcher {
+    top: 6%;
+    width: 96vw;
+  }
+  .quickswitcher-type {
+    min-width: 64px;
+  }
+}


### PR DESCRIPTION
Introduces a QuickSwitcher controller and UI, enabling users to quickly search and navigate layouts, media, displays, campaigns, playlists, and navigation routes. Adds backend endpoint, dependency injection, and frontend components including JavaScript logic and styles. Integrates with the main bundle and provides keyboard shortcut (Ctrl/Cmd+K) for activation.

<img width="953" height="397" alt="image" src="https://github.com/user-attachments/assets/4b6482e1-c132-42e7-a0e5-d18b87dc7395" />
