### PR TITLE
User: Fixed cannot delete oauth user entry

### DIFF
--- a/lib/Listener/OnUserDelete/OnUserDelete.php
+++ b/lib/Listener/OnUserDelete/OnUserDelete.php
@@ -56,6 +56,8 @@ class OnUserDelete
     private function deleteChildren($user)
     {
         // Delete oAuth clients
+        $this->store->update('DELETE FROM `oauth_lkclientuser` WHERE userId = :userId', ['userId' => $user->userId]);
+
         $this->store->update('DELETE FROM `oauth_clients` WHERE userId = :userId', ['userId' => $user->userId]);
 
         $this->store->update('DELETE FROM `session` WHERE userId = :userId', ['userId' => $user->userId]);


### PR DESCRIPTION
## Changes

- Added deletion of user oauth entry in `oauth_lkclientuser` table

Relates to https://github.com/xibosignage/xibo/issues/3785