### PR TITLE
Fix sqlerror with empty CampaignID

### DIFF
--- a/lib/Factory/LayoutFactory.php
+++ b/lib/Factory/LayoutFactory.php
@@ -2582,6 +2582,9 @@ class LayoutFactory extends BaseFactory
                 foreach ($this->getStore()->select($sql, []) as $row) {
                     $campaignIds[] = $row['CampaignID'];
                 }
+                if (count($campaignIds) === 0) {
+                    $campaignIds[] = "NULL";
+                }
 
                 $body .= ' AND campaign.CampaignID NOT IN ( ' . implode(',', array_filter($campaignIds)) . ' )  
                      AND layout.layoutID NOT IN (SELECT DISTINCT defaultlayoutid FROM display) 


### PR DESCRIPTION
This PR fixes issue [3819](https://github.com/xibosignage/xibo/issues/3819).