### PR TITLE
Preview: isolating user supplied JavaScript

### DIFF
--- a/docker/etc/apache2/sites-available/000-default.conf
+++ b/docker/etc/apache2/sites-available/000-default.conf
@@ -57,10 +57,6 @@ ServerTokens OS
   CustomLog /dev/stdout combined
   CustomLog /dev/stdout requesttime
 
-  # Hardening
-  Header always append X-Frame-Options SAMEORIGIN
-  Header always append X-Content-Type-Options nosniff
-
   # Alias /xibo /var/www/cms/web
 
 </VirtualHost>

--- a/lib/Controller/Base.php
+++ b/lib/Controller/Base.php
@@ -193,7 +193,10 @@ class Base
      */
     protected function isApi(Request $request)
     {
-        return ($request->getAttribute('_entryPoint') != 'web');
+        return (
+            $request->getAttribute('_entryPoint') != 'web'
+            && $request->getAttribute('_entryPoint') != 'preview'
+        );
     }
 
     /**

--- a/lib/Controller/Layout.php
+++ b/lib/Controller/Layout.php
@@ -2778,7 +2778,7 @@ class Layout extends Base
 
         $layout = $this->layoutFactory->getById($id);
 
-        if (!$this->getUser()->checkViewable($layout)) {
+        if (!$this->getUser()->checkViewable($layout) && $request->getAttribute('authedViaToken') !== true) {
             throw new AccessDeniedException();
         }
 

--- a/lib/Controller/Layout.php
+++ b/lib/Controller/Layout.php
@@ -48,11 +48,11 @@ use Xibo\Factory\UserGroupFactory;
 use Xibo\Factory\WidgetDataFactory;
 use Xibo\Factory\WidgetFactory;
 use Xibo\Helper\DateFormatHelper;
-use Xibo\Helper\Environment;
 use Xibo\Helper\LayoutUploadHandler;
 use Xibo\Helper\Profiler;
 use Xibo\Helper\SendFile;
 use Xibo\Helper\Status;
+use Xibo\Middleware\TokenAuthMiddleware;
 use Xibo\Service\MediaService;
 use Xibo\Service\MediaServiceInterface;
 use Xibo\Support\Exception\AccessDeniedException;
@@ -60,7 +60,6 @@ use Xibo\Support\Exception\GeneralException;
 use Xibo\Support\Exception\InvalidArgumentException;
 use Xibo\Support\Exception\NotFoundException;
 use Xibo\Widget\Render\WidgetDownloader;
-use Xibo\Widget\SubPlaylistItem;
 
 /**
  * Class Layout
@@ -1848,7 +1847,12 @@ class Layout extends Base
                     'external' => true,
                     'url' => '#',
                     'onclick' => 'createMiniLayoutPreview',
-                    'onclickParam' => $this->urlFor($request, 'layout.preview', ['id' => $layout->layoutId]),
+                    'onclickParam' => TokenAuthMiddleware::sign(
+                        $request,
+                        '/preview/layout/preview/' . $layout->layoutId,
+                        time() + 3600,
+                        $this->getConfig()->getApiKeyDetails()['encryptionKey'],
+                    ),
                     'text' => __('Preview Layout')
                 );
 
@@ -1859,7 +1863,12 @@ class Layout extends Base
                         'external' => true,
                         'url' => '#',
                         'onclick' => 'createMiniLayoutPreview',
-                        'onclickParam' => $this->urlFor($request, 'layout.preview', ['id' => $layout->layoutId]) . '?isPreviewDraft=true',
+                        'onclickParam' => TokenAuthMiddleware::sign(
+                            $request,
+                            '/preview/layout/preview/' . $layout->layoutId . '?isPreviewDraft=true',
+                            time() + 3600,
+                            $this->getConfig()->getApiKeyDetails()['encryptionKey'],
+                        ),
                         'text' => __('Preview Draft Layout')
                     );
                 }

--- a/lib/Controller/Layout.php
+++ b/lib/Controller/Layout.php
@@ -52,7 +52,7 @@ use Xibo\Helper\LayoutUploadHandler;
 use Xibo\Helper\Profiler;
 use Xibo\Helper\SendFile;
 use Xibo\Helper\Status;
-use Xibo\Middleware\TokenAuthMiddleware;
+use Xibo\Service\JwtServiceInterface;
 use Xibo\Service\MediaService;
 use Xibo\Service\MediaServiceInterface;
 use Xibo\Support\Exception\AccessDeniedException;
@@ -156,6 +156,7 @@ class Layout extends Base
         WidgetFactory $widgetFactory,
         private readonly WidgetDataFactory $widgetDataFactory,
         PlaylistFactory $playlistFactory,
+        private readonly JwtServiceInterface $jwtService,
     ) {
         $this->session = $session;
         $this->userFactory = $userFactory;
@@ -223,8 +224,9 @@ class Layout extends Base
         $layout = $this->layoutFactory->loadById($id);
         $sanitizedParams = $this->getSanitizer($request->getParams());
 
-        if (!$this->getUser()->checkEditable($layout))
+        if (!$this->getUser()->checkEditable($layout)) {
             throw new AccessDeniedException();
+        }
 
         // Get the parent layout if it's editable
         if ($layout->isEditable()) {
@@ -239,10 +241,15 @@ class Layout extends Base
             } else {
                 $resolution = $this->resolutionFactory->getByDimensions($layout->width, $layout->height);
             }
-        } catch (NotFoundException $notFoundException) {
-            $this->getLog()->info('Layout Editor with an unknown resolution, we will create it with name: ' . $layout->width . ' x ' . $layout->height);
+        } catch (NotFoundException) {
+            $this->getLog()->info('Layout Editor with an unknown resolution, we will create it with name: '
+                . $layout->width . ' x ' . $layout->height);
 
-            $resolution = $this->resolutionFactory->create($layout->width . ' x ' . $layout->height, (int)$layout->width, (int)$layout->height);
+            $resolution = $this->resolutionFactory->create(
+                $layout->width . ' x ' . $layout->height,
+                (int)$layout->width,
+                (int)$layout->height
+            );
             $resolution->userId = $this->userFactory->getSystemUser()->userId;
             $resolution->save();
         }
@@ -267,6 +274,13 @@ class Layout extends Base
             ]),
             'modules' => $moduleFactory->getAssignableModules(),
             'timeZones' => $timeZones,
+            'previewJwt' => $this->jwtService->generateJwt(
+                'Preview',
+                'layout',
+                $layout->layoutId,
+                '/preview/layout/preview/' . $layout->layoutId,
+                3600,
+            )->toString(),
         ];
 
         // Call the render the template
@@ -1842,17 +1856,20 @@ class Layout extends Base
 
             // Preview
             if ($this->getUser()->featureEnabled('layout.view')) {
+                $jwt = $this->jwtService->generateJwt(
+                    'Preview',
+                    'layout',
+                    $layout->layoutId,
+                    '/preview/layout/preview/' . $layout->layoutId,
+                    3600,
+                )->toString();
+
                 $layout->buttons[] = array(
                     'id' => 'layout_button_preview',
                     'external' => true,
                     'url' => '#',
                     'onclick' => 'createMiniLayoutPreview',
-                    'onclickParam' => TokenAuthMiddleware::sign(
-                        $request,
-                        '/preview/layout/preview/' . $layout->layoutId,
-                        time() + 3600,
-                        $this->getConfig()->getApiKeyDetails()['encryptionKey'],
-                    ),
+                    'onclickParam' => '/preview/layout/preview/' . $layout->layoutId . '?jwt=' . $jwt,
                     'text' => __('Preview Layout')
                 );
 
@@ -1863,12 +1880,8 @@ class Layout extends Base
                         'external' => true,
                         'url' => '#',
                         'onclick' => 'createMiniLayoutPreview',
-                        'onclickParam' => TokenAuthMiddleware::sign(
-                            $request,
-                            '/preview/layout/preview/' . $layout->layoutId . '?isPreviewDraft=true',
-                            time() + 3600,
-                            $this->getConfig()->getApiKeyDetails()['encryptionKey'],
-                        ),
+                        'onclickParam' => '/preview/layout/preview/' . $layout->layoutId . '?jwt=' . $jwt
+                            . '&isPreviewDraft=true',
                         'text' => __('Preview Draft Layout')
                     );
                 }

--- a/lib/Controller/Layout.php
+++ b/lib/Controller/Layout.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2025 Xibo Signage Ltd
+ * Copyright (C) 2026 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -48,6 +48,7 @@ use Xibo\Factory\UserGroupFactory;
 use Xibo\Factory\WidgetDataFactory;
 use Xibo\Factory\WidgetFactory;
 use Xibo\Helper\DateFormatHelper;
+use Xibo\Helper\HttpsDetect;
 use Xibo\Helper\LayoutUploadHandler;
 use Xibo\Helper\Profiler;
 use Xibo\Helper\SendFile;
@@ -1578,6 +1579,7 @@ class Layout extends Base
         $parsedQueryParams = $this->getSanitizer($request->getQueryParams());
         // Should we parse the description into markdown
         $showDescriptionId = $parsedQueryParams->getInt('showDescriptionId');
+        $baseUrl = (new HttpsDetect())->getBaseUrl($request);
 
         // We might need to embed some extra content into the response if the "Show Description"
         // is set to media listing
@@ -1869,7 +1871,7 @@ class Layout extends Base
                     'external' => true,
                     'url' => '#',
                     'onclick' => 'createMiniLayoutPreview',
-                    'onclickParam' => '/preview/layout/preview/' . $layout->layoutId . '?jwt=' . $jwt,
+                    'onclickParam' => $baseUrl . '/preview/layout/preview/' . $layout->layoutId . '?jwt=' . $jwt,
                     'text' => __('Preview Layout')
                 );
 
@@ -1880,7 +1882,7 @@ class Layout extends Base
                         'external' => true,
                         'url' => '#',
                         'onclick' => 'createMiniLayoutPreview',
-                        'onclickParam' => '/preview/layout/preview/' . $layout->layoutId . '?jwt=' . $jwt
+                        'onclickParam' => $baseUrl . '/preview/layout/preview/' . $layout->layoutId . '?jwt=' . $jwt
                             . '&isPreviewDraft=true',
                         'text' => __('Preview Draft Layout')
                     );

--- a/lib/Controller/Library.php
+++ b/lib/Controller/Library.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2025 Xibo Signage Ltd
+ * Copyright (C) 2026 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -1673,7 +1673,7 @@ class Library extends Base
             $this->getLog()->debug('download: preview mode, seeing if we can output an image/video');
 
             // Output a 1px image if we're not allowed to see the media.
-            if (!$this->getUser()->checkViewable($media)) {
+            if (!$this->getUser()->checkViewable($media) && $request->getAttribute('authedViaToken') !== true) {
                 echo Img::make($this->getConfig()->uri('img/1x1.png', true))->encode();
                 return $this->render($request, $response->withHeader('Content-Type', 'image/png'));
             }
@@ -1700,7 +1700,7 @@ class Library extends Base
             $this->getLog()->debug('download: not preview mode, expect a full download');
 
             // We are not a preview, and therefore we ought to check sharing before we download
-            if (!$this->getUser()->checkViewable($media)) {
+            if (!$this->getUser()->checkViewable($media) && $request->getAttribute('authedViaToken') !== true) {
                 throw new AccessDeniedException();
             }
 

--- a/lib/Controller/Library.php
+++ b/lib/Controller/Library.php
@@ -524,7 +524,7 @@ class Library extends Base
         $parsedQueryParams = $this->getSanitizer($request->getQueryParams());
 
         // Variables used for link signing
-        $isReturnPublicUrls = $parsedQueryParams->getCheckbox('isReturnPublicUrls') == 0;
+        $isReturnPublicUrls = $parsedQueryParams->getCheckbox('isReturnPublicUrls') == 1;
 
         // Construct the SQL
         $mediaList = $this->mediaFactory->query($this->gridRenderSort($parsedQueryParams), $this->gridRenderFilter([

--- a/lib/Controller/Library.php
+++ b/lib/Controller/Library.php
@@ -55,9 +55,8 @@ use Xibo\Factory\WidgetFactory;
 use Xibo\Helper\ByteFormatter;
 use Xibo\Helper\DateFormatHelper;
 use Xibo\Helper\Environment;
-use Xibo\Helper\HttpsDetect;
-use Xibo\Helper\LinkSigner;
 use Xibo\Helper\XiboUploadHandler;
+use Xibo\Middleware\TokenAuthMiddleware;
 use Xibo\Service\MediaService;
 use Xibo\Service\MediaServiceInterface;
 use Xibo\Support\Exception\AccessDeniedException;
@@ -525,10 +524,7 @@ class Library extends Base
         $parsedQueryParams = $this->getSanitizer($request->getQueryParams());
 
         // Variables used for link signing
-        $isReturnPublicUrls = $parsedQueryParams->getCheckbox('isReturnPublicUrls') == 1;
-        $thumbnailRouteName = $isReturnPublicUrls ? 'library.public.thumbnail' : 'library.thumbnail';
-        $encryptionKey = $this->getConfig()->getApiKeyDetails()['encryptionKey'];
-        $rootUrl = (new HttpsDetect())->getUrl();
+        $isReturnPublicUrls = $parsedQueryParams->getCheckbox('isReturnPublicUrls') == 0;
 
         // Construct the SQL
         $mediaList = $this->mediaFactory->query($this->gridRenderSort($parsedQueryParams), $this->gridRenderFilter([
@@ -574,23 +570,18 @@ class Library extends Base
                     }
 
                     if ($renderThumbnail) {
-                        $thumbnailUrl = $this->urlFor($request, $thumbnailRouteName, [
-                            'id' => $media->mediaId,
-                        ]);
-
                         if ($isReturnPublicUrls) {
-                            // If we are coming from the API we should remove the /api part of the URL
-                            if ($this->isApi($request)) {
-                                $thumbnailUrl = str_replace('/api/', '/', $thumbnailUrl);
-                            }
-
                             // Sign the link.
-                            $thumbnailUrl = $rootUrl . $thumbnailUrl . '?' . LinkSigner::getSignature(
-                                $rootUrl,
-                                $thumbnailUrl,
+                            $thumbnailUrl = TokenAuthMiddleware::sign(
+                                $request,
+                                '/preview/library/thumbnail/' . $media->mediaId,
                                 time() + 3600,
-                                $encryptionKey,
+                                $this->getConfig()->getApiKeyDetails()['encryptionKey'],
                             );
+                        } else {
+                            $thumbnailUrl = $this->urlFor($request, 'library.thumbnail', [
+                                'id' => $media->mediaId,
+                            ]);
                         }
 
                         $media->setUnmatchedProperty('thumbnail', $thumbnailUrl);
@@ -1760,7 +1751,7 @@ class Library extends Base
      * @return \Psr\Http\Message\ResponseInterface|Response
      * @throws \Xibo\Support\Exception\GeneralException
      */
-    public function thumbnail(Request $request, Response $response, $id, bool $isForceGrantAccess = false)
+    public function thumbnail(Request $request, Response $response, $id)
     {
         $this->setNoOutput();
 
@@ -1775,7 +1766,7 @@ class Library extends Base
             . '. Media is a ' . $media->mediaType);
 
         // Permissions.
-        if (!$this->getUser()->checkViewable($media) && !$isForceGrantAccess) {
+        if (!$this->getUser()->checkViewable($media) && $request->getAttribute('authedViaToken') !== true) {
             // Output a 1px image if we're not allowed to see the media.
             echo Img::make($this->getConfig()->uri('img/1x1.png', true))->encode();
             return $this->render($request, $response);
@@ -1796,52 +1787,6 @@ class Library extends Base
         );
 
         return $this->render($request, $response);
-    }
-
-    /**
-     * Public Thumbnail
-     *  this is an unauthenticated route (publicRoutes)
-     *  we need to authenticate using the S3 link signing
-     * @param Request $request
-     * @param Response $response
-     * @param $id
-     * @return \Slim\Http\Response
-     * @throws \Xibo\Support\Exception\AccessDeniedException
-     * @throws \Xibo\Support\Exception\GeneralException
-     */
-    public function thumbnailPublic(Request $request, Response $response, $id): Response
-    {
-        // Authenticate.
-        $params = $this->getSanitizer($request->getParams());
-
-        // Has the URL expired
-        if (time() > $params->getInt('X-Amz-Expires')) {
-            throw new AccessDeniedException(__('Expired'));
-        }
-
-        // Validate the URL.
-        $encryptionKey = $this->getConfig()->getApiKeyDetails()['encryptionKey'];
-        $signature = $params->getString('X-Amz-Signature');
-
-        $calculatedSignature = \Xibo\Helper\LinkSigner::getSignature(
-            (new HttpsDetect())->getUrl(),
-            $request->getUri()->getPath(),
-            $params->getInt('X-Amz-Expires'),
-            $encryptionKey,
-            $params->getString('X-Amz-Date'),
-            true,
-        );
-
-        if ($signature !== $calculatedSignature) {
-            throw new AccessDeniedException(__('Invalid URL'));
-        }
-
-        $this->getLog()->debug('thumbnailPublic: authorised for ' . $id);
-
-        $res = $this->thumbnail($request, $response, $id, true);
-
-        // Pass to the thumbnail route
-        return $res->withHeader('Access-Control-Allow-Origin', '*');
     }
 
     /**

--- a/lib/Controller/Preview.php
+++ b/lib/Controller/Preview.php
@@ -24,6 +24,7 @@ namespace Xibo\Controller;
 use Slim\Http\Response as Response;
 use Slim\Http\ServerRequest as Request;
 use Xibo\Factory\LayoutFactory;
+use Xibo\Middleware\TokenAuthMiddleware;
 use Xibo\Service\JwtServiceInterface;
 use Xibo\Support\Exception\AccessDeniedException;
 
@@ -89,12 +90,17 @@ class Preview extends Base
         $this->getState()->setData([
             'layout' => $layout,
             'previewOptions' => [
-                'getXlfUrl' => $this->urlFor($request, 'layout.getXlf', ['id' => $layout->layoutId]),
+                'xlfUrl' => $this->urlFor($request, 'layout.getXlf', ['id' => $layout->layoutId]),
                 'getResourceUrl' => $this->urlFor($request, 'module.getResource', [
                     'regionId' => ':regionId',
                     'id' => ':id',
                 ]),
-                'libraryDownloadUrl' => $this->urlFor($request, 'library.download', ['id' => ':id']),
+                'layoutBackgroundDownloadUrl' => TokenAuthMiddleware::sign(
+                    $request,
+                    '/preview/layout/background/' . $layout->layoutId,
+                    time() + 3600,
+                    $this->getConfig()->getApiKeyDetails()['encryptionKey'],
+                ),
                 'loaderUrl' => $this->getConfig()->uri('img/loader.gif'),
                 'layoutPreviewUrl' => $this->urlFor($request, 'layout.preview', ['id' => '[layoutCode]']),
             ],

--- a/lib/Controller/Preview.php
+++ b/lib/Controller/Preview.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2025 Xibo Signage Ltd
+ * Copyright (C) 2026 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -69,7 +69,14 @@ class Preview extends Base
             $layout = $this->layoutFactory->getById($id);
         }
 
-        if ($request->getAttribute('authedViaToken') !== true) {
+        /** @var \Lcobucci\JWT\Token $token */
+        $token = $request->getAttribute('authedToken');
+        if (empty($token)) {
+            throw new AccessDeniedException();
+        }
+
+        // Check the token allows access to this layout.
+        if (!$token->isPermittedFor('layout') || !$token->isIdentifiedBy($layout->layoutId)) {
             throw new AccessDeniedException();
         }
 
@@ -84,12 +91,12 @@ class Preview extends Base
             'previewOptions' => [
                 'getXlfUrl' => $this->urlFor($request, 'layout.getXlf', ['id' => $layout->layoutId]),
                 'getResourceUrl' => $this->urlFor($request, 'module.getResource', [
-                    'regionId' => ':regionId', 'id' => ':id'
+                    'regionId' => ':regionId',
+                    'id' => ':id',
                 ]),
                 'libraryDownloadUrl' => $this->urlFor($request, 'library.download', ['id' => ':id']),
-                'layoutBackgroundDownloadUrl' => $this->urlFor($request, 'layout.download.background', ['id' => ':id']),
                 'loaderUrl' => $this->getConfig()->uri('img/loader.gif'),
-                'layoutPreviewUrl' => $this->urlFor($request, 'layout.preview', ['id' => '[layoutCode]'])
+                'layoutPreviewUrl' => $this->urlFor($request, 'layout.preview', ['id' => '[layoutCode]']),
             ],
             'previewJwt' => $this->jwtService->generateJwt(
                 'Preview',

--- a/lib/Controller/Preview.php
+++ b/lib/Controller/Preview.php
@@ -24,6 +24,7 @@ namespace Xibo\Controller;
 use Slim\Http\Response as Response;
 use Slim\Http\ServerRequest as Request;
 use Xibo\Factory\LayoutFactory;
+use Xibo\Service\JwtServiceInterface;
 use Xibo\Support\Exception\AccessDeniedException;
 
 /**
@@ -41,7 +42,7 @@ class Preview extends Base
      * Set common dependencies.
      * @param LayoutFactory $layoutFactory
      */
-    public function __construct($layoutFactory)
+    public function __construct($layoutFactory, private readonly JwtServiceInterface $jwtService)
     {
         $this->layoutFactory = $layoutFactory;
     }
@@ -89,7 +90,14 @@ class Preview extends Base
                 'layoutBackgroundDownloadUrl' => $this->urlFor($request, 'layout.download.background', ['id' => ':id']),
                 'loaderUrl' => $this->getConfig()->uri('img/loader.gif'),
                 'layoutPreviewUrl' => $this->urlFor($request, 'layout.preview', ['id' => '[layoutCode]'])
-            ]
+            ],
+            'previewJwt' => $this->jwtService->generateJwt(
+                'Preview',
+                'layout',
+                $layout->layoutId,
+                '/preview/layout/preview/' . $layout->layoutId,
+                3600,
+            )->toString(),
         ]);
 
         return $this->render($request, $response);

--- a/lib/Controller/Preview.php
+++ b/lib/Controller/Preview.php
@@ -126,7 +126,15 @@ class Preview extends Base
     {
         $layout = $this->layoutFactory->concurrentRequestLock($this->layoutFactory->getById($id));
         try {
-            if (!$this->getUser()->checkViewable($layout)) {
+            /** @var \Lcobucci\JWT\Token $token */
+            $token = $request->getAttribute('authedToken');
+            if (!$this->getUser()->checkViewable($layout) && empty($token)) {
+                throw new AccessDeniedException();
+            }
+
+            if (!empty($token)
+                && (!$token->isPermittedFor('layout') || !$token->isIdentifiedBy($layout->layoutId))
+            ) {
                 throw new AccessDeniedException();
             }
 

--- a/lib/Controller/Preview.php
+++ b/lib/Controller/Preview.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2024 Xibo Signage Ltd
+ * Copyright (C) 2025 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -68,9 +68,7 @@ class Preview extends Base
             $layout = $this->layoutFactory->getById($id);
         }
 
-        if (!$this->getUser()->checkViewable($layout)
-            || !$this->getUser()->featureEnabled(['layout.view', 'playlist.view', 'campaign.view'])
-        ) {
+        if ($request->getAttribute('authedViaToken') !== true) {
             throw new AccessDeniedException();
         }
 

--- a/lib/Controller/Region.php
+++ b/lib/Controller/Region.php
@@ -33,6 +33,7 @@ use Xibo\Factory\RegionFactory;
 use Xibo\Factory\TransitionFactory;
 use Xibo\Factory\WidgetFactory;
 use Xibo\Middleware\TokenAuthMiddleware;
+use Xibo\Service\JwtServiceInterface;
 use Xibo\Support\Exception\AccessDeniedException;
 use Xibo\Support\Exception\ControllerNotImplemented;
 use Xibo\Support\Exception\GeneralException;
@@ -81,7 +82,8 @@ class Region extends Base
         $widgetFactory,
         $transitionFactory,
         $moduleFactory,
-        $layoutFactory
+        $layoutFactory,
+        private readonly JwtServiceInterface $jwtService,
     ) {
         $this->regionFactory = $regionFactory;
         $this->widgetFactory = $widgetFactory;
@@ -628,12 +630,15 @@ class Region extends Base
                     $region,
                     $widget,
                     $sanitizedQuery,
-                    TokenAuthMiddleware::sign(
-                        $request,
-                        '/preview/playlist/widget/resource/' . $region->regionId . '/' . $widget->widgetId,
-                        time() + 3600,
-                        $this->getConfig()->getApiKeyDetails()['encryptionKey'],
-                    ) . '&preview=1',
+                    '/preview/playlist/widget/resource/' . $region->regionId . '/' . $widget->widgetId
+                        . '?preview=1&jwt='
+                        . $this->jwtService->generateJwt(
+                            'Preview',
+                            'layout',
+                            $region->layoutId,
+                            '/preview/playlist/widget/resource/' . $region->regionId . '/' . $widget->widgetId,
+                            3600,
+                        )->toString(),
                     TokenAuthMiddleware::sign(
                         $request,
                         '/preview/library/download/' . ($widget->getPrimaryMedia()[0] ?? null),

--- a/lib/Controller/Region.php
+++ b/lib/Controller/Region.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2023 Xibo Signage Ltd
+ * Copyright (C) 2025 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -32,6 +32,7 @@ use Xibo\Factory\ModuleFactory;
 use Xibo\Factory\RegionFactory;
 use Xibo\Factory\TransitionFactory;
 use Xibo\Factory\WidgetFactory;
+use Xibo\Middleware\TokenAuthMiddleware;
 use Xibo\Support\Exception\AccessDeniedException;
 use Xibo\Support\Exception\ControllerNotImplemented;
 use Xibo\Support\Exception\GeneralException;
@@ -627,14 +628,18 @@ class Region extends Base
                     $region,
                     $widget,
                     $sanitizedQuery,
-                    $this->urlFor(
+                    TokenAuthMiddleware::sign(
                         $request,
-                        'library.download',
-                        [
-                            'regionId' => $region->regionId,
-                            'id' => $widget->getPrimaryMedia()[0] ?? null
-                        ]
-                    ) . '?preview=1',
+                        '/preview/playlist/widget/resource/' . $region->regionId . '/' . $widget->widgetId,
+                        time() + 3600,
+                        $this->getConfig()->getApiKeyDetails()['encryptionKey'],
+                    ) . '&preview=1',
+                    TokenAuthMiddleware::sign(
+                        $request,
+                        '/preview/library/download/' . ($widget->getPrimaryMedia()[0] ?? null),
+                        time() + 3600,
+                        $this->getConfig()->getApiKeyDetails()['encryptionKey'],
+                    ) . '&preview=1',
                     $additionalContexts
                 );
             $this->getState()->extra['countOfWidgets'] = $countWidgets;

--- a/lib/Controller/Region.php
+++ b/lib/Controller/Region.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2025 Xibo Signage Ltd
+ * Copyright (C) 2026 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -32,6 +32,7 @@ use Xibo\Factory\ModuleFactory;
 use Xibo\Factory\RegionFactory;
 use Xibo\Factory\TransitionFactory;
 use Xibo\Factory\WidgetFactory;
+use Xibo\Helper\HttpsDetect;
 use Xibo\Middleware\TokenAuthMiddleware;
 use Xibo\Service\JwtServiceInterface;
 use Xibo\Support\Exception\AccessDeniedException;
@@ -623,6 +624,7 @@ class Region extends Base
 
             // Output a preview
             $module = $this->moduleFactory->getByType($widget->type);
+            $baseUrl = (new HttpsDetect())->getBaseUrl($request);
             $this->getState()->html = $this->moduleFactory
                 ->createWidgetHtmlRenderer()
                 ->preview(
@@ -630,13 +632,13 @@ class Region extends Base
                     $region,
                     $widget,
                     $sanitizedQuery,
-                    '/preview/playlist/widget/resource/' . $region->regionId . '/' . $widget->widgetId
+                    $baseUrl . '/preview/playlist/widget/resource/' . $region->regionId . '/' . $widget->widgetId
                         . '?preview=1&jwt='
                         . $this->jwtService->generateJwt(
                             'Preview',
                             'layout',
                             $region->layoutId,
-                            '/preview/playlist/widget/resource/' . $region->regionId . '/' . $widget->widgetId,
+                            '/preview/layout/preview/' . $region->layoutId,
                             3600,
                         )->toString(),
                     TokenAuthMiddleware::sign(

--- a/lib/Controller/Widget.php
+++ b/lib/Controller/Widget.php
@@ -40,6 +40,7 @@ use Xibo\Factory\WidgetAudioFactory;
 use Xibo\Factory\WidgetDataFactory;
 use Xibo\Factory\WidgetFactory;
 use Xibo\Helper\DateFormatHelper;
+use Xibo\Middleware\TokenAuthMiddleware;
 use Xibo\Support\Exception\AccessDeniedException;
 use Xibo\Support\Exception\ConfigurationException;
 use Xibo\Support\Exception\GeneralException;
@@ -1330,16 +1331,13 @@ class Widget extends Base
     {
         $this->setNoOutput();
 
+        if ($request->getAttribute('authedViaToken') !== true) {
+            throw new AccessDeniedException();
+        }
+
+        // Load requested objects
         $region = $this->regionFactory->getById($regionId);
-        if (!$this->getUser()->checkViewable($region)) {
-            throw new AccessDeniedException(__('This Region is not shared with you'));
-        }
-
         $widget = $this->widgetFactory->loadByWidgetId($id);
-        if (!$this->getUser()->checkViewable($widget)) {
-            throw new AccessDeniedException(__('This Widget is not shared with you'));
-        }
-
         $module = $this->moduleFactory->getByType($widget->type);
 
         // 3 options
@@ -1392,11 +1390,17 @@ class Widget extends Base
             );
 
             if (!empty($resource)) {
+                $encryptionKey = $this->getConfig()->getApiKeyDetails()['encryptionKey'];
                 $resource = $renderer->decorateForPreview(
                     $region,
                     $resource,
-                    function (string $route, array $data, array $params = []) use ($request) {
-                        return $this->urlFor($request, $route, $data, $params);
+                    function (string $route, array $data, array $params = []) use ($request, $encryptionKey) {
+                        return TokenAuthMiddleware::sign(
+                            $request,
+                            $this->urlFor($request, $route, $data, $params),
+                            time() + 3600,
+                            $encryptionKey,
+                        );
                     },
                     $request,
                 );

--- a/lib/Controller/Widget.php
+++ b/lib/Controller/Widget.php
@@ -1409,13 +1409,17 @@ class Widget extends Base
                 $resource = $renderer->decorateForPreview(
                     $region,
                     $resource,
-                    function (string $route, array $data, array $params = []) use ($request, $encryptionKey) {
-                        return TokenAuthMiddleware::sign(
-                            $request,
-                            $this->urlFor($request, $route, $data, $params),
-                            time() + 3600,
-                            $encryptionKey,
-                        );
+                    function (string $route, array $data, array $params = []) use ($request, $encryptionKey, $token) {
+                        if ($route === 'layout.preview.bundle' || $route === 'module.getData') {
+                            return $this->urlFor($request, $route, $data, $params);
+                        } else {
+                            return TokenAuthMiddleware::sign(
+                                $request,
+                                $this->urlFor($request, $route, $data, $params),
+                                time() + 3600,
+                                $encryptionKey,
+                            );
+                        }
                     },
                     $request,
                 );

--- a/lib/Controller/Widget.php
+++ b/lib/Controller/Widget.php
@@ -1112,16 +1112,26 @@ class Widget extends Base
      */
     public function getData(Request $request, Response $response, $regionId, $id)
     {
+        if ($request->getAttribute('authedViaToken') !== true) {
+            throw new AccessDeniedException();
+        }
+
+        /** @var \Lcobucci\JWT\Token $token */
+        $token = $request->getAttribute('authedToken');
+        if (empty($token)) {
+            throw new AccessDeniedException();
+        }
+
+        // Get the region
         $region = $this->regionFactory->getById($regionId);
-        if (!$this->getUser()->checkViewable($region)) {
-            throw new AccessDeniedException(__('This Region is not shared with you'));
+
+        // Check the token allows access to this layout.
+        if (!$token->isPermittedFor('layout') || !$token->isIdentifiedBy($region->layoutId)) {
+            throw new AccessDeniedException();
         }
 
+        // Get the other objects
         $widget = $this->widgetFactory->loadByWidgetId($id);
-        if (!$this->getUser()->checkViewable($widget)) {
-            throw new AccessDeniedException(__('This Widget is not shared with you'));
-        }
-
         $module = $this->moduleFactory->getByType($widget->type);
 
         // This is always a preview
@@ -1335,8 +1345,21 @@ class Widget extends Base
             throw new AccessDeniedException();
         }
 
-        // Load requested objects
+        /** @var \Lcobucci\JWT\Token $token */
+        $token = $request->getAttribute('authedToken');
+        if (empty($token)) {
+            throw new AccessDeniedException();
+        }
+
+        // Get the region
         $region = $this->regionFactory->getById($regionId);
+
+        // Check the token allows access to this layout.
+        if (!$token->isPermittedFor('layout') || !$token->isIdentifiedBy($region->layoutId)) {
+            throw new AccessDeniedException();
+        }
+
+        // Get the other objects
         $widget = $this->widgetFactory->loadByWidgetId($id);
         $module = $this->moduleFactory->getByType($widget->type);
 

--- a/lib/Controller/Widget.php
+++ b/lib/Controller/Widget.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2025 Xibo Signage Ltd
+ * Copyright (C) 2026 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -1112,10 +1112,6 @@ class Widget extends Base
      */
     public function getData(Request $request, Response $response, $regionId, $id)
     {
-        if ($request->getAttribute('authedViaToken') !== true) {
-            throw new AccessDeniedException();
-        }
-
         /** @var \Lcobucci\JWT\Token $token */
         $token = $request->getAttribute('authedToken');
         if (empty($token)) {
@@ -1340,10 +1336,6 @@ class Widget extends Base
     public function getResource(Request $request, Response $response, $regionId, $id)
     {
         $this->setNoOutput();
-
-        if ($request->getAttribute('authedViaToken') !== true) {
-            throw new AccessDeniedException();
-        }
 
         /** @var \Lcobucci\JWT\Token $token */
         $token = $request->getAttribute('authedToken');

--- a/lib/Controller/Widget.php
+++ b/lib/Controller/Widget.php
@@ -1410,12 +1410,11 @@ class Widget extends Base
                     $region,
                     $resource,
                     function (string $route, array $data, array $params = []) use ($request, $encryptionKey, $token) {
-                        if ($route === 'layout.preview.bundle' || $route === 'module.asset.download') {
+                        if ($route === 'layout.preview.bundle'
+                            || $route === 'module.asset.download'
+                            || $route === 'module.getData'
+                        ) {
                             return $this->urlFor($request, $route, $data, $params);
-                        } else if ($route === 'module.getData') {
-                            // TODO: once XLR has been modified to include the JWT in the header, this should be moved
-                            //  up to the condition above.
-                            return $this->urlFor($request, $route, $data, $params) . '?jwt=' . $token->toString();
                         } else {
                             return TokenAuthMiddleware::sign(
                                 $request,

--- a/lib/Controller/Widget.php
+++ b/lib/Controller/Widget.php
@@ -1410,8 +1410,12 @@ class Widget extends Base
                     $region,
                     $resource,
                     function (string $route, array $data, array $params = []) use ($request, $encryptionKey, $token) {
-                        if ($route === 'layout.preview.bundle' || $route === 'module.getData') {
+                        if ($route === 'layout.preview.bundle' || $route === 'module.asset.download') {
                             return $this->urlFor($request, $route, $data, $params);
+                        } else if ($route === 'module.getData') {
+                            // TODO: once XLR has been modified to include the JWT in the header, this should be moved
+                            //  up to the condition above.
+                            return $this->urlFor($request, $route, $data, $params) . '?jwt=' . $token->toString();
                         } else {
                             return TokenAuthMiddleware::sign(
                                 $request,

--- a/lib/Dependencies/Controllers.php
+++ b/lib/Dependencies/Controllers.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2024 Xibo Signage Ltd
+ * Copyright (C) 2025 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -253,6 +253,7 @@ class Controllers
                     $c->get('widgetFactory'),
                     $c->get('widgetDataFactory'),
                     $c->get('playlistFactory'),
+                    $c->get('jwtService'),
                 );
                 $controller->useBaseDependenciesService($c->get('ControllerBaseDependenciesService'));
                 return $controller;
@@ -429,7 +430,8 @@ class Controllers
                     $c->get('widgetFactory'),
                     $c->get('transitionFactory'),
                     $c->get('moduleFactory'),
-                    $c->get('layoutFactory')
+                    $c->get('layoutFactory'),
+                    $c->get('jwtService'),
                 );
                 $controller->useBaseDependenciesService($c->get('ControllerBaseDependenciesService'));
                 return $controller;

--- a/lib/Dependencies/Controllers.php
+++ b/lib/Dependencies/Controllers.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2025 Xibo Signage Ltd
+ * Copyright (C) 2026 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -73,7 +73,8 @@ class Controllers
                     $c->get('layoutFactory'),
                     $c->get('tagFactory'),
                     $c->get('folderFactory'),
-                    $c->get('displayGroupFactory')
+                    $c->get('displayGroupFactory'),
+                    $c->get('jwtService'),
                 );
                 $controller->useBaseDependenciesService($c->get('ControllerBaseDependenciesService'));
                 return $controller;

--- a/lib/Dependencies/Controllers.php
+++ b/lib/Dependencies/Controllers.php
@@ -411,7 +411,8 @@ class Controllers
             },
             '\Xibo\Controller\Preview' => function (ContainerInterface $c) {
                 $controller = new \Xibo\Controller\Preview(
-                    $c->get('layoutFactory')
+                    $c->get('layoutFactory'),
+                    $c->get('jwtService'),
                 );
                 $controller->useBaseDependenciesService($c->get('ControllerBaseDependenciesService'));
                 return $controller;

--- a/lib/Factory/ContainerFactory.php
+++ b/lib/Factory/ContainerFactory.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2023 Xibo Signage Ltd
+ * Copyright (C) 2025 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -95,6 +95,7 @@ class ContainerFactory
                 $basePath = str_replace('/api', '', $basePath);
                 $basePath = str_replace('/maintenance', '', $basePath);
                 $basePath = str_replace('/install', '', $basePath);
+                $basePath = str_replace('/preview', '', $basePath);
 
                 // Handle an empty (we always have our root with reference to `/`
                 if ($basePath == null) {

--- a/lib/Factory/ModuleTemplateFactory.php
+++ b/lib/Factory/ModuleTemplateFactory.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2024 Xibo Signage Ltd
+ * Copyright (C) 2026 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -231,7 +231,7 @@ class ModuleTemplateFactory extends BaseFactory
             if ($includeUserTemplates) {
                 $this->templates = array_merge(
                     $this->templates,
-                    $this->loadUserTemplates()
+                    $this->loadUserTemplates([], [], true)
                 );
             }
         }
@@ -264,8 +264,9 @@ class ModuleTemplateFactory extends BaseFactory
     /**
      * Load user templates from the database.
      * @return ModuleTemplate[]
+     * @throws \Xibo\Support\Exception\NotFoundException
      */
-    public function loadUserTemplates($sortOrder = [], $filterBy = []): array
+    public function loadUserTemplates($sortOrder = [], $filterBy = [], $disableUserCheck = false): array
     {
         $this->getLog()->debug('load: Loading user templates');
 
@@ -290,6 +291,8 @@ class ModuleTemplateFactory extends BaseFactory
                             AND view = 1
                 ) AS groupsWithPermissions';
 
+        $params['permissionEntityGroups'] = 'Xibo\\Entity\\ModuleTemplate';
+
         $body = ' FROM `module_templates`
                 WHERE 1 = 1 ';
 
@@ -308,16 +311,16 @@ class ModuleTemplateFactory extends BaseFactory
             $params['dataType'] = $filter->getString('dataType') ;
         }
 
-        $params['permissionEntityGroups'] = 'Xibo\\Entity\\ModuleTemplate';
-
-        $this->viewPermissionSql(
-            'Xibo\Entity\ModuleTemplate',
-            $body,
-            $params,
-            'module_templates.id',
-            'module_templates.ownerId',
-            $filterBy,
-        );
+        if (!$disableUserCheck) {
+            $this->viewPermissionSql(
+                'Xibo\Entity\ModuleTemplate',
+                $body,
+                $params,
+                'module_templates.id',
+                'module_templates.ownerId',
+                $filterBy,
+            );
+        }
 
         $order = '';
         if (is_array($sortOrder) && !empty($sortOrder)) {

--- a/lib/Helper/HttpsDetect.php
+++ b/lib/Helper/HttpsDetect.php
@@ -23,7 +23,7 @@
 
 namespace Xibo\Helper;
 
-use Slim\Http\ServerRequest;
+use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * Class HttpsDetect
@@ -60,10 +60,10 @@ class HttpsDetect
     /**
      * Get the base URL for the instance
      *  this should give us the CMS URL including alias and file
-     * @param \Slim\Http\ServerRequest|null $request
+     * @param \Psr\Http\Message\ServerRequestInterface|null $request
      * @return string
      */
-    public function getBaseUrl(?ServerRequest $request = null): string
+    public function getBaseUrl(?ServerRequestInterface $request = null): string
     {
         // Check REQUEST_URI is set. IIS doesn't set it, so we need to build it
         // Attribution:

--- a/lib/Middleware/CorsPreviewMiddleware.php
+++ b/lib/Middleware/CorsPreviewMiddleware.php
@@ -34,7 +34,7 @@ class CorsPreviewMiddleware implements MiddlewareInterface
 {
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        $response = $handler->handle($request);
+        $response = $handler->handle($request->withAttribute('_entryPoint', 'preview'));
 
         // Is CORS required?
         if ($request->getHeaderLine('Sec-Fetch-Site') === 'cross-site') {

--- a/lib/Middleware/CorsPreviewMiddleware.php
+++ b/lib/Middleware/CorsPreviewMiddleware.php
@@ -1,0 +1,53 @@
+<?php
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Xibo\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * CORS middleware for preview.
+ */
+class CorsPreviewMiddleware implements MiddlewareInterface
+{
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $response = $handler->handle($request);
+
+        // Is CORS required?
+        if ($request->getHeaderLine('Sec-Fetch-Site') === 'cross-site') {
+            // Handle CORS headers
+            $response = $response
+                ->withHeader('Access-Control-Allow-Origin', '*')
+                ->withHeader('Access-Control-Allow-Methods', 'GET, OPTIONS')
+                ->withHeader(
+                    'Access-Control-Allow-Headers',
+                    'Content-Type, X-Requested-With, Accept, Origin, X-PREVIEW-JWT'
+                );
+        }
+
+        return $response;
+    }
+}

--- a/lib/Middleware/Theme.php
+++ b/lib/Middleware/Theme.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2024 Xibo Signage Ltd
+ * Copyright (C) 2025 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -117,17 +117,19 @@ class Theme implements Middleware
         $route = $routeContext->getRoute();
 
         // Resolve the current route name
-        $routeName = ($route == null) ? 'notfound' : $route->getName();
-        $view['baseUrl'] = $routeParser->urlFor('home');
+        if ($request->getAttribute('_entryPoint') === 'web') {
+            $routeName = ($route == null) ? 'notfound' : $route->getName();
+            $view['baseUrl'] = $routeParser->urlFor('home');
 
-        try {
-            $logoutRoute = empty($container->get('logoutRoute')) ? 'logout' : $container->get('logoutRoute');
-            $view['logoutUrl'] = $routeParser->urlFor($logoutRoute);
-        } catch (\Exception $e) {
-            $view['logoutUrl'] = $routeParser->urlFor('logout');
+            try {
+                $logoutRoute = empty($container->get('logoutRoute')) ? 'logout' : $container->get('logoutRoute');
+                $view['logoutUrl'] = $routeParser->urlFor($logoutRoute);
+            } catch (\Exception) {
+                $view['logoutUrl'] = $routeParser->urlFor('logout');
+            }
+            $view['route'] = $routeName;
         }
 
-        $view['route'] = $routeName;
         $view['theme'] = $container->get('configService');
         $view['settings'] = $settings;
         $view['helpService'] = $container->get('helpService');

--- a/lib/Middleware/TokenAuthMiddleware.php
+++ b/lib/Middleware/TokenAuthMiddleware.php
@@ -119,10 +119,8 @@ class TokenAuthMiddleware implements MiddlewareInterface
             throw new NotFoundException();
         }
 
-        // Add a CORS header
-        return $handler->handle($request
-            ->withAttribute('_entryPoint', 'preview')
-            ->withHeader('Access-Control-Allow-Origin', '*'));
+        // Handled
+        return $handler->handle($request);
     }
 
     /**

--- a/lib/Middleware/TokenAuthMiddleware.php
+++ b/lib/Middleware/TokenAuthMiddleware.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2025 Xibo Signage Ltd
+ * Copyright (C) 2026 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -83,6 +83,9 @@ class TokenAuthMiddleware implements MiddlewareInterface
                 if (!$token->hasBeenIssuedBy('Preview')) {
                     throw new AccessDeniedException(__('Invalid URL'));
                 }
+
+                // We are authenticated via an auth token (e.g. whole resource access)
+                $request = $request->withAttribute('authedToken', $token);
             } catch (RequiredConstraintsViolated) {
                 throw new AccessDeniedException(__('Invalid'));
             }
@@ -108,16 +111,15 @@ class TokenAuthMiddleware implements MiddlewareInterface
             if ($signature !== $calculatedSignature) {
                 throw new AccessDeniedException(__('Invalid URL'));
             }
+
+            // We are authenticated via the token (e.g. single file access)
+            $request = $request->withAttribute('authedViaToken', true);
         }
 
-        // Authed via a token
-        $request = $request
-            ->withAttribute('_entryPoint', 'preview')
-            ->withAttribute('authedViaToken', true)
-            ->withAttribute('authedToken', $token ?? null);
-
         // Add a CORS header
-        return $handler->handle($request)->withHeader('Access-Control-Allow-Origin', '*');
+        return $handler->handle($request
+            ->withAttribute('_entryPoint', 'preview')
+            ->withHeader('Access-Control-Allow-Origin', '*'));
     }
 
     /**

--- a/lib/Middleware/TokenAuthMiddleware.php
+++ b/lib/Middleware/TokenAuthMiddleware.php
@@ -23,7 +23,6 @@
 namespace Xibo\Middleware;
 
 use Illuminate\Support\Str;
-use Lcobucci\JWT\Validation\RequiredConstraintsViolated;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -33,6 +32,7 @@ use Xibo\Helper\HttpsDetect;
 use Xibo\Helper\LinkSigner;
 use Xibo\Service\JwtServiceInterface;
 use Xibo\Support\Exception\AccessDeniedException;
+use Xibo\Support\Exception\NotFoundException;
 use Xibo\Support\Sanitizer\SanitizerInterface;
 
 /**
@@ -60,6 +60,7 @@ class TokenAuthMiddleware implements MiddlewareInterface
      * @throws \Psr\Container\ContainerExceptionInterface
      * @throws \Psr\Container\NotFoundExceptionInterface
      * @throws \Xibo\Support\Exception\AccessDeniedException
+     * @throws \Xibo\Support\Exception\NotFoundException
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
@@ -86,10 +87,10 @@ class TokenAuthMiddleware implements MiddlewareInterface
 
                 // We are authenticated via an auth token (e.g. whole resource access)
                 $request = $request->withAttribute('authedToken', $token);
-            } catch (RequiredConstraintsViolated) {
+            } catch (\Exception) {
                 throw new AccessDeniedException(__('Invalid'));
             }
-        } else {
+        } else if ($params->hasParam('X-Amz-Signature')) {
             // AMZ Link
             // Has the URL expired
             if (time() > $params->getInt('X-Amz-Expires')) {
@@ -114,6 +115,8 @@ class TokenAuthMiddleware implements MiddlewareInterface
 
             // We are authenticated via the token (e.g. single file access)
             $request = $request->withAttribute('authedViaToken', true);
+        } else {
+            throw new NotFoundException();
         }
 
         // Add a CORS header

--- a/lib/Middleware/TokenAuthMiddleware.php
+++ b/lib/Middleware/TokenAuthMiddleware.php
@@ -1,0 +1,137 @@
+<?php
+/*
+ * Copyright (C) 2025 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Xibo\Middleware;
+
+use Illuminate\Support\Str;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Xibo\Helper\HttpsDetect;
+use Xibo\Helper\LinkSigner;
+use Xibo\Support\Exception\AccessDeniedException;
+use Xibo\Support\Sanitizer\SanitizerInterface;
+
+/**
+ * Preview Auth Middleware
+ * -----------------------
+ * This middleware protects various routes in the Preview Entrypoint
+ * It ensures they have a valid link before rendering
+ */
+class TokenAuthMiddleware implements MiddlewareInterface
+{
+    private ?string $encryptionKey = null;
+
+    /**
+     * FeatureAuth constructor.
+     * @param ContainerInterface $container
+     */
+    public function __construct(private ContainerInterface $container)
+    {
+    }
+
+    /**
+     * @param \Psr\Http\Message\ServerRequestInterface $request
+     * @param \Psr\Http\Server\RequestHandlerInterface $handler
+     * @return \Psr\Http\Message\ResponseInterface
+     * @throws \Xibo\Support\Exception\AccessDeniedException
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        if ($this->encryptionKey == null) {
+            $this->encryptionKey = $this->container->get('configService')->getApiKeyDetails()['encryptionKey'];
+        }
+
+        // Check the link.
+        $params = $this->getSanitizer($request->getParams());
+
+        // Has the URL expired
+        if (time() > $params->getInt('X-Amz-Expires')) {
+            throw new AccessDeniedException(__('Expired'));
+        }
+
+        // Validate the URL.
+        $signature = $params->getString('X-Amz-Signature');
+
+        $calculatedSignature = \Xibo\Helper\LinkSigner::getSignature(
+            (new HttpsDetect())->getRootUrl(),
+            $request->getUri()->getPath(),
+            $params->getInt('X-Amz-Expires'),
+            $this->encryptionKey,
+            $params->getString('X-Amz-Date'),
+            true,
+        );
+
+        if ($signature !== $calculatedSignature) {
+            throw new AccessDeniedException(__('Invalid URL'));
+        }
+
+        // Authed via a token
+        $request = $request
+            ->withAttribute('_entryPoint', 'preview')
+            ->withAttribute('authedViaToken', true);
+
+        // Add a CORS header
+        return $handler->handle($request)->withHeader('Access-Control-Allow-Origin', '*');
+    }
+
+    /**
+     * Sign the given link with a signed URL
+     * @param \Psr\Http\Message\ServerRequestInterface $request
+     * @param string $url
+     * @param int $expiry
+     * @param string $encryptionKey
+     * @return string
+     */
+    public static function sign(
+        ServerRequestInterface $request,
+        string $url,
+        int $expiry,
+        string $encryptionKey
+    ): string {
+        $rootUrl = (new HttpsDetect())->getBaseUrl($request);
+
+        if ($request->getAttribute('_entryPoint') != 'web') {
+            $url = str_replace('/api/', '/', $url);
+        }
+
+        return $rootUrl . $url . (Str::contains($url, '?') ? '&' : '?') . LinkSigner::getSignature(
+            $rootUrl,
+            $url,
+            $expiry,
+            $encryptionKey,
+        );
+    }
+
+    /**
+     * @param $getParams
+     * @return \Xibo\Support\Sanitizer\SanitizerInterface
+     * @throws \Psr\Container\ContainerExceptionInterface
+     * @throws \Psr\Container\NotFoundExceptionInterface
+     */
+    private function getSanitizer($getParams): SanitizerInterface
+    {
+        return $this->container->get('sanitizerService')->getSanitizer($getParams);
+    }
+}

--- a/lib/Middleware/TokenAuthMiddleware.php
+++ b/lib/Middleware/TokenAuthMiddleware.php
@@ -23,6 +23,7 @@
 namespace Xibo\Middleware;
 
 use Illuminate\Support\Str;
+use Lcobucci\JWT\Validation\RequiredConstraintsViolated;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -30,6 +31,7 @@ use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Xibo\Helper\HttpsDetect;
 use Xibo\Helper\LinkSigner;
+use Xibo\Service\JwtServiceInterface;
 use Xibo\Support\Exception\AccessDeniedException;
 use Xibo\Support\Sanitizer\SanitizerInterface;
 
@@ -55,6 +57,8 @@ class TokenAuthMiddleware implements MiddlewareInterface
      * @param \Psr\Http\Message\ServerRequestInterface $request
      * @param \Psr\Http\Server\RequestHandlerInterface $handler
      * @return \Psr\Http\Message\ResponseInterface
+     * @throws \Psr\Container\ContainerExceptionInterface
+     * @throws \Psr\Container\NotFoundExceptionInterface
      * @throws \Xibo\Support\Exception\AccessDeniedException
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
@@ -66,31 +70,51 @@ class TokenAuthMiddleware implements MiddlewareInterface
         // Check the link.
         $params = $this->getSanitizer($request->getParams());
 
-        // Has the URL expired
-        if (time() > $params->getInt('X-Amz-Expires')) {
-            throw new AccessDeniedException(__('Expired'));
-        }
+        // Are we a JWT?
+        $previewToken = $request->getHeader('X-PREVIEW-JWT')[0] ?? null;
+        $jwt = $params->getString('jwt', ['default' => $previewToken]);
+        if (!empty($jwt)) {
+            // Yes, validate the JWT
+            try {
+                // Parse the token and assert its valid
+                $token = $this->getJwtService()->validateJwt($jwt);
 
-        // Validate the URL.
-        $signature = $params->getString('X-Amz-Signature');
+                // Check claims.
+                if (!$token->hasBeenIssuedBy('Preview')) {
+                    throw new AccessDeniedException(__('Invalid URL'));
+                }
+            } catch (RequiredConstraintsViolated) {
+                throw new AccessDeniedException(__('Invalid'));
+            }
+        } else {
+            // AMZ Link
+            // Has the URL expired
+            if (time() > $params->getInt('X-Amz-Expires')) {
+                throw new AccessDeniedException(__('Expired'));
+            }
 
-        $calculatedSignature = \Xibo\Helper\LinkSigner::getSignature(
-            (new HttpsDetect())->getRootUrl(),
-            $request->getUri()->getPath(),
-            $params->getInt('X-Amz-Expires'),
-            $this->encryptionKey,
-            $params->getString('X-Amz-Date'),
-            true,
-        );
+            // Validate the URL.
+            $signature = $params->getString('X-Amz-Signature');
 
-        if ($signature !== $calculatedSignature) {
-            throw new AccessDeniedException(__('Invalid URL'));
+            $calculatedSignature = \Xibo\Helper\LinkSigner::getSignature(
+                (new HttpsDetect())->getRootUrl(),
+                $request->getUri()->getPath(),
+                $params->getInt('X-Amz-Expires'),
+                $this->encryptionKey,
+                $params->getString('X-Amz-Date'),
+                true,
+            );
+
+            if ($signature !== $calculatedSignature) {
+                throw new AccessDeniedException(__('Invalid URL'));
+            }
         }
 
         // Authed via a token
         $request = $request
             ->withAttribute('_entryPoint', 'preview')
-            ->withAttribute('authedViaToken', true);
+            ->withAttribute('authedViaToken', true)
+            ->withAttribute('authedToken', $token ?? null);
 
         // Add a CORS header
         return $handler->handle($request)->withHeader('Access-Control-Allow-Origin', '*');
@@ -133,5 +157,15 @@ class TokenAuthMiddleware implements MiddlewareInterface
     private function getSanitizer($getParams): SanitizerInterface
     {
         return $this->container->get('sanitizerService')->getSanitizer($getParams);
+    }
+
+    /**
+     * @return \Xibo\Service\JwtServiceInterface
+     * @throws \Psr\Container\ContainerExceptionInterface
+     * @throws \Psr\Container\NotFoundExceptionInterface
+     */
+    private function getJwtService(): JwtServiceInterface
+    {
+        return $this->container->get('jwtService');
     }
 }

--- a/lib/Widget/Render/WidgetHtmlRenderer.php
+++ b/lib/Widget/Render/WidgetHtmlRenderer.php
@@ -108,6 +108,7 @@ class WidgetHtmlRenderer
      * @param \Xibo\Entity\Widget $widget
      * @param \Xibo\Support\Sanitizer\SanitizerInterface $params
      * @param string $downloadUrl
+     * @param string $previewUrl
      * @param array $additionalContexts An array of additional key/value contexts for the templates
      * @return string
      * @throws \Twig\Error\LoaderError
@@ -119,6 +120,7 @@ class WidgetHtmlRenderer
         Region $region,
         Widget $widget,
         SanitizerInterface $params,
+        string $previewUrl,
         string $downloadUrl,
         array $additionalContexts = []
     ): string {
@@ -151,6 +153,7 @@ class WidgetHtmlRenderer
                     'module-html-preview.twig',
                     array_merge(
                         [
+                            'previewIframeSrc' => $previewUrl,
                             'width' => $width,
                             'height' => $height,
                             'regionId' => $region->regionId,

--- a/lib/Widget/Render/WidgetHtmlRenderer.php
+++ b/lib/Widget/Render/WidgetHtmlRenderer.php
@@ -313,23 +313,26 @@ class WidgetHtmlRenderer
                 if (Str::startsWith($match, 'mediaId')) {
                     $params['type'] = 'image';
                 }
+                $url = $urlFor('library.download', $params);
                 $output = str_replace(
                     '[[' . $match . ']]',
-                    $urlFor('library.download', $params) . '&preview=1',
+                    $url . (Str::contains($url, '?') ? '&' : '?') . 'preview=1',
                     $output
                 );
             } else if (Str::startsWith($match, 'assetId')) {
                 $value = explode('=', $match);
+                $url = $urlFor('module.asset.download', ['assetId' => $value[1]]);
                 $output = str_replace(
                     '[[' . $match . ']]',
-                    $urlFor('module.asset.download', ['assetId' => $value[1]]) . '&preview=1',
+                    $url . (Str::contains($url, '?') ? '&' : '?') . 'preview=1',
                     $output
                 );
             } else if (Str::startsWith($match, 'assetAlias')) {
                 $value = explode('=', $match);
+                $url = $urlFor('module.asset.download', ['assetId' => $value[1]]);
                 $output = str_replace(
                     '[[' . $match . ']]',
-                    $urlFor('module.asset.download', ['assetId' => $value[1]]) . '&preview=1&isAlias=1',
+                    $url . (Str::contains($url, '?') ? '&' : '?') . 'preview=1&isAlias=1',
                     $output
                 );
             }

--- a/lib/Widget/Render/WidgetHtmlRenderer.php
+++ b/lib/Widget/Render/WidgetHtmlRenderer.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2025 Xibo Signage Ltd
+ * Copyright (C) 2026 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -315,21 +315,21 @@ class WidgetHtmlRenderer
                 }
                 $output = str_replace(
                     '[[' . $match . ']]',
-                    $urlFor('library.download', $params) . '?preview=1',
+                    $urlFor('library.download', $params) . '&preview=1',
                     $output
                 );
             } else if (Str::startsWith($match, 'assetId')) {
                 $value = explode('=', $match);
                 $output = str_replace(
                     '[[' . $match . ']]',
-                    $urlFor('module.asset.download', ['assetId' => $value[1]]) . '?preview=1',
+                    $urlFor('module.asset.download', ['assetId' => $value[1]]) . '&preview=1',
                     $output
                 );
             } else if (Str::startsWith($match, 'assetAlias')) {
                 $value = explode('=', $match);
                 $output = str_replace(
                     '[[' . $match . ']]',
-                    $urlFor('module.asset.download', ['assetId' => $value[1]]) . '?preview=1&isAlias=1',
+                    $urlFor('module.asset.download', ['assetId' => $value[1]]) . '&preview=1&isAlias=1',
                     $output
                 );
             }

--- a/lib/routes-web.php
+++ b/lib/routes-web.php
@@ -137,13 +137,7 @@ $app->group('', function(\Slim\Routing\RouteCollectorProxy $group) {
     $group->get('/layout/xlf/{id}', ['\Xibo\Controller\Preview', 'getXlf'])->setName('layout.getXlf');
     $group->get('/layout/background/{id}', ['\Xibo\Controller\Layout', 'downloadBackground'])->setName('layout.download.background');
     $group->get('/layout/thumbnail/{id}', ['\Xibo\Controller\Layout', 'downloadThumbnail'])->setName('layout.download.thumbnail');
-    $group->get('/layout/playerBundle', ['\Xibo\Controller\Preview', 'playerBundle'])->setName('layout.preview.bundle');
-    $group->get('/connector/widget/preview', ['\Xibo\Controller\Connector', 'connectorPreview'])->setName('layout.preview.connector');
 })->addMiddleware(new FeatureAuth($app->getContainer(), ['layout.view', 'template.view']));
-
-$app->get('/layout/preview/{id}', ['\Xibo\Controller\Preview', 'show'])
-    ->addMiddleware(new FeatureAuth($app->getContainer(), ['layout.view', 'template.view', 'campaign.view']))
-    ->setName('layout.preview');
 
 // forms
 $app->get('/layout/form/add', ['\Xibo\Controller\Layout','addForm'])
@@ -189,15 +183,6 @@ $app->group('', function(\Slim\Routing\RouteCollectorProxy $group) {
 
     // Designer
     $group->get('/playlist/form/library/assign/{id}', ['\Xibo\Controller\Playlist','libraryAssignForm'])->setName('playlist.library.assign.form');
-
-    // Outputs
-    $group->get('/playlist/widget/resource/{regionId}[/{id}]', [
-        '\Xibo\Controller\Widget', 'getResource'
-    ])->setName('module.getResource');
-
-    $group->get('/playlist/widget/data/{regionId}/{id}', [
-        '\Xibo\Controller\Widget', 'getData'
-    ])->setName('module.getData');
 })->addMiddleware(new FeatureAuth($app->getContainer(), ['layout.modify']));
 
 $app->group('', function (\Slim\Routing\RouteCollectorProxy $group) {
@@ -574,6 +559,9 @@ $app->group('', function (\Slim\Routing\RouteCollectorProxy $group) {
     $group->get('/module/form/settings/{id}', ['\Xibo\Controller\Module','settingsForm'])
         ->setName('module.settings.form');
 })->addMiddleware(new FeatureAuth($app->getContainer(), ['module.view']));
+
+$app->get('/module/asset/{assetId}', ['\Xibo\Controller\Module', 'assetDownload'])
+    ->setName('module.asset.download');
 
 //
 // Developer

--- a/lib/routes.php
+++ b/lib/routes.php
@@ -350,8 +350,6 @@ $app->group('', function (RouteCollectorProxy $group) {
 
 $app->get('/library/download/{id}', ['\Xibo\Controller\Library', 'download'])->setName('library.download');
 $app->get('/library/thumbnail/{id}', ['\Xibo\Controller\Library', 'thumbnail'])->setName('library.thumbnail');
-$app->get('/public/thumbnail/{id}', ['\Xibo\Controller\Library', 'thumbnailPublic'])
-    ->setName('library.public.thumbnail');
 
 $app->post('/library', ['\Xibo\Controller\Library','add'])->setName('library.add')
     ->addMiddleware(new \Xibo\Middleware\FeatureAuth($app->getContainer(), ['library.add', 'dashboard.playlist']));
@@ -652,11 +650,6 @@ $app->get('/module', ['\Xibo\Controller\Module','grid'])->setName('module.search
 $app->get('/module/templates/{dataType}', [
     '\Xibo\Controller\Module', 'templateGrid'
 ])->setName('module.template.search');
-
-$app->get('/module/asset/{assetId}', [
-    '\Xibo\Controller\Module',
-    'assetDownload',
-])->setName('module.asset.download');
 
 // Properties
 $app->get('/module/properties/{id}', ['\Xibo\Controller\Module','getProperties'])

--- a/modules/forecastio.xml
+++ b/modules/forecastio.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (C) 2024 Xibo Signage Ltd
+  ~ Copyright (C) 2026 Xibo Signage Ltd
   ~
   ~ Xibo - Digital Signage - https://xibosignage.com
   ~
@@ -106,6 +106,11 @@ if (properties.lang !== null && String(properties.lang).length > 0) {
     moment.locale(properties.lang);
 } else {
     moment.locale(globalOptions.locale);
+}
+
+// Drop out if no items
+if (items.length <= 0) {
+    return;
 }
 
 // Make replacements [] with target data

--- a/modules/layout-renderer.twig
+++ b/modules/layout-renderer.twig
@@ -52,7 +52,7 @@
             {% endautoescape %}
 
             {% set layoutObj = [{layoutId: layout.layoutId }] %}
-            {% set xlrOptions = previewOptions|merge({inPreview: true, previewJwt: previewJwt}) %}
+            {% set xlrOptions = previewOptions|merge({inPreview: true, previewJwt: previewJwt, platform: "CMS"}) %}
             (function($){
                 $(document).ready(function(){
                     var xiboLayoutRenderer = new XiboLayoutRenderer({{ layoutObj|json_encode()|raw }}, [], {{ xlrOptions|json_encode()|raw }});

--- a/modules/layout-renderer.twig
+++ b/modules/layout-renderer.twig
@@ -36,7 +36,6 @@
         {# Import JS bundle from dist #}
         <script src="{{ theme.rootUri() }}dist/preview.bundle.min.js?v={{ version }}&rev={{revision}}" nonce="{{ cspNonce }}"></script>
         <script type="text/javascript" nonce="{{ cspNonce }}">
-
             var previewTranslations = {};
             // Translations we want always available
             {% autoescape "js" %}
@@ -53,7 +52,7 @@
             {% endautoescape %}
 
             {% set layoutObj = [{layoutId: layout.layoutId }] %}
-            {% set xlrOptions = previewOptions|merge({inPreview: true}) %}
+            {% set xlrOptions = previewOptions|merge({inPreview: true, previewJwt: previewJwt}) %}
             (function($){
                 $(document).ready(function(){
                     var xiboLayoutRenderer = new XiboLayoutRenderer({{ layoutObj|json_encode()|raw }}, [], {{ xlrOptions|json_encode()|raw }});

--- a/modules/src/editor-render.js
+++ b/modules/src/editor-render.js
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) 2022 Xibo Signage Ltd
+ * Copyright (C) 2025 Xibo Signage Ltd
  *
- * Xibo - Digital Signage - http://www.xibo.org.uk
+ * Xibo - Digital Signage - https://xibosignage.com
  *
  * This file is part of Xibo.
  *
@@ -51,4 +51,7 @@ $(function() {
       }
     }
   };
+
+  // Post a message to say we're loaded
+  window.parent.postMessage({type: 'loaded'}, '*');
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@mapbox/leaflet-pip": "^1.1.0",
         "@popperjs/core": "^2.11.8",
         "@ssddanbrown/codemirror-lang-twig": "^1.0.0",
-        "@xibosignage/xibo-layout-renderer": "git+https://github.com/xibosignage/xibo-layout-renderer.git#6e7a3dbc3a500d64662665b2dc360c81bce70b2d",
+        "@xibosignage/xibo-layout-renderer": "git+https://github.com/xibosignage/xibo-layout-renderer.git#489fa304f64fcd461f4b35549bc5ccf741d9f6af",
         "@xiechao/codemirror-lang-handlebars": "^1.0.4",
         "ajax-bootstrap-select": "^1.4.5",
         "blueimp-file-upload": "^10.32.0",
@@ -77,7 +77,7 @@
         "selecto": "^1.26.3",
         "toastr": "~2.1.4",
         "underscore": "^1.13.7",
-        "xibo-interactive-control": "git+https://github.com/xibosignage/xibo-interactive-control.git#44ad744a5a2a0af9e7fcdb828dbdbeff45cc40f0"
+        "xibo-interactive-control": "git+https://github.com/xibosignage/xibo-interactive-control.git#675ce4ac297625d7d94d4b867002693a234f4e84"
       },
       "devDependencies": {
         "@babel/core": "^7.24.9",
@@ -3432,8 +3432,8 @@
     },
     "node_modules/@xibosignage/xibo-layout-renderer": {
       "version": "1.0.21",
-      "resolved": "git+ssh://git@github.com/xibosignage/xibo-layout-renderer.git#6e7a3dbc3a500d64662665b2dc360c81bce70b2d",
-      "integrity": "sha512-HVsoRagigH8qXok8HLZ9Lx+kFuiOXdnNch/8SehkPJP7Y42QHL9tDp20wYqILR1bxbQjUsVk8/OQK0N/u0gecw==",
+      "resolved": "git+ssh://git@github.com/xibosignage/xibo-layout-renderer.git#489fa304f64fcd461f4b35549bc5ccf741d9f6af",
+      "integrity": "sha512-4V6l1UIwW5Z1o3Js0qGar51ACoRlEuKJPab4SImux+v8sJmrHVvQoxgYT3vJ6buKVmT4LFOTIg/IoOKfec3+qQ==",
       "license": "LGPL-3.0",
       "dependencies": {
         "@types/xml2js": "^0.4.14",
@@ -10451,8 +10451,8 @@
     },
     "node_modules/xibo-interactive-control": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/xibosignage/xibo-interactive-control.git#44ad744a5a2a0af9e7fcdb828dbdbeff45cc40f0",
-      "integrity": "sha512-FHyrngjuc2SFxTmB6gQ/Hp7w5hXtoh0kyDNNltlZ2C9x+q1uX1+VWbEO8P7LEQmx/uf8PNM7QoSi0JwfZeTwkA==",
+      "resolved": "git+ssh://git@github.com/xibosignage/xibo-interactive-control.git#675ce4ac297625d7d94d4b867002693a234f4e84",
+      "integrity": "sha512-8Jp/XK46vg2veVH7E7SzcBhfth5fCTBG90DG3wzBRXwuFLHLmOdFqLrfcg0VO+9X+33IlyVA2pdaKfvp2QPqjA==",
       "license": "AGPL-3.0"
     },
     "node_modules/xml2js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@mapbox/leaflet-pip": "^1.1.0",
         "@popperjs/core": "^2.11.8",
         "@ssddanbrown/codemirror-lang-twig": "^1.0.0",
-        "@xibosignage/xibo-layout-renderer": "^1.0.21",
+        "@xibosignage/xibo-layout-renderer": "git+https://github.com/xibosignage/xibo-layout-renderer.git#6e7a3dbc3a500d64662665b2dc360c81bce70b2d",
         "@xiechao/codemirror-lang-handlebars": "^1.0.4",
         "ajax-bootstrap-select": "^1.4.5",
         "blueimp-file-upload": "^10.32.0",
@@ -3432,8 +3432,8 @@
     },
     "node_modules/@xibosignage/xibo-layout-renderer": {
       "version": "1.0.21",
-      "resolved": "https://registry.npmjs.org/@xibosignage/xibo-layout-renderer/-/xibo-layout-renderer-1.0.21.tgz",
-      "integrity": "sha512-+GEC8cwfOPXkLiNFKO9MgkuARr224gxU7DsETyc8S8dmPdjWoTCdlAOpGJooEfbew2+i+RLbHj9BWfYRimYR9w==",
+      "resolved": "git+ssh://git@github.com/xibosignage/xibo-layout-renderer.git#6e7a3dbc3a500d64662665b2dc360c81bce70b2d",
+      "integrity": "sha512-HVsoRagigH8qXok8HLZ9Lx+kFuiOXdnNch/8SehkPJP7Y42QHL9tDp20wYqILR1bxbQjUsVk8/OQK0N/u0gecw==",
       "license": "LGPL-3.0",
       "dependencies": {
         "@types/xml2js": "^0.4.14",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@mapbox/leaflet-pip": "^1.1.0",
     "@popperjs/core": "^2.11.8",
     "@ssddanbrown/codemirror-lang-twig": "^1.0.0",
-    "@xibosignage/xibo-layout-renderer": "^1.0.21",
+    "@xibosignage/xibo-layout-renderer": "git+https://github.com/xibosignage/xibo-layout-renderer.git#6e7a3dbc3a500d64662665b2dc360c81bce70b2d",
     "@xiechao/codemirror-lang-handlebars": "^1.0.4",
     "ajax-bootstrap-select": "^1.4.5",
     "blueimp-file-upload": "^10.32.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@mapbox/leaflet-pip": "^1.1.0",
     "@popperjs/core": "^2.11.8",
     "@ssddanbrown/codemirror-lang-twig": "^1.0.0",
-    "@xibosignage/xibo-layout-renderer": "git+https://github.com/xibosignage/xibo-layout-renderer.git#6e7a3dbc3a500d64662665b2dc360c81bce70b2d",
+    "@xibosignage/xibo-layout-renderer": "git+https://github.com/xibosignage/xibo-layout-renderer.git#489fa304f64fcd461f4b35549bc5ccf741d9f6af",
     "@xiechao/codemirror-lang-handlebars": "^1.0.4",
     "ajax-bootstrap-select": "^1.4.5",
     "blueimp-file-upload": "^10.32.0",
@@ -128,6 +128,6 @@
     "selecto": "^1.26.3",
     "toastr": "~2.1.4",
     "underscore": "^1.13.7",
-    "xibo-interactive-control": "git+https://github.com/xibosignage/xibo-interactive-control.git#44ad744a5a2a0af9e7fcdb828dbdbeff45cc40f0"
+    "xibo-interactive-control": "git+https://github.com/xibosignage/xibo-interactive-control.git#675ce4ac297625d7d94d4b867002693a234f4e84"
   }
 }

--- a/ui/src/core/xibo-cms.js
+++ b/ui/src/core/xibo-cms.js
@@ -295,7 +295,7 @@ window.XiboInitialise = function(scope, options) {
   $(scope + ' .colorpicker-input:not(.colorpicker-form-element)')
     .each(function(_i, el) {
       $(el).colorpicker({
-        container: $(el).find('.picker-container')
+        container: $(el).find('.picker-container'),
       });
     });
 
@@ -1702,8 +1702,8 @@ window.XiboMultiSelectFormRender = function(button) {
         // so use the form open hook if one has been provided.
         formOpenCallback = $button.data().formCallback;
 
-      // If form needs confirmation
-      formConfirm = $button.data().formConfirm;
+        // If form needs confirmation
+        formConfirm = $button.data().formConfirm;
       }
     }
   });
@@ -2858,8 +2858,8 @@ window.createMiniLayoutPreview = function(previewUrl) {
   // Create base template for preview content
   const previewTemplate =
     Handlebars.compile(
-      '<iframe scrolling="no" sandbox="allow-scripts" src="{{url}}" width="{{width}}px" ' +
-      'height="{{height}}px" style="border:0;"></iframe>');
+      '<iframe scrolling="no" sandbox="allow-scripts" src="{{url}}" ' +
+      'width="{{width}}px height="{{height}}px" style="border:0;"></iframe>');
 
   // Clean all selected elements
   $layoutPreviewContent.html('');

--- a/ui/src/core/xibo-cms.js
+++ b/ui/src/core/xibo-cms.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Xibo Signage Ltd
+ * Copyright (C) 2025 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -2858,7 +2858,7 @@ window.createMiniLayoutPreview = function(previewUrl) {
   // Create base template for preview content
   const previewTemplate =
     Handlebars.compile(
-      '<iframe scrolling="no" src="{{url}}" width="{{width}}px" ' +
+      '<iframe scrolling="no" sandbox="allow-scripts" src="{{url}}" width="{{width}}px" ' +
       'height="{{height}}px" style="border:0;"></iframe>');
 
   // Clean all selected elements

--- a/ui/src/editor-core/widget.js
+++ b/ui/src/editor-core/widget.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Xibo Signage Ltd
+ * Copyright (C) 2025 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -1383,6 +1383,9 @@ Widget.prototype.getData = function() {
       url: requestPath,
       type: linkToAPI.type,
       dataType: 'json',
+      headers: {
+        'X-PREVIEW-JWT': previewJwt,
+      },
     }).done((data) => {
       // If we don't have data, show sample data
       if (!data.data) {

--- a/ui/src/layout-editor/viewer.js
+++ b/ui/src/layout-editor/viewer.js
@@ -3989,6 +3989,11 @@ Viewer.prototype.updateRegionContent = function(
     $iframe.off('load.viewerUpdate').on('load.viewerUpdate', function() {
       updateIframe($iframe);
     });
+
+    // Iframe was loaded already, always update
+    if ($iframe.data('notFirstCall')) {
+      updateIframe($iframe);
+    }
   }
 
   // Process image and video/playlist thumbs

--- a/ui/src/layout-editor/viewer.js
+++ b/ui/src/layout-editor/viewer.js
@@ -2606,6 +2606,7 @@ Viewer.prototype.playPreview = function(dimensions) {
     url: requestPath,
     width: dimensions.width,
     height: dimensions.height,
+    previewJwt: previewJwt,
   });
 
   // Clear temp data

--- a/ui/src/layout-editor/viewer.js
+++ b/ui/src/layout-editor/viewer.js
@@ -3918,10 +3918,18 @@ Viewer.prototype.updateRegionContent = function(
   changed = false,
 ) {
   const $container = this.DOMObject.find(`#${region.id}`);
+  const $iframe = $container.find('iframe');
+  let hasInitialized = false;
 
   // Update iframe
-  const updateIframe = function($iframe) {
-    $iframe.css({
+  const updateIframe = function($targetIframe) {
+    // Prevent double update
+    if (hasInitialized) {
+      return false;
+    }
+    hasInitialized = true;
+
+    $targetIframe.css({
       width: region.scaledDimensions.width,
       height: region.scaledDimensions.height,
     });
@@ -3935,29 +3943,51 @@ Viewer.prototype.updateRegionContent = function(
 
     // Check if it's the first call
     // If it is, send a flag to pause effects on start
-    if (!$iframe.data('notFirstCall')) {
-      $iframe.data('notFirstCall', true);
+    if (!$targetIframe.data('notFirstCall')) {
+      $targetIframe.data('notFirstCall', true);
       options.pauseEffectOnStart = true;
     }
 
     // We need to recalculate the scale inside of the iframe
-    $iframe[0].contentWindow
-      .postMessage({
-        method: 'renderContent',
-        options: options,
-      }, '*');
+    $targetIframe[0].contentWindow.postMessage({
+      method: 'renderContent',
+      options: options,
+    }, '*');
   };
-
-  // Get iframe
-  const $iframe = $container.find('iframe');
 
   // Check if iframe exists, and is loaded
   if ($iframe.length) {
-    // The iframe will message us when it is loaded.
-    window.addEventListener('message', function(event) {
-      if (event.data.type === 'loaded') {
+    const rawIframe = $iframe[0];
+
+    // Clean up previous listeners
+    if (rawIframe._loadedMessageHandler) {
+      window.removeEventListener('message', rawIframe._loadedMessageHandler);
+      rawIframe._loadedMessageHandler = null;
+    }
+
+
+    // Define the new message handler
+    const messageHandler = (event) => {
+      // Only accept messages from OUR iframe
+      if (
+        event.source === rawIframe.contentWindow &&
+        event.data.type === 'loaded'
+      ) {
+        // Cleanup handler
+        window.removeEventListener('message', messageHandler);
+        rawIframe._loadedMessageHandler = null;
+
         updateIframe($iframe);
       }
+    };
+
+    // Attach handler and store reference
+    rawIframe._loadedMessageHandler = messageHandler;
+    window.addEventListener('message', messageHandler);
+
+    // Fallback - if we missed the message event
+    $iframe.off('load.viewerUpdate').on('load.viewerUpdate', function() {
+      updateIframe($iframe);
     });
   }
 
@@ -3968,6 +3998,7 @@ Viewer.prototype.updateRegionContent = function(
       '[data-type="widget_video"], ' +
       '[data-type="playlist"]',
     );
+
   if ($imageContainer.length) {
     const $image = $imageContainer.find('img');
 

--- a/ui/src/layout-editor/viewer.js
+++ b/ui/src/layout-editor/viewer.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Xibo Signage Ltd
+ * Copyright (C) 2025 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -3952,18 +3952,12 @@ Viewer.prototype.updateRegionContent = function(
 
   // Check if iframe exists, and is loaded
   if ($iframe.length) {
-    // If iframe globalOptions are not loaded
-    // wait for the iframe to load
-    if (!$iframe[0].contentWindow.window.globalOptions) {
-      // Wait for the iframe to load and update it
-      $iframe[0].onload = function() {
-        $iframe.data('notFirstCall', true);
+    // The iframe will message us when it is loaded.
+    window.addEventListener('message', function(event) {
+      if (event.data.type === 'loaded') {
         updateIframe($iframe);
-      };
-    } else {
-      // Update iframe
-      updateIframe($iframe);
-    }
+      }
+    });
   }
 
   // Process image and video/playlist thumbs

--- a/ui/src/templates/viewer-layout-preview.hbs
+++ b/ui/src/templates/viewer-layout-preview.hbs
@@ -1,4 +1,5 @@
-<iframe scrolling="no" 
+<iframe scrolling="no"
+    sandbox="allow-scripts"
     src="{{url}}" 
     width="{{width}}px" 
     height="{{height}}px" 

--- a/ui/src/templates/viewer-layout-preview.hbs
+++ b/ui/src/templates/viewer-layout-preview.hbs
@@ -1,6 +1,6 @@
 <iframe scrolling="no"
     sandbox="allow-scripts"
-    src="{{url}}" 
+    src="{{url}}?jwt={{previewJwt}}"
     width="{{width}}px" 
     height="{{height}}px" 
     style="border:0;">

--- a/views/campaign-preview.twig
+++ b/views/campaign-preview.twig
@@ -1,6 +1,6 @@
 {#
 /**
- * Copyright (C) 2020 Xibo Signage Ltd
+ * Copyright (C) 2026 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - http://www.xibo.org.uk
  *
@@ -42,9 +42,15 @@
                         <div class="row">
                             <div class="col-sm-12">
                                 <div class="embed-responsive embed-responsive-4by3">
-                                    <div class="embed-responsive-item preview-container"
-                                         data-url="{{ url_for('layout.preview', { "id": extendedLayout.layout.layoutId }) }}">
-                                        <div id="preview_canvas_container_{{extendedLayout.layout.layoutId}}" style="width: 100%; height: 100%;"></div>
+                                    <div class="embed-responsive-item preview-container">
+                                        <div id="preview_canvas_container_{{extendedLayout.layout.layoutId}}" style="width: 100%; height: 100%;">
+                                            <iframe sandbox="allow-scripts" frameborder="0"
+                                                    id="player_frame_{{extendedLayout.layout.layoutId}}"
+                                                    src="{{ extendedLayout.previewUrl }}?jwt={{ extendedLayout.previewJwt }}"
+                                                    style="position: absolute; top: 0; left: 0; pointer-events: unset"
+                                                >
+                                            </iframe>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
@@ -56,7 +62,7 @@
                                 <small>{% trans "duration" %}:</small> {{ extendedLayout.duration|datehms }}<br/>
                             </div>
                             <div class="col-sm-4">
-                                <a class="btn btn-white" href="{{ url_for("layout.preview", {id: extendedLayout.layout.layoutId}) }}" target="_blank">
+                                <a class="btn btn-white" href="{{ extendedLayout.previewUrl }}?jwt={{ extendedLayout.previewJwt }}" target="_blank">
                                     {% trans "Open full screen" %}
                                     <span class="fa fa-tablet"></span>
                                 </a>
@@ -67,46 +73,4 @@
             </div>
         </div>
     </div>
-{% endblock %}
-
-{% block javaScript %}
-    <script src="{{ theme.rootUri() }}dist/preview.bundle.min.js?v={{ version }}&rev={{revision}}" nonce="{{ cspNonce }}"></script>
-    <script src="{{ theme.rootUri() }}dist/vendor/html5preloader/html5Preloader.js?v={{ version }}&rev={{revision}}" nonce="{{ cspNonce }}"></script>
-    <script type="text/javascript" nonce="{{ cspNonce }}">
-        var previewTranslations = {};
-        // Translations we want always available
-        {% autoescape "js" %}
-            previewTranslations.actionControllerTitle = "{{ "Webhook Controller"|trans }}";
-            previewTranslations.navigateToLayout = "{{ "Navigate to layout with code [layoutTag]?"|trans }}";
-            previewTranslations.emptyRegionMessage = "{{ "Empty region!"|trans }}";
-            previewTranslations.nextItem = "{{ "Next Item"|trans }}";
-            previewTranslations.previousItem = "{{ "Previous Item"|trans }}";
-            previewTranslations.navWidget = "{{ "Navigate to Widget"|trans }}";
-            previewTranslations.navLayout = "{{ "Navigate to Layout"|trans }}";
-            previewTranslations.widgetId = "{{ "Widget ID"|trans }}";
-            previewTranslations.layoutCode = "{{ "Layout Code"|trans }}";
-            previewTranslations.target = "{{ "Target"|trans }}";
-        {% endautoescape %}
-
-        (function($){
-          $(document).ready(function(){
-            {% for extendedLayout in extendedLayouts %}
-                var iframe = $('<iframe sandbox="allow-scripts">', {
-                    src: '{{ url_for("layout.preview", {id: extendedLayout.layout.layoutId}) }}', // URL to load in the iframe
-                    id: 'player_frame_{{extendedLayout.layout.layoutId}}',
-                    frameborder: 0,
-                    css: {
-                        position: 'absolute',
-                        'pointer-events': 'unset',
-                        top: 0,
-                        left: 0
-                    }
-                });
-
-                // Append the iframe to the container
-                $('#preview_canvas_container_{{extendedLayout.layout.layoutId}}').append(iframe);
-            {% endfor %}
-          });
-        }(jQuery));
-    </script>
 {% endblock %}

--- a/views/campaign-preview.twig
+++ b/views/campaign-preview.twig
@@ -91,7 +91,7 @@
         (function($){
           $(document).ready(function(){
             {% for extendedLayout in extendedLayouts %}
-                var iframe = $('<iframe>', {
+                var iframe = $('<iframe sandbox="allow-scripts">', {
                     src: '{{ url_for("layout.preview", {id: extendedLayout.layout.layoutId}) }}', // URL to load in the iframe
                     id: 'player_frame_{{extendedLayout.layout.layoutId}}',
                     frameborder: 0,

--- a/views/editorVars.twig
+++ b/views/editorVars.twig
@@ -63,7 +63,7 @@
                     type: 'GET'
                 },
                 preview: {
-                    url: "{{ url_for("layout.preview", {id: ':id'}) }}",
+                    url: "{{ theme.rootUri() }}/preview/layout/preview/:id",
                     type: 'GET'
                 },
                 checkout: {
@@ -343,7 +343,7 @@
                     type: 'GET'
                 },
                 getData: {
-                    url: "{{ url_for("module.getData", {regionId: ':regionId', id: ':id'}) }}",
+                    url: "{{ theme.rootUri() }}preview/playlist/widget/data/:regionId/:id",
                     type: 'GET'
                 },
                 assetDownload: {

--- a/views/editorVars.twig
+++ b/views/editorVars.twig
@@ -63,7 +63,7 @@
                     type: 'GET'
                 },
                 preview: {
-                    url: "{{ theme.rootUri() }}/preview/layout/preview/:id",
+                    url: "{{ theme.rootUri() }}preview/layout/preview/:id",
                     type: 'GET'
                 },
                 checkout: {

--- a/views/layout-designer-page.twig
+++ b/views/layout-designer-page.twig
@@ -50,9 +50,9 @@
         <script src="{{ theme.rootUri() }}dist/wysiwygEditor.bundle.min.js?v={{ version }}&rev={{revision}}" nonce="{{ cspNonce }}"></script>
         <script src="{{ theme.rootUri() }}dist/editorCommon.bundle.min.js?v={{ version }}&rev={{revision}}" nonce="{{ cspNonce }}"></script>
         <script type="text/javascript" nonce="{{ cspNonce }}">
-            {% autoescape "js" %}
-                var previewJwt = "{{ previewJwt }}";
+            var previewJwt = "{{ previewJwt }}";
 
+            {% autoescape "js" %}
                 {# Custom translations #}
                 var layoutEditorHelpLink = "{{ help }}";
                 {# Insert custom translations here #}

--- a/views/layout-designer-page.twig
+++ b/views/layout-designer-page.twig
@@ -50,9 +50,10 @@
         <script src="{{ theme.rootUri() }}dist/wysiwygEditor.bundle.min.js?v={{ version }}&rev={{revision}}" nonce="{{ cspNonce }}"></script>
         <script src="{{ theme.rootUri() }}dist/editorCommon.bundle.min.js?v={{ version }}&rev={{revision}}" nonce="{{ cspNonce }}"></script>
         <script type="text/javascript" nonce="{{ cspNonce }}">
-
-            {# Custom translations #}
             {% autoescape "js" %}
+                var previewJwt = "{{ previewJwt }}";
+
+                {# Custom translations #}
                 var layoutEditorHelpLink = "{{ help }}";
                 {# Insert custom translations here #}
                 var layoutEditorTrans = {

--- a/views/layout-designer-page.twig
+++ b/views/layout-designer-page.twig
@@ -1,6 +1,6 @@
 {#
 /**
- * Copyright (C) 2020 Xibo Signage Ltd
+ * Copyright (C) 2025 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - http://www.xibo.org.uk
  *

--- a/views/module-html-preview.twig
+++ b/views/module-html-preview.twig
@@ -1,5 +1,6 @@
-<iframe scrolling="no" 
-        src="{{ url_for("module.getResource", {regionId: regionId, id: widgetId}) }}?preview=1" 
+<iframe scrolling="no"
+        sandbox="allow-scripts"
+        src="{{ previewIframeSrc }}"
         width="{{ width }}px"
         height="{{ height }}px" 
         style="border:0;"

--- a/views/schedule-page.twig
+++ b/views/schedule-page.twig
@@ -315,7 +315,7 @@
     <script type="text/javascript" nonce="{{ cspNonce }}">
         {# JS variables #}
         var scheduleRecurrenceDeleteUrl = "{{ url_for("schedule.recurrence.delete.form", {id:':id'}) }}";
-        var layoutPreviewUrl = "{{ url_for("layout.preview", {id: ':id'}) }}";
+        var layoutPreviewUrl = "{{ theme.rootUri() }}preview/layout/preview/:id";
         var scheduleSearchUrl = "{{ url_for("schedule.search") }}";
         var userAgendaViewEnabled = "{{ currentUser.featureEnabled('schedule.agenda') }}";
 

--- a/web/.htaccess
+++ b/web/.htaccess
@@ -22,6 +22,11 @@ RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_URI} ^/install/.*$
 RewriteRule ^ install/index.php [QSA,L]
 
+# preview
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_URI} ^/preview/.*$
+RewriteRule ^ preview/index.php [QSA,L]
+
 # pwa
 RewriteCond %{REQUEST_URI} ^/pwa/getResource.*$
 RewriteRule ^ pwa/index.php [QSA,L]

--- a/web/preview/index.php
+++ b/web/preview/index.php
@@ -83,7 +83,7 @@ $app->add(new \Xibo\Middleware\Log($app));
 $app->add(new \Xibo\Middleware\State($app));
 $app->add(new \Xibo\Middleware\Storage($app));
 $app->add(new \Xibo\Middleware\Xmr($app));
-$app->add(new \Xibo\Middleware\Csp($app->getContainer()));
+$app->add(new \Xibo\Middleware\Csp($app->getContainer(), false));
 $app->add(TwigMiddleware::createFromContainer($app));
 $app->addRoutingMiddleware();
 $app->add(new \Xibo\Middleware\TrailingSlashMiddleware($app));
@@ -118,6 +118,10 @@ $app->group('/', function () use ($app) {
         ->setName('module.getData');
     $app->get('/fonts/fontcss', ['\Xibo\Controller\Font','fontCss'])
         ->setName('library.font.css');
+    $app->get('/fonts/download/{id}', ['\Xibo\Controller\Font', 'download'])
+        ->setName('font.download');
+    $app->get('/layout/background/{id}', ['\Xibo\Controller\Layout', 'downloadBackground'])
+        ->setName('layout.download.background');
     $app->get('/library/download/{id}', ['\Xibo\Controller\Library', 'download'])
         ->setName('library.download');
     $app->get('/library/thumbnail/{id}', ['\Xibo\Controller\Library', 'thumbnail'])
@@ -130,8 +134,6 @@ $app->group('/', function () use ($app) {
         ->setName('layout.preview.bundle');
     $app->get('/module/asset/{assetId}', ['\Xibo\Controller\Module', 'assetDownload'])
         ->setName('module.asset.download');
-    $app->get('/fonts/download/{id}', ['\Xibo\Controller\Font', 'download'])
-        ->setName('font.download');
 });
 
 // Run App

--- a/web/preview/index.php
+++ b/web/preview/index.php
@@ -1,0 +1,142 @@
+<?php
+/*
+ * Copyright (C) 2025 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use Monolog\Logger;
+use Monolog\Processor\UidProcessor;
+use Psr\Container\ContainerInterface;
+use Slim\Views\TwigMiddleware;
+use Xibo\Factory\ContainerFactory;
+
+define('XIBO', true);
+define('PROJECT_ROOT', realpath(__DIR__ . '/../..'));
+
+require PROJECT_ROOT . '/vendor/autoload.php';
+
+// Enable/Disable logging
+if (\Xibo\Helper\Environment::isDevMode() || \Xibo\Helper\Environment::isForceDebugging()) {
+    error_reporting(E_ALL);
+    ini_set('display_errors', 1);
+} else {
+    error_reporting(0);
+    ini_set('display_errors', 0);
+}
+
+// Should we show the installer?
+if (!file_exists(PROJECT_ROOT . '/web/settings.php')) {
+    die('Not configured');
+}
+
+// Check that the cache folder if writeable - if it isn't we're in big trouble
+if (!is_writable(PROJECT_ROOT . '/cache')) {
+    die('Installation Error: Cannot write files into the Cache Folder');
+}
+
+// Create the container for dependency injection.
+try {
+    $container = ContainerFactory::create();
+} catch (Exception $e) {
+    die($e->getMessage());
+}
+
+// Configure Monolog
+$container->set('logger', function (ContainerInterface $container) {
+    $logger = new Logger('PREVIEW');
+
+    $logger->pushProcessor(new UidProcessor());
+    $logger->pushHandler(new \Xibo\Helper\DatabaseLogHandler());
+
+    return $logger;
+});
+
+// Create a Slim application
+$app = \DI\Bridge\Slim\Bridge::create($container);
+$app->setBasePath($container->get('basePath'));
+
+// Config
+$container->get('configService');
+$container->set('name', 'PREVIEW');
+
+// Middleware
+$app->add(new \Xibo\Middleware\Theme($app));
+$app->add(new \Xibo\Middleware\ConnectorMiddleware($app));
+$app->add(new \Xibo\Middleware\ListenersMiddleware($app));
+$app->add(new \Xibo\Middleware\Log($app));
+$app->add(new \Xibo\Middleware\State($app));
+$app->add(new \Xibo\Middleware\Storage($app));
+$app->add(new \Xibo\Middleware\Xmr($app));
+$app->add(new \Xibo\Middleware\Csp($app->getContainer()));
+$app->add(TwigMiddleware::createFromContainer($app));
+$app->addRoutingMiddleware();
+$app->add(new \Xibo\Middleware\TrailingSlashMiddleware($app));
+
+// Add Error Middleware
+$errorMiddleware = $app->addErrorMiddleware(
+    \Xibo\Helper\Environment::isDevMode() || \Xibo\Helper\Environment::isForceDebugging(),
+    true,
+    true
+);
+$errorMiddleware->setDefaultErrorHandler(\Xibo\Middleware\Handlers::webErrorHandler($container));
+
+// Application routes
+// ------------------
+// Private ones
+$app->group('/', function () use ($app) {
+    $app->get('/layout/preview/{id}', ['\Xibo\Controller\Preview', 'show'])
+        ->setName('layout.preview');
+    $app->get('/layout/xlf/{id}', ['\Xibo\Controller\Preview', 'getXlf'])
+        ->setName('layout.getXlf');
+    $app->get('/layout/background/{id}', ['\Xibo\Controller\Layout', 'downloadBackground'])
+        ->setName('layout.download.background');
+    $app->get('/connector/widget/preview', ['\Xibo\Controller\Connector', 'connectorPreview'])
+        ->setName('layout.preview.connector');
+    $app->get('/module/asset/{assetId}', ['\Xibo\Controller\Module', 'assetDownload'])
+        ->setName('module.asset.download');
+    $app->get('/playlist/widget/resource/{regionId}[/{id}]', ['\Xibo\Controller\Widget', 'getResource'])
+        ->setName('module.getResource');
+    $app->get('/playlist/widget/data/{regionId}/{id}', ['\Xibo\Controller\Widget', 'getData'])
+        ->setName('module.getData');
+    $app->get('/fonts/fontcss', ['\Xibo\Controller\Font','fontCss'])
+        ->setName('library.font.css');
+    $app->get('/fonts/download/{id}', ['\Xibo\Controller\Font', 'download'])
+        ->setName('font.download');
+    $app->get('/library/download/{id}', ['\Xibo\Controller\Library', 'download'])
+        ->setName('library.download');
+    $app->get('/library/thumbnail/{id}', ['\Xibo\Controller\Library', 'thumbnail'])
+        ->setName('library.public.thumbnail');
+})->addMiddleware(new \Xibo\Middleware\TokenAuthMiddleware($app->getContainer()));
+
+// Public ones
+$app->get('/layout/playerBundle', ['\Xibo\Controller\Preview', 'playerBundle'])
+    ->setName('layout.preview.bundle');
+
+// Run App
+try {
+    $app->run();
+} catch (Exception $e) {
+    echo 'Fatal Error - sorry this shouldn\'t happen. ';
+    echo '<br>' . $e->getMessage();
+
+    // Only output debug trace if we're configured to display errors
+    if (ini_get('display_errors') == 1) {
+        echo '<br><br><code>' . nl2br($e->getTraceAsString()) . '</code>';
+    }
+}

--- a/web/preview/index.php
+++ b/web/preview/index.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2025 Xibo Signage Ltd
+ * Copyright (C) 2026 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -104,8 +104,6 @@ $app->group('/', function () use ($app) {
         ->setName('layout.preview');
     $app->get('/layout/xlf/{id}', ['\Xibo\Controller\Preview', 'getXlf'])
         ->setName('layout.getXlf');
-    $app->get('/layout/background/{id}', ['\Xibo\Controller\Layout', 'downloadBackground'])
-        ->setName('layout.download.background');
     $app->get('/connector/widget/preview', ['\Xibo\Controller\Connector', 'connectorPreview'])
         ->setName('layout.preview.connector');
     $app->get('/module/asset/{assetId}', ['\Xibo\Controller\Module', 'assetDownload'])

--- a/web/preview/index.php
+++ b/web/preview/index.php
@@ -87,6 +87,7 @@ $app->add(new \Xibo\Middleware\Csp($app->getContainer()));
 $app->add(TwigMiddleware::createFromContainer($app));
 $app->addRoutingMiddleware();
 $app->add(new \Xibo\Middleware\TrailingSlashMiddleware($app));
+$app->add(new \Xibo\Middleware\CorsPreviewMiddleware());
 
 // Add Error Middleware
 $errorMiddleware = $app->addErrorMiddleware(
@@ -98,6 +99,11 @@ $errorMiddleware->setDefaultErrorHandler(\Xibo\Middleware\Handlers::webErrorHand
 
 // Application routes
 // ------------------
+// CORS
+$app->options('/{routes:.+}', function ($request, $response) {
+    return $response;
+});
+
 // Private ones
 $app->group('/', function () use ($app) {
     $app->get('/layout/preview/{id}', ['\Xibo\Controller\Preview', 'show'])
@@ -106,16 +112,12 @@ $app->group('/', function () use ($app) {
         ->setName('layout.getXlf');
     $app->get('/connector/widget/preview', ['\Xibo\Controller\Connector', 'connectorPreview'])
         ->setName('layout.preview.connector');
-    $app->get('/module/asset/{assetId}', ['\Xibo\Controller\Module', 'assetDownload'])
-        ->setName('module.asset.download');
     $app->get('/playlist/widget/resource/{regionId}[/{id}]', ['\Xibo\Controller\Widget', 'getResource'])
         ->setName('module.getResource');
     $app->get('/playlist/widget/data/{regionId}/{id}', ['\Xibo\Controller\Widget', 'getData'])
         ->setName('module.getData');
     $app->get('/fonts/fontcss', ['\Xibo\Controller\Font','fontCss'])
         ->setName('library.font.css');
-    $app->get('/fonts/download/{id}', ['\Xibo\Controller\Font', 'download'])
-        ->setName('font.download');
     $app->get('/library/download/{id}', ['\Xibo\Controller\Library', 'download'])
         ->setName('library.download');
     $app->get('/library/thumbnail/{id}', ['\Xibo\Controller\Library', 'thumbnail'])
@@ -123,8 +125,14 @@ $app->group('/', function () use ($app) {
 })->addMiddleware(new \Xibo\Middleware\TokenAuthMiddleware($app->getContainer()));
 
 // Public ones
-$app->get('/layout/playerBundle', ['\Xibo\Controller\Preview', 'playerBundle'])
-    ->setName('layout.preview.bundle');
+$app->group('/', function () use ($app) {
+    $app->get('/layout/playerBundle', ['\Xibo\Controller\Preview', 'playerBundle'])
+        ->setName('layout.preview.bundle');
+    $app->get('/module/asset/{assetId}', ['\Xibo\Controller\Module', 'assetDownload'])
+        ->setName('module.asset.download');
+    $app->get('/fonts/download/{id}', ['\Xibo\Controller\Font', 'download'])
+        ->setName('font.download');
+});
 
 // Run App
 try {


### PR DESCRIPTION
 - Start separating out the preview routes from the main web routes.
 - Rework library public thumbnails to use new preview route
 - Add sandbox to all preview iframes.
 - Implement JWT token as well as S3 style
 - Add layoutId into JWT and check auth