### PR TITLE
User: Fixed duplicate media name when assigning media items

### DIFF
--- a/lib/Entity/Media.php
+++ b/lib/Entity/Media.php
@@ -404,6 +404,8 @@ class Media implements \JsonSerializable
             // If the media is imported from a provider (ie Pixabay, etc), use it instead of importing again.
             if (isset($this->apiRef) && $this->apiRef === $result[0]['apiRef']) {
                 $this->mediaId = intval($result[0]['mediaId']);
+            } else if ($options['isMediaReassigned']) {
+                $this->name = $this->getReassignedMediaName($result[0]['name']);
             } else {
                 throw new DuplicateEntityException(__('Media you own already has this name. Please choose another.'));
             }
@@ -456,6 +458,7 @@ class Media implements \JsonSerializable
             'deferred' => false,
             'saveTags' => true,
             'audit' => true,
+            'isMediaReassigned' => false
         ], $options);
 
         if ($options['validate'] && $this->mediaType !== 'module') {
@@ -1036,5 +1039,23 @@ class Media implements \JsonSerializable
         ]);
 
         return $this;
+    }
+
+    /**
+     * Get the reassigned media name
+     * @param $media
+     * @return string
+     */
+    private function getReassignedMediaName($media): string
+    {
+        // Separate the base and file extension
+        $separator = strrpos($media, '.');
+
+        [$base, $ext] = $separator
+            ? [substr($media, 0, $separator), substr($media, $separator)]
+            : [$media, ''];
+
+        // Append a suffix if the target user already has a media item with this name
+        return $base . '_imported' . $ext;
     }
 }

--- a/lib/Entity/Media.php
+++ b/lib/Entity/Media.php
@@ -1048,6 +1048,9 @@ class Media implements \JsonSerializable
      */
     private function getReassignedMediaName($media): string
     {
+        // Append a numeric suffix if the target user already has a media item with this name
+        // However, we first need to check similar names to ensure that there's no conflict in renaming the media.
+
         // Separate the base and file extension
         $separator = strrpos($media, '.');
 
@@ -1055,7 +1058,39 @@ class Media implements \JsonSerializable
             ? [substr($media, 0, $separator), substr($media, $separator)]
             : [$media, ''];
 
-        // Append a suffix if the target user already has a media item with this name
-        return $base . '_transferred' . $ext;
+        // Get all similar names
+        $params = [];
+        $checkSQL = 'SELECT `name` FROM `media` WHERE `name` LIKE :name AND userid = :userId';
+
+        $params['name'] = $base . '%';
+        $params['userId'] = $this->ownerId;
+
+        $entries = $this->getStore()->select($checkSQL, $params);
+
+        $count = [];
+
+        foreach ($entries as $entry) {
+            $name = $entry['name'];
+
+            if ($name === $base . $ext) {
+                $count[] = 0;
+                continue;
+            }
+
+            // Check for numeric suffix like (1), (2), etc. to get the correct subsequent suffix
+            $suffix = trim(substr($name, strlen($base), strlen($name) - strlen($base) - strlen($ext)));
+
+            if (strlen($suffix) > 2 && $suffix[0] === '(' && $suffix[-1] === ')') {
+                $count[] = (int) substr($suffix, 1, -1);
+            }
+        }
+
+        $i = 0;
+
+        while (in_array($i, $count, true)) {
+            $i++;
+        }
+
+        return $base . ($i > 0 ? " ($i)" : '') . $ext;
     }
 }

--- a/lib/Entity/Media.php
+++ b/lib/Entity/Media.php
@@ -1056,6 +1056,6 @@ class Media implements \JsonSerializable
             : [$media, ''];
 
         // Append a suffix if the target user already has a media item with this name
-        return $base . '_imported' . $ext;
+        return $base . '_transferred' . $ext;
     }
 }

--- a/lib/Listener/LayoutListener.php
+++ b/lib/Listener/LayoutListener.php
@@ -136,7 +136,12 @@ class LayoutListener
             // Reassign layouts, regions, region Playlists and Widgets.
             foreach ($this->layoutFactory->getByOwnerId($user->userId) as $layout) {
                 $layout->setOwner($newUser->userId, true);
-                $layout->save(['notify' => false, 'saveTags' => false, 'setBuildRequired' => false]);
+                $layout->save([
+                    'notify' => false,
+                    'saveTags' => false,
+                    'setBuildRequired' => false,
+                    'isLayoutReassigned' => true
+                ]);
             }
         } else if ($function === 'countChildren') {
             $layouts = $this->layoutFactory->getByOwnerId($user->userId);

--- a/lib/Listener/MediaListener.php
+++ b/lib/Listener/MediaListener.php
@@ -119,8 +119,11 @@ class MediaListener
             }
         } else if ($function === 'reassignAll') {
             foreach ($this->mediaFactory->getByOwnerId($user->userId, 1) as $media) {
-                ($media->mediaType === 'module') ? $media->setOwner($systemUser->userId) : $media->setOwner($newUser->getOwnerId());
-                $media->save();
+                $media->mediaType === 'module'
+                    ? $media->setOwner($systemUser->userId)
+                    : $media->setOwner($newUser->getOwnerId());
+
+                $media->save(['isMediaReassigned' => true]);
             }
         } else if ($function === 'countChildren') {
             $media = $this->mediaFactory->getByOwnerId($user->userId, 1);

--- a/lib/Listener/PlaylistListener.php
+++ b/lib/Listener/PlaylistListener.php
@@ -95,7 +95,7 @@ class PlaylistListener
             // Reassign playlists and widgets
             foreach ($this->playlistFactory->getByOwnerId($user->userId) as $playlist) {
                 $playlist->setOwner($newUser->userId);
-                $playlist->save();
+                $playlist->save(['isPlaylistReassigned' => true]);
             }
         } else if ($function === 'countChildren') {
             $playlists = $this->playlistFactory->getByOwnerId($user->userId);


### PR DESCRIPTION
## Changes

- Append numeric suffix if the target user already has a content with the same name

Relates to https://github.com/xibosignage/xibo/issues/3804