### PR TITLE
XMR: Fixed windows player v4 R406 fails to open web socket after CMS upgrade to 4.0

### DIFF
--- a/lib/Entity/Display.php
+++ b/lib/Entity/Display.php
@@ -704,7 +704,7 @@ class Display implements \JsonSerializable
     public function isWebSocketXmrSupported(): bool
     {
         return $this->clientType === 'chromeOS'
-            || ($this->clientType === 'windows' && $this->clientCode >= 406)
+            || ($this->clientType === 'windows' && $this->clientCode >= 407)
             || ($this->clientType === 'android' && $this->clientCode >= 408);
     }
 


### PR DESCRIPTION
## Changes

- Fixed windows player v4 R406 fails to open web socket after CMS upgrade to 4.0

Relates to https://github.com/xibosignage/xibo/issues/3812