### PR TITLE
Add Schedule API: Fixed mediaId not documented and CMS auto-assigns the wrong media

### DIFF
--- a/lib/Controller/Schedule.php
+++ b/lib/Controller/Schedule.php
@@ -1195,8 +1195,7 @@ class Schedule extends Base
 
             if (!$id) {
                 throw new InvalidArgumentException(
-                    __(ucfirst($type) . 'Id is required when scheduling ' . $type . ' events.'),
-                    $type . 'Id'
+                    sprintf('%sId is required when scheduling %s events.', ucfirst($type), $type)
                 );
             }
 
@@ -1949,8 +1948,7 @@ class Schedule extends Base
 
             if (!$id) {
                 throw new InvalidArgumentException(
-                    __(ucfirst($type) . 'Id is required when scheduling ' . $type . ' events.'),
-                    $type . 'Id'
+                    sprintf('%sId is required when scheduling %s events.', ucfirst($type), $type)
                 );
             }
 

--- a/lib/Controller/Schedule.php
+++ b/lib/Controller/Schedule.php
@@ -928,7 +928,7 @@ class Schedule extends Base
      *  @SWG\Parameter(
      *      name="fullScreenCampaignId",
      *      in="formData",
-     *      description="For Media or Playlist eventyType. The Layout specific Campaign ID to use for this Event.
+     *      description="For Media or Playlist event Type. The Layout specific Campaign ID to use for this Event.
      * This needs to be the Layout created with layout/fullscreen function",
      *      type="integer",
      *      required=false
@@ -937,6 +937,13 @@ class Schedule extends Base
      *      name="commandId",
      *      in="formData",
      *      description="The Command ID to use for this Event.",
+     *      type="integer",
+     *      required=false
+     *  ),
+     *  @SWG\Parameter(
+     *      name="mediaId",
+     *      in="formData",
+     *      description="The Media ID to use for this Event.",
      *      type="integer",
      *      required=false
      *  ),
@@ -1185,6 +1192,13 @@ class Schedule extends Base
         if ($this->isFullScreenSchedule($schedule->eventTypeId)) {
             $type = $schedule->eventTypeId === \Xibo\Entity\Schedule::$MEDIA_EVENT ? 'media' : 'playlist';
             $id = ($type === 'media') ? $sanitizedParams->getInt('mediaId') : $sanitizedParams->getInt('playlistId');
+
+            if (!$id) {
+                throw new InvalidArgumentException(
+                    __(ucfirst($type) . 'Id is required when scheduling ' . $type . ' events.'),
+                    $type . 'Id'
+                );
+            }
 
             $fsLayout = $this->layoutFactory->createFullScreenLayout(
                 $type,
@@ -1633,6 +1647,13 @@ class Schedule extends Base
      *      required=false
      *  ),
      *  @SWG\Parameter(
+     *      name="mediaId",
+     *      in="formData",
+     *      description="The Media ID to use for this Event.",
+     *      type="integer",
+     *      required=false
+     *  ),
+     *  @SWG\Parameter(
      *      name="displayOrder",
      *      in="formData",
      *      description="The display order for this event. ",
@@ -1925,6 +1946,13 @@ class Schedule extends Base
         if ($this->isFullScreenSchedule($schedule->eventTypeId)) {
             $type = $schedule->eventTypeId === \Xibo\Entity\Schedule::$MEDIA_EVENT ? 'media' : 'playlist';
             $id = ($type === 'media') ? $sanitizedParams->getInt('mediaId') : $sanitizedParams->getInt('playlistId');
+
+            if (!$id) {
+                throw new InvalidArgumentException(
+                    __(ucfirst($type) . 'Id is required when scheduling ' . $type . ' events.'),
+                    $type . 'Id'
+                );
+            }
 
             // Create a full screen layout for this event
             $fsLayout = $this->layoutFactory->createFullScreenLayout(

--- a/lib/Controller/Schedule.php
+++ b/lib/Controller/Schedule.php
@@ -219,9 +219,9 @@ class Schedule extends Base
     {
         $response = $response
             ->withHeader(
-            'Warning',
-            '299 - "Deprecated API: /schedule/data/events will be removed in v5.0"'
-        );
+                'Warning',
+                '299 - "Deprecated API: /schedule/data/events will be removed in v5.0"'
+            );
 
         $this->getLog()->error('Deprecated API called: /schedule/data/events');
 

--- a/web/swagger.json
+++ b/web/swagger.json
@@ -8887,7 +8887,7 @@
                     {
                         "name": "fullScreenCampaignId",
                         "in": "formData",
-                        "description": "For Media or Playlist eventyType. The Layout specific Campaign ID to use for this Event.\r\n     * This needs to be the Layout created with layout/fullscreen function",
+                        "description": "For Media or Playlist event Type. The Layout specific Campaign ID to use for this Event.\r\n     * This needs to be the Layout created with layout/fullscreen function",
                         "required": false,
                         "type": "integer"
                     },
@@ -8895,6 +8895,13 @@
                         "name": "commandId",
                         "in": "formData",
                         "description": "The Command ID to use for this Event.",
+                        "required": false,
+                        "type": "integer"
+                    },
+                    {
+                        "name": "mediaId",
+                        "in": "formData",
+                        "description": "The Media ID to use for this Event.",
                         "required": false,
                         "type": "integer"
                     },
@@ -9138,6 +9145,13 @@
                         "name": "commandId",
                         "in": "formData",
                         "description": "The Command ID to use for this Event.",
+                        "required": false,
+                        "type": "integer"
+                    },
+                    {
+                        "name": "mediaId",
+                        "in": "formData",
+                        "description": "The Media ID to use for this Event.",
                         "required": false,
                         "type": "integer"
                     },


### PR DESCRIPTION
## Changes

- Added validation on Add Schedule API for media event types

Relates to https://github.com/xibosignage/xibo/issues/3777