### PR TITLE
Notification attachment: Fixed validation for file type

### DIFF
--- a/lib/Controller/Notification.php
+++ b/lib/Controller/Notification.php
@@ -474,7 +474,7 @@ class Notification extends Base
         $options = [
             'userId' => $this->getUser()->userId,
             'controller' => $this,
-            'accept_file_types' => '/\.jpg|.jpeg|.png|.bmp|.gif|.zip|.pdf/i'
+            'accept_file_types' => '/\.(jpg|jpeg|png|bmp|gif|zip|pdf)$/i'
         ];
 
         // Output handled by UploadHandler


### PR DESCRIPTION
## Changes

- Update regex validation to ensure file type matching occurs only at the end of the filename.

Relates to https://github.com/xibosignageltd/xibo-private/issues/1092