### PR TITLE
Interactivity: Fixed action validation on layout import

### DIFF
--- a/lib/Entity/Layout.php
+++ b/lib/Entity/Layout.php
@@ -1376,7 +1376,6 @@ class Layout implements \JsonSerializable
                     // Pull out the global widget, if we have one (we should)
                     if ($item->type === 'global') {
                         $widget = $item;
-
                     }
 
                     // Get the highest duration.
@@ -2760,11 +2759,11 @@ class Layout implements \JsonSerializable
 
     /**
      * This function will adjust the Action sourceId and targetId in all relevant objects in our imported Layout
-     *
+     * @param bool $validate
      * @throws InvalidArgumentException
      * @throws NotFoundException
      */
-    public function manageActions()
+    public function manageActions(bool $validate = true): void
     {
         $oldRegionIds = [];
         $newRegionIds = [];
@@ -2824,7 +2823,7 @@ class Layout implements \JsonSerializable
                 }
             }
 
-            $action->save();
+            $action->save(['validate' => $validate]);
         }
 
         // Actions with Region
@@ -2862,7 +2861,7 @@ class Layout implements \JsonSerializable
                 }
             }
 
-            $action->save();
+            $action->save(['validate' => $validate]);
         }
 
         // Actions with Widget
@@ -2902,7 +2901,7 @@ class Layout implements \JsonSerializable
                 }
             }
 
-            $action->save();
+            $action->save(['validate' => $validate]);
         }
 
         // Make sure we update targetRegionId in Drawer Widgets.

--- a/lib/Helper/LayoutUploadHandler.php
+++ b/lib/Helper/LayoutUploadHandler.php
@@ -97,8 +97,11 @@ class LayoutUploadHandler extends BlueImpUploadHandler
             if (!empty($layout->getUnmatchedProperty('thumbnail'))) {
                 rename($layout->getUnmatchedProperty('thumbnail'), $layout->getThumbnailUri());
             }
+
             $layout->managePlaylistClosureTable();
-            $layout->manageActions();
+
+            // When importing a layout, skip action validation
+            $layout->manageActions(false);
 
             // Handle widget data
             $fallback = $layout->getUnmatchedProperty('fallback');


### PR DESCRIPTION
## Changes

- Updated `manageActions` to skip action validations during layout import. This is to allow users to manage the imported layouts in a different CMS that might have a different environment or settings.

Relates to https://github.com/xibosignage/xibo/issues/3765