### PR TITLE
SSL: parse the correct HTTP_X_FORWARDED_PROTO variable

### DIFF
--- a/lib/Helper/HttpsDetect.php
+++ b/lib/Helper/HttpsDetect.php
@@ -162,7 +162,7 @@ class HttpsDetect
         $whiteListLoadBalancers = $config->getSetting('WHITELIST_LOAD_BALANCERS');
         $originIp = $_SERVER['REMOTE_ADDR'] ?? '';
         $forwardedProtoHttps = (
-            strtolower($request->getHeaderLine('HTTP_X_FORWARDED_PROTO')) === 'https'
+            strtolower($_SERVER['HTTP_X_FORWARDED_PROTO'] ?? '') === 'https'
             && $originIp != ''
             && (
                 $whiteListLoadBalancers === '' || in_array($originIp, explode(',', $whiteListLoadBalancers))


### PR DESCRIPTION
fixes xibosignage/xibo#3794