### PR TITLE
Layouts: Fixed overlay layouts max plays per hour settings

### DIFF
--- a/lib/Xmds/Soap.php
+++ b/lib/Xmds/Soap.php
@@ -1500,6 +1500,7 @@ class Soap
                         $overlay->setAttribute('duration', $row['duration'] ?? 0);
                         $overlay->setAttribute('isGeoAware', $row['isGeoAware'] ?? 0);
                         $overlay->setAttribute('geoLocation', $row['geoLocation'] ?? null);
+                        $overlay->setAttribute('maxPlaysPerHour', $row['maxPlaysPerHour'] ?? 0);
 
                         // Add criteria notes
                         if (count($criteriaNodes) > 0) {


### PR DESCRIPTION
## Changes

- Added the missing `maxPlaysPerHour` node in overlay layouts

Relates to https://github.com/xibosignage/xibo/issues/3776