### PR TITLE
Layouts: Fixed show filter and sql error on campaignId

### DIFF
--- a/lib/Factory/LayoutFactory.php
+++ b/lib/Factory/LayoutFactory.php
@@ -2575,21 +2575,24 @@ class LayoutFactory extends BaseFactory
                 $campaignIds[] = $row['CampaignID'];
             }
 
-            if (!empty($campaignIds)) {
-                if ($parsedFilter->getInt('filterLayoutStatusId') == 2) {
-                    // Only show used layouts
-                    $body .= ' AND ('
-                        . '      campaign.CampaignID IN ( ' . implode(',', array_filter($campaignIds)) . ' ) 
-                             OR layout.layoutID IN (SELECT DISTINCT defaultlayoutid FROM display) 
-                             OR layout.layoutID IN (SELECT DISTINCT layoutId FROM lklayoutdisplaygroup)'
-                        . ' ) ';
-                } else {
-                    // Only show unused layouts
-                    $body .= ' AND campaign.CampaignID NOT IN ( ' . implode(',', array_filter($campaignIds)) . ' )  
-                         AND layout.layoutID NOT IN (SELECT DISTINCT defaultlayoutid FROM display) 
-                         AND layout.layoutID NOT IN (SELECT DISTINCT layoutId FROM lklayoutdisplaygroup) 
-                         ';
+            if ($parsedFilter->getInt('filterLayoutStatusId') == 2) {
+                // Only show used layouts
+                $body .= ' AND (';
+
+                if (!empty($campaignIds)) {
+                    $body .= ' campaign.CampaignID IN ( ' . implode(',', array_filter($campaignIds)) . ' ) OR ';
                 }
+
+                $body .= ' layout.layoutID IN (SELECT DISTINCT defaultlayoutid FROM display) 
+                             OR layout.layoutID IN (SELECT DISTINCT layoutId FROM lklayoutdisplaygroup) ) ';
+            } else {
+                if (!empty($campaignIds)) {
+                    $body .= ' AND campaign.CampaignID NOT IN ( ' . implode(',', array_filter($campaignIds)) .
+                        ' )';
+                }
+                // Only show unused layouts
+                $body .= ' AND layout.layoutID NOT IN (SELECT DISTINCT defaultlayoutid FROM display) 
+                         AND layout.layoutID NOT IN (SELECT DISTINCT layoutId FROM lklayoutdisplaygroup) ';
             }
         }
 

--- a/lib/Factory/LayoutFactory.php
+++ b/lib/Factory/LayoutFactory.php
@@ -2575,28 +2575,26 @@ class LayoutFactory extends BaseFactory
                 $campaignIds[] = $row['CampaignID'];
             }
 
-            if ($parsedFilter->getInt('filterLayoutStatusId') == 2) {
-                $body .= ' AND (';
-
-                // We have current or future scheduled in-use layouts/campaigns
-                if (!empty($campaignIds)) {
-                    $body .= ' campaign.CampaignID IN ( ' . implode(',', array_filter($campaignIds)) . ' ) OR';
-                }
-
-                $body .= ' layout.layoutID IN (SELECT DISTINCT defaultlayoutid FROM display) 
-                             OR layout.layoutID IN (SELECT DISTINCT layoutId FROM lklayoutdisplaygroup) )';
-            } else {
-                if (!empty($campaignIds)) {
+            if (!empty($campaignIds)) {
+                if ($parsedFilter->getInt('filterLayoutStatusId') == 2) {
+                    // Only show used layouts
+                    $body .= ' AND ('
+                        . '      campaign.CampaignID IN ( ' . implode(',', array_filter($campaignIds)) . ' ) 
+                             OR layout.layoutID IN (SELECT DISTINCT defaultlayoutid FROM display) 
+                             OR layout.layoutID IN (SELECT DISTINCT layoutId FROM lklayoutdisplaygroup)'
+                        . ' ) ';
+                } else {
+                    // Only show unused layouts
                     $body .= ' AND campaign.CampaignID NOT IN ( ' . implode(',', array_filter($campaignIds))
                         . ' ) ';
 
                     if ($parsedFilter->getInt('isFullScreenCampaign', ['default' => -1]) == 1) {
                         $body .= 'AND campaign.type IN ("media", "playlist") ';
                     }
-                }
 
-                $body .= 'AND layout.layoutID NOT IN (SELECT DISTINCT defaultlayoutid FROM display) 
-                 AND layout.layoutID NOT IN (SELECT DISTINCT layoutId FROM lklayoutdisplaygroup) ';
+                    $body .= 'AND layout.layoutID NOT IN (SELECT DISTINCT defaultlayoutid FROM display) 
+                        AND layout.layoutID NOT IN (SELECT DISTINCT layoutId FROM lklayoutdisplaygroup) ';
+                }
             }
         }
 

--- a/lib/Factory/LayoutFactory.php
+++ b/lib/Factory/LayoutFactory.php
@@ -2559,15 +2559,15 @@ class LayoutFactory extends BaseFactory
         // Used - In active schedule, scheduled in the future, directly assigned to displayGroup, default Layout.
         // Unused - Every layout NOT matching the Used ie not in active schedule, not scheduled in the future, not directly assigned to any displayGroup, not default layout.
         if ($parsedFilter->getInt('filterLayoutStatusId', ['default' => 1]) != 1)  {
-            // Get the current or future scheduled layouts
-            $now = Carbon::now()->format('U');
-            $sql = 'SELECT DISTINCT schedule.CampaignID FROM schedule';
-            $campaignIds = [];
-
-            // Note: For the maintenance XTR, we will only delete unused/unscheduled fullscreen campaign layouts
-            // (i.e. when the user schedules a media and later on deletes the schedule)
-            if ($parsedFilter->getInt('isFullScreenCampaign', ['default' => -1]) != 1) {
-                $sql .= ' WHERE ( ( schedule.fromDt < ' . $now
+            // Note: For the maintenance XTR, we need to query all scheduled playlist or media events
+            // so that we can exclude them once we delete unused/unscheduled fullscreen campaign layouts
+            if ($parsedFilter->getInt('removeUnusedFullScreenLayouts', ['default' => -1]) == 1) {
+                $sql = 'SELECT DISTINCT schedule.CampaignID FROM schedule';
+            } else {
+                // Get the current or future scheduled layouts
+                $now = Carbon::now()->format('U');
+                $campaignIds = [];
+                $sql = 'SELECT DISTINCT schedule.CampaignID FROM schedule WHERE ( ( schedule.fromDt < ' . $now
                     . ' OR schedule.fromDt = 0 ) ' . ' AND schedule.toDt > ' . $now . ') OR schedule.fromDt > ' . $now;
             }
 
@@ -2585,15 +2585,10 @@ class LayoutFactory extends BaseFactory
                         . ' ) ';
                 } else {
                     // Only show unused layouts
-                    $body .= ' AND campaign.CampaignID NOT IN ( ' . implode(',', array_filter($campaignIds))
-                        . ' ) ';
-
-                    if ($parsedFilter->getInt('isFullScreenCampaign', ['default' => -1]) == 1) {
-                        $body .= 'AND campaign.type IN ("media", "playlist") ';
-                    }
-
-                    $body .= 'AND layout.layoutID NOT IN (SELECT DISTINCT defaultlayoutid FROM display) 
-                        AND layout.layoutID NOT IN (SELECT DISTINCT layoutId FROM lklayoutdisplaygroup) ';
+                    $body .= ' AND campaign.CampaignID NOT IN ( ' . implode(',', array_filter($campaignIds)) . ' )  
+                         AND layout.layoutID NOT IN (SELECT DISTINCT defaultlayoutid FROM display) 
+                         AND layout.layoutID NOT IN (SELECT DISTINCT layoutId FROM lklayoutdisplaygroup) 
+                         ';
                 }
             }
         }
@@ -2639,9 +2634,14 @@ class LayoutFactory extends BaseFactory
             }
         }
 
-        if ($parsedFilter->getString('campaignType') != '') {
-            $body .= ' AND campaign.type = :type ';
-            $params['type'] = $parsedFilter->getString('campaignType');
+        // Get the fullscreen media or playlist layout
+        if ($parsedFilter->getInt('isFullScreenCampaign', ['default' => -1]) == 1) {
+            $body .= ' AND campaign.type IN ("media", "playlist") ';
+        } else if ($parsedFilter->getString('campaignType') != '') {
+            if ($parsedFilter->getString('campaignType') != '') {
+                $body .= ' AND campaign.type = :type ';
+                $params['type'] = $parsedFilter->getString('campaignType');
+            }
         }
 
         // Logged in user view permissions

--- a/lib/Factory/LayoutFactory.php
+++ b/lib/Factory/LayoutFactory.php
@@ -2638,10 +2638,8 @@ class LayoutFactory extends BaseFactory
         if ($parsedFilter->getInt('isFullScreenCampaign', ['default' => -1]) == 1) {
             $body .= ' AND campaign.type IN ("media", "playlist") ';
         } else if ($parsedFilter->getString('campaignType') != '') {
-            if ($parsedFilter->getString('campaignType') != '') {
-                $body .= ' AND campaign.type = :type ';
-                $params['type'] = $parsedFilter->getString('campaignType');
-            }
+            $body .= ' AND campaign.type = :type ';
+            $params['type'] = $parsedFilter->getString('campaignType');
         }
 
         // Logged in user view permissions

--- a/lib/Factory/LayoutFactory.php
+++ b/lib/Factory/LayoutFactory.php
@@ -2559,40 +2559,54 @@ class LayoutFactory extends BaseFactory
         // Used - In active schedule, scheduled in the future, directly assigned to displayGroup, default Layout.
         // Unused - Every layout NOT matching the Used ie not in active schedule, not scheduled in the future, not directly assigned to any displayGroup, not default layout.
         if ($parsedFilter->getInt('filterLayoutStatusId', ['default' => 1]) != 1)  {
-            // Note: For the maintenance XTR, we need to query all scheduled playlist or media events
-            // so that we can exclude them once we delete unused/unscheduled fullscreen campaign layouts
-            if ($parsedFilter->getInt('removeUnusedFullScreenLayouts', ['default' => -1]) == 1) {
-                $sql = 'SELECT DISTINCT schedule.CampaignID FROM schedule';
-            } else {
-                // Get the current or future scheduled layouts
-                $now = Carbon::now()->format('U');
-                $campaignIds = [];
-                $sql = 'SELECT DISTINCT schedule.CampaignID FROM schedule WHERE ( ( schedule.fromDt < ' . $now
-                    . ' OR schedule.fromDt = 0 ) ' . ' AND schedule.toDt > ' . $now . ') OR schedule.fromDt > ' . $now;
-            }
-
-            foreach ($this->getStore()->select($sql, []) as $row) {
-                $campaignIds[] = $row['CampaignID'];
-            }
+            // Get the current or future scheduled layouts
+            $now = Carbon::now()->format('U');
 
             if ($parsedFilter->getInt('filterLayoutStatusId') == 2) {
                 // Only show used layouts
-                $body .= ' AND (';
+                $body .= ' AND (
+                    EXISTS (
+                        SELECT 1
+                        FROM schedule
+                        WHERE schedule.CampaignID = campaign.CampaignID
+                        AND (
+                            (
+                                (schedule.fromDt < :now OR schedule.fromDt = 0)
+                                AND schedule.toDt > :now
+                            )
+                            OR schedule.fromDt > :now
+                        )
+                    )
+                    OR layout.layoutID IN (SELECT DISTINCT defaultlayoutid FROM display)
+                    OR layout.layoutID IN (SELECT DISTINCT layoutId FROM lklayoutdisplaygroup)
+                ) ';
 
-                if (!empty($campaignIds)) {
-                    $body .= ' campaign.CampaignID IN ( ' . implode(',', array_filter($campaignIds)) . ' ) OR ';
-                }
-
-                $body .= ' layout.layoutID IN (SELECT DISTINCT defaultlayoutid FROM display) 
-                             OR layout.layoutID IN (SELECT DISTINCT layoutId FROM lklayoutdisplaygroup) ) ';
+                $params['now'] = $now;
             } else {
-                if (!empty($campaignIds)) {
-                    $body .= ' AND campaign.CampaignID NOT IN ( ' . implode(',', array_filter($campaignIds)) .
-                        ' )';
-                }
                 // Only show unused layouts
-                $body .= ' AND layout.layoutID NOT IN (SELECT DISTINCT defaultlayoutid FROM display) 
-                         AND layout.layoutID NOT IN (SELECT DISTINCT layoutId FROM lklayoutdisplaygroup) ';
+                $body .= '
+                    AND NOT EXISTS (
+                        SELECT 1
+                        FROM schedule
+                        WHERE schedule.CampaignID = campaign.CampaignID ';
+
+                // Note: For the maintenance XTR, we don't have to add the date in the query
+                if ($parsedFilter->getInt('removeUnusedFullScreenLayouts', ['default' => -1]) != 1) {
+                    $body .=
+                        ' AND (
+                            (
+                                (schedule.fromDt < :now OR schedule.fromDt = 0)
+                                AND schedule.toDt > :now
+                            )
+                            OR schedule.fromDt > :now
+                        )';
+
+                    $params['now'] = $now;
+                }
+
+                $body .= '
+                    ) AND layout.layoutID NOT IN (SELECT DISTINCT defaultlayoutid FROM display)
+                    AND layout.layoutID NOT IN (SELECT DISTINCT layoutId FROM lklayoutdisplaygroup) ';
             }
         }
 

--- a/lib/Factory/LayoutFactory.php
+++ b/lib/Factory/LayoutFactory.php
@@ -2559,34 +2559,44 @@ class LayoutFactory extends BaseFactory
         // Used - In active schedule, scheduled in the future, directly assigned to displayGroup, default Layout.
         // Unused - Every layout NOT matching the Used ie not in active schedule, not scheduled in the future, not directly assigned to any displayGroup, not default layout.
         if ($parsedFilter->getInt('filterLayoutStatusId', ['default' => 1]) != 1)  {
-            if ($parsedFilter->getInt('filterLayoutStatusId') == 2) {
+            // Get the current or future scheduled layouts
+            $now = Carbon::now()->format('U');
+            $sql = 'SELECT DISTINCT schedule.CampaignID FROM schedule';
+            $campaignIds = [];
 
-                // Only show used layouts
-                $now = Carbon::now()->format('U');
-                $sql = 'SELECT DISTINCT schedule.CampaignID FROM schedule WHERE ( ( schedule.fromDt < '. $now . ' OR schedule.fromDt = 0 ) ' . ' AND schedule.toDt > ' . $now . ') OR schedule.fromDt > ' . $now;
-                $campaignIds = [];
-                foreach ($this->getStore()->select($sql, []) as $row) {
-                    $campaignIds[] = $row['CampaignID'];
-                }
-                $body .= ' AND ('
-                    . '      campaign.CampaignID IN ( ' . implode(',', array_filter($campaignIds)) . ' ) 
-                             OR layout.layoutID IN (SELECT DISTINCT defaultlayoutid FROM display) 
-                             OR layout.layoutID IN (SELECT DISTINCT layoutId FROM lklayoutdisplaygroup)'
-                    . ' ) ';
+            // Note: For the maintenance XTR, we will only delete unused/unscheduled fullscreen campaign layouts
+            // (i.e. when the user schedules a media and later on deletes the schedule)
+            if ($parsedFilter->getInt('isFullScreenCampaign', ['default' => -1]) != 1) {
+                $sql .= ' WHERE ( ( schedule.fromDt < ' . $now
+                    . ' OR schedule.fromDt = 0 ) ' . ' AND schedule.toDt > ' . $now . ') OR schedule.fromDt > ' . $now;
             }
-            else {
-                // Only show unused layouts
-                $now = Carbon::now()->format('U');
-                $sql = 'SELECT DISTINCT schedule.CampaignID FROM schedule WHERE ( ( schedule.fromDt < '. $now . ' OR schedule.fromDt = 0 ) ' . ' AND schedule.toDt > ' . $now . ') OR schedule.fromDt > ' . $now;
-                $campaignIds = [];
-                foreach ($this->getStore()->select($sql, []) as $row) {
-                    $campaignIds[] = $row['CampaignID'];
+
+            foreach ($this->getStore()->select($sql, []) as $row) {
+                $campaignIds[] = $row['CampaignID'];
+            }
+
+            if ($parsedFilter->getInt('filterLayoutStatusId') == 2) {
+                $body .= ' AND (';
+
+                // We have current or future scheduled in-use layouts/campaigns
+                if (!empty($campaignIds)) {
+                    $body .= ' campaign.CampaignID IN ( ' . implode(',', array_filter($campaignIds)) . ' ) OR';
                 }
 
-                $body .= ' AND campaign.CampaignID NOT IN ( ' . implode(',', array_filter($campaignIds)) . ' )  
-                     AND layout.layoutID NOT IN (SELECT DISTINCT defaultlayoutid FROM display) 
-                     AND layout.layoutID NOT IN (SELECT DISTINCT layoutId FROM lklayoutdisplaygroup) 
-                     ';
+                $body .= ' layout.layoutID IN (SELECT DISTINCT defaultlayoutid FROM display) 
+                             OR layout.layoutID IN (SELECT DISTINCT layoutId FROM lklayoutdisplaygroup) )';
+            } else {
+                if (!empty($campaignIds)) {
+                    $body .= ' AND campaign.CampaignID NOT IN ( ' . implode(',', array_filter($campaignIds))
+                        . ' ) ';
+
+                    if ($parsedFilter->getInt('isFullScreenCampaign', ['default' => -1]) == 1) {
+                        $body .= 'AND campaign.type IN ("media", "playlist") ';
+                    }
+                }
+
+                $body .= 'AND layout.layoutID NOT IN (SELECT DISTINCT defaultlayoutid FROM display) 
+                 AND layout.layoutID NOT IN (SELECT DISTINCT layoutId FROM lklayoutdisplaygroup) ';
             }
         }
 
@@ -2631,10 +2641,7 @@ class LayoutFactory extends BaseFactory
             }
         }
 
-        // Get the fullscreen media or playlist layout
-        if ($parsedFilter->getInt('isFullScreenCampaign', ['default' => -1]) == 1) {
-            $body .= ' AND campaign.type IN ("media", "playlist") ';
-        } else if ($parsedFilter->getString('campaignType') != '') {
+        if ($parsedFilter->getString('campaignType') != '') {
             $body .= ' AND campaign.type = :type ';
             $params['type'] = $parsedFilter->getString('campaignType');
         }

--- a/lib/XTR/MaintenanceRegularTask.php
+++ b/lib/XTR/MaintenanceRegularTask.php
@@ -654,7 +654,7 @@ class MaintenanceRegularTask implements TaskInterface
     }
 
     /**
-     * Deletes unused full screen layouts
+     * Remove unused full screen layouts associated with a deleted event
      * @throws NotFoundException
      * @throws GeneralException
      */
@@ -666,6 +666,7 @@ class MaintenanceRegularTask implements TaskInterface
 
         foreach ($this->layoutFactory->query(null, [
             'filterLayoutStatusId' => 3,
+            'removeUnusedFullScreenLayouts' => 1,
             'isFullScreenCampaign' => 1
         ]) as $layout) {
             $count++;


### PR DESCRIPTION
## Changes

The fix is divided into two parts: 
1. Handle empty campaignId lists properly to address the SQL query issue for the show filter and missing campaignId ([#3819](https://github.com/xibosignage/xibo/issues/3819), [#3814](https://github.com/xibosignage/xibo/issues/3814))
2. When running XTR Maintenance, the `tidyUnusedFullScreenLayout` process removes fullscreen layouts marked as unused, including some that were scheduled in the past ([#3818](https://github.com/xibosignage/xibo/issues/3818)). However, it should only remove fullscreen layouts that belong to deleted fullscreen events.

Relates to https://github.com/xibosignage/xibo/issues/3819, https://github.com/xibosignage/xibo/issues/3814, https://github.com/xibosignage/xibo/issues/3818