### PR TITLE
MYSQL: Fixed access denied error for tablespaces during Docker backups

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -157,7 +157,8 @@ then
     echo "We will upgrade it, take a backup"
 
     # We're going to run an upgrade. Make a database backup
-    mysqldump -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USER -p$MYSQL_PASSWORD --hex-blob $MYSQL_DATABASE | gzip > /var/www/backup/db-$(date +"%Y-%m-%d_%H-%M-%S").sql.gz
+    mysqldump -h $MYSQL_HOST -P $MYSQL_PORT -u $MYSQL_USER -p$MYSQL_PASSWORD \
+      --hex-blob --no-tablespaces $MYSQL_DATABASE | gzip > /var/www/backup/db-$(date +"%Y-%m-%d_%H-%M-%S").sql.gz
 
     # Drop app cache on upgrade
     rm -rf /var/www/cms/cache/*

--- a/docker/etc/periodic/15min/cms-db-backup
+++ b/docker/etc/periodic/15min/cms-db-backup
@@ -25,7 +25,7 @@
 age=86401
 
 MYSQL_BACKUP_ENABLED=
-MYSQL_DATABASE= 
+MYSQL_DATABASE=
 
 # Is this enabled?
 if [ "$MYSQL_BACKUP_ENABLED" == "false" ]
@@ -60,15 +60,17 @@ mysqldump_running=$?
 if [ $age -gt 86400 ] && [ $mysqldump_running -ne 0 ]
 then
     echo "Creating new backup"
-    
+
     # Tell bash to consider all exit values when evaluating the
     # exit code of a pipe rather than just the right-most one
     # That way we can detect if mysqldump errors or is killed etc
     set -o pipefail
-    
-    /usr/bin/mysqldump --single-transaction --hex-blob $MYSQL_DATABASE | gzip > /var/www/backup/db/backup.sql.gz
+
+    /usr/bin/mysqldump --single-transaction --hex-blob --no-tablespaces $MYSQL_DATABASE \
+      | gzip > /var/www/backup/db/backup.sql.gz
+
     RESULT=$?
-    
+
     if [ $RESULT -eq 0 ] && [ -e /var/www/backup/db/backup.sql.gz ]
     then
         echo "Rotating backups"


### PR DESCRIPTION
## Changes

- Updated docker commands for db backups to fix the permission issue by adding `--no-tablespaces` option

Relates to https://github.com/xibosignage/xibo/issues/3764