### PR TITLE
Media: when saving a file ensure the original file name is not too long

### DIFF
--- a/lib/Entity/Media.php
+++ b/lib/Entity/Media.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2024 Xibo Signage Ltd
+ * Copyright (C) 2025 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -622,8 +622,8 @@ class Media implements \JsonSerializable
             $fileName = substr(basename($fileName), 0, strpos(basename($fileName), '?'));
         }
 
-        // Sanitize what we have left.
-        $fileName = htmlspecialchars($fileName);
+        // Sanitize what we have left and make it fit in the space we have.
+        $fileName = substr(htmlspecialchars($fileName), 0, 254);
 
         $this->mediaId = $this->getStore()->insert('
             INSERT INTO `media` (`name`, `type`, duration, originalFilename, userID, retired, moduleSystemFile, released, apiRef, valid, `createdDt`, `modifiedDt`, `enableStat`, `folderId`, `permissionsFolderId`, `orientation`, `width`, `height`)


### PR DESCRIPTION
fixes xibosignage/xibo#3771