### PR TITLE
DataSet Data Connector: Sandbox isolation for testing environment

### DIFF
--- a/lib/Controller/DataSet.php
+++ b/lib/Controller/DataSet.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2024 Xibo Signage Ltd
+ * Copyright (C) 2025 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -21,9 +21,6 @@
  */
 namespace Xibo\Controller;
 
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\RequestException;
-use Illuminate\Support\Str;
 use Slim\Http\Response as Response;
 use Slim\Http\ServerRequest as Request;
 use Xibo\Event\DataConnectorScriptRequestEvent;
@@ -1919,72 +1916,5 @@ class DataSet extends Base
         ]);
 
         return $this->render($request, $response);
-    }
-
-    /**
-     * Real-time data script test
-     * @param Request $request
-     * @param Response $response
-     * @param $id
-     * @return Response
-     * @throws GeneralException
-     */
-    public function dataConnectorRequest(Request $request, Response $response, $id): Response
-    {
-        $dataSet = $this->dataSetFactory->getById($id);
-
-        if (!$this->getUser()->checkEditable($dataSet)) {
-            throw new AccessDeniedException();
-        }
-
-        $params = $this->getSanitizer($request->getParams());
-        $url = $params->getString('url');
-        $method = $params->getString('method', ['default' => 'GET']);
-        $headers = $params->getArray('headers');
-        $body = $params->getArray('body');
-
-        // Verify that the requested URL appears in the script somewhere.
-        $script = $dataSet->getScript();
-
-        if (!Str::contains($script, $url)) {
-            throw new InvalidArgumentException(__('URL not found in data connector script'), 'url');
-        }
-
-        // Make the request
-        $options = [];
-        if (is_array($headers)) {
-            $options['headers'] = $headers;
-        }
-
-        if ($method === 'GET') {
-            $options['query'] = $body;
-        } else {
-            $options['body'] = $body;
-        }
-
-        $this->getLog()->debug('dataConnectorRequest: making request with options ' . var_export($options, true));
-
-        // Use guzzle to make the request
-        try {
-            $client = new Client();
-            $remoteResponse = $client->request($method, $url, $options);
-
-            // Format the response
-            $response->getBody()->write($remoteResponse->getBody()->getContents());
-            $response = $response->withAddedHeader('Content-Type', $remoteResponse->getHeader('Content-Type')[0]);
-            $response = $response->withStatus($remoteResponse->getStatusCode());
-        } catch (RequestException $exception) {
-            $this->getLog()->error('dataConnectorRequest: error with request: ' . $exception->getMessage());
-
-            if ($exception->hasResponse()) {
-                $remoteResponse = $exception->getResponse();
-                $response = $response->withStatus($remoteResponse->getStatusCode());
-                $response->getBody()->write($remoteResponse->getBody()->getContents());
-            } else {
-                $response = $response->withStatus(500);
-            }
-        }
-
-        return $response;
     }
 }

--- a/lib/routes-web.php
+++ b/lib/routes-web.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2024 Xibo Signage Ltd
+ * Copyright (C) 2025 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -427,7 +427,6 @@ $app->group('', function(\Slim\Routing\RouteCollectorProxy $group) {
     $group->get('/dataset/form/{id}/selectfolder', ['\Xibo\Controller\DataSet', 'selectFolderForm'])->setName('dataSet.selectfolder.form');
 
     $group->get('/dataset/dataConnector/{id}', ['\Xibo\Controller\DataSet', 'dataConnectorView'])->setName('dataSet.dataConnector.view');
-    $group->get('/dataset/dataConnector/request/{id}', ['\Xibo\Controller\DataSet', 'dataConnectorRequest'])->setName('dataSet.dataConnector.request');
     $group->get('/dataset/dataConnector/test/{id}', ['\Xibo\Controller\DataSet', 'dataConnectorTest'])->setName('dataSet.dataConnector.test');
 
     // columns

--- a/views/dataset-data-connector-page.twig
+++ b/views/dataset-data-connector-page.twig
@@ -1,6 +1,6 @@
 {#
 /*
- * Copyright (C) 2024 Xibo Signage Ltd
+ * Copyright (C) 2025 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -171,15 +171,24 @@
           $scriptParams.val(localStorage.getItem('dataSetRealtimeTestParams'));
 
           // Output the iframe containing the window
-          $script.html('<iframe src="{{ url_for("dataSet.dataConnector.test", {id: dataSet.dataSetId}) }}" />');
+          $script.html('<iframe sandbox="allow-scripts" src="{{ url_for("dataSet.dataConnector.test", {id: dataSet.dataSetId}) }}" />');
 
           // Window message to receive data and logs.
+          window.addEventListener('message', function(event) {
+            receiveData(event.data.type, event.data);
+          });
+
+          // Receive data function
           window.receiveData = function(type, data) {
             if (type === 'loaded') {
               console.debug('Script loaded');
-              $script.find('iframe')[0].contentWindow.xiboDC.initialise({{ dataSet.dataSetId }}, $scriptParams.val());
+              $script.find('iframe')[0].contentWindow.postMessage({
+                type: 'init',
+                id: {{ dataSet.dataSetId }},
+                params: $scriptParams.val()
+              }, '*');
             } else if (type === 'log') {
-              $logs.prepend('[' + moment().format('YY-MM-DD HH:mm:ss') + '] ' + data + '\n');
+              $logs.prepend('[' + moment().format('YY-MM-DD HH:mm:ss') + '] ' + data.data + '\n');
             } else if (type === 'set') {
               // Update the table
               // if the dataKey matches my connector's DataSetId, then render out a table
@@ -225,9 +234,9 @@
               channel.postMessage({type: 'xiboDC_data', dataKey: data.dataKey, data: data.data});
             } else if (type === 'notify') {
               // Log
-              $logs.prepend('[' + moment().format('YY-MM-DD HH:mm:ss') + '] Notify for ' + data + '\n');
+              $logs.prepend('[' + moment().format('YY-MM-DD HH:mm:ss') + '] Notify for ' + data.dataKey + '\n');
 
-              channel.postMessage({type: "xiboDC_notify", dataKey: data});
+              channel.postMessage({type: "xiboDC_notify", dataKey: data.dataKey});
             } else if (type === 'criteria') {
               // Schedule criteria, update in the table.
               criteria[data.dataKey] = data.data;
@@ -238,34 +247,16 @@
             }
           }
 
-          window.makeRequest = function (path, {type, headers, data, done, error} = {}) {
-            $.ajax('{{ url_for("dataSet.dataConnector.request", {id: dataSet.dataSetId}) }}', {
-              data: {
-                url: path,
-                method: type,
-                headers: headers,
-                body: data
-              },
-              success: function(data, textStatus, jqXHR) {
-                if (typeof(done) == 'function') {
-                  done(jqXHR.status, data);
-                }
-              },
-              error: function(jqXHR, textStatus, errorThrown) {
-                if (typeof(done) == 'function') {
-                  error(jqXHR.status, jqXHR.responseText);
-                }
-              }
-            });
-          }
-
           // Refresh the iframe.
           window.onSubmitCallback = function(xhr, form) {
-            $script.find('iframe')[0].contentWindow.location.reload();
+            $script.find('iframe').remove();
+            $script.html('<iframe sandbox="allow-scripts" src="{{ url_for("dataSet.dataConnector.test", {id: dataSet.dataSetId}) }}" />');
           }
 
           $scriptParams.on('change', function() {
-            $script.find('iframe')[0].contentWindow.xiboDC.initialise({{ dataSet.dataSetId }}, $scriptParams.val());
+            $script.find('iframe').remove();
+            $script.html('<iframe sandbox="allow-scripts" src="{{ url_for("dataSet.dataConnector.test", {id: dataSet.dataSetId}) }}" />');
+
             localStorage.setItem('dataSetRealtimeTestParams', $scriptParams.val());
           });
         });

--- a/views/dataset-data-connector-test-page.twig
+++ b/views/dataset-data-connector-test-page.twig
@@ -1,6 +1,6 @@
 {#
 /*
- * Copyright (C) 2024 Xibo Signage Ltd
+ * Copyright (C) 2025 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -34,6 +34,13 @@
     </head>
     <body>
         <script type="text/javascript" nonce="{{ cspNonce }}">
+          window.addEventListener('message', function(event) {
+            if (event.data.type === 'init') {
+              console.log('Starting script');
+              xiboDC.initialise(event.data.id, event.data.params.data);
+            }
+          });
+
           window.xiboDC = (function() {
             'use strict';
 
@@ -64,10 +71,12 @@
                */
               setData: function(dataKey, data, {done, error} = {}) {
                 // Persist the data we've been given
-                window.parent.receiveData('set', {
+                window.parent.postMessage({
+                  type: 'set',
                   dataKey: dataKey,
                   data: data
-                });
+                }, '*');
+
                 if (typeof (done) == 'function') {
                   done(true);
                 }
@@ -79,7 +88,7 @@
                */
               notifyHost: function(dataKey) {
                 // Update the table.
-                window.parent.receiveData('notify', dataKey);
+                window.parent.postMessage({type: 'notify', dataKey: dataKey}, '*');
               },
 
               /**
@@ -94,7 +103,23 @@
                * @param  {callback} [options.error]
                */
               makeRequest: function(path, {type, headers, data, done, error} = {}) {
-                window.parent.makeRequest(path, {type, headers, data, done, error});
+                console.log('Request subject to CORS when tested via the CMS.');
+
+                $.ajax(path, {
+                  data: data,
+                  method: type,
+                  headers: headers,
+                  success: function(data, textStatus, jqXHR) {
+                    if (typeof(done) == 'function') {
+                      done(jqXHR.status, data);
+                    }
+                  },
+                  error: function(jqXHR, textStatus, errorThrown) {
+                    if (typeof(done) == 'function') {
+                      error(jqXHR.status, jqXHR.responseText);
+                    }
+                  }
+                });
               },
 
               /**
@@ -104,14 +129,15 @@
                * @param {int} ttl A TTL in seconds
                */
               setCriteria: function(metric, value, ttl) {
-                window.parent.receiveData('criteria', {
+                window.parent.postMessage({
+                  type: 'criteria',
                   dataKey: metric,
                   data: {
                     metric: metric,
                     value: value || null,
                     ttl: ttl,
                   }
-                });
+                }, '*');
               },
             }
             return mainLib;
@@ -122,13 +148,13 @@
             const log = console.log;
             console.log = function () {
               log.apply(this, Array.prototype.slice.call(arguments));
-              window.parent.receiveData('log', Array.prototype.slice.call(arguments));
+              window.parent.postMessage({type: 'log', data: Array.prototype.slice.call(arguments)}, '*');
             };
           }());
 
           // Say when we're loaded.
           window.onload = function () {
-            window.parent.receiveData('loaded', null);
+            window.parent.postMessage({type: 'loaded'}, '*');
           }
         </script>
         <script type="text/javascript" nonce="{{ cspNonce }}">


### PR DESCRIPTION
This PR adds iframe sandbox isolation to the DataSet data connecter testing page.

Now that the testing page is in a different origin, we need to use postMessage to exchange information.

It also removes the ability to use the CMS as a proxy route for making an HTTP request. This means that CORS will need to be configured for testing HTTP data sources because it will request using browser instead.

fixes xibosignageltd/xibo-private#1101