### PR TITLE
PWA: fix for URLs output in CSS (handling duplicates)

### DIFF
--- a/web/xmds.php
+++ b/web/xmds.php
@@ -231,9 +231,20 @@ if (isset($_GET['file'])) {
 
             // Rewrite CSS for PWAs
             $cssFile = file_get_contents($libraryLocation . $file->path);
-            $matches = [];
-            preg_match_all('/url\(\'?(.*?)\'?\)/', $cssFile, $matches);
-            foreach ($matches[1] as $match) {
+
+            // Use callback to modify each match individually (to avoid substituting duplicates more than once)
+            $cssFile = preg_replace_callback('/url\(\'?(.*?)\'?\)/', function ($matches) use (
+                $requiredFileFactory,
+                $displayId,
+                $display,
+                $encryptionKey,
+                $cdnUrl,
+                $file,
+                $logger
+            ) {
+                // Process the match
+                $match = $matches[1];
+
                 // Look up the file to get the right ID/path.
                 try {
                     $replacementFile = $requiredFileFactory->getByDisplayAndDependencyPath($displayId, $match);
@@ -248,15 +259,13 @@ if (isset($_GET['file'])) {
                         $file->fileType === 'fontCss' ? 'font' : 'asset',
                         true,
                     );
-                    $cssFile = str_replace(
-                        $match,
-                        $url,
-                        $cssFile,
-                    );
-                } catch (Exception $exception) {
+
+                    return 'url(\'' . $url . '\')';
+                } catch (Exception) {
                     $logger->error('CSS has dependency which does not exist in Required Files: ' . $match);
+                    return $matches[0];
                 }
-            }
+            }, $cssFile);
 
             $file->size = strlen($cssFile);
 


### PR DESCRIPTION
fixes xibosignage/xibo#3822

This is a problem when the same font-family appears more than once in the fonts.css, e.g.

```css
@font-face {
    font-family: 'linear';
    src: url('http://localhost:5173/xmds.php?file=http://localhost:5173/xmds.php?file=linear-by-braydon-fuller.otf&displayId=350&type=P&itemId=2&fileType=font&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20260302T000000Z&X-Amz-Expires=1772463570&X-Amz-SignedHeaders=host&X-Amz-Signature=f408186919b3fab36179527b8f55c8037c4618ea8dce0b332691741192cd420a&displayId=350&type=P&itemId=2&fileType=font&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20260302T000000Z&X-Amz-Expires=1772463570&X-Amz-SignedHeaders=host&X-Amz-Signature=f408186919b3fab36179527b8f55c8037c4618ea8dce0b332691741192cd420a');
}
@font-face {
    font-family: 'linear regular';
    src: url('http://localhost:5173/xmds.php?file=http://localhost:5173/xmds.php?file=linear-by-braydon-fuller.otf&displayId=350&type=P&itemId=2&fileType=font&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20260302T000000Z&X-Amz-Expires=1772463570&X-Amz-SignedHeaders=host&X-Amz-Signature=f408186919b3fab36179527b8f55c8037c4618ea8dce0b332691741192cd420a&displayId=350&type=P&itemId=2&fileType=font&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20260302T000000Z&X-Amz-Expires=1772463570&X-Amz-SignedHeaders=host&X-Amz-Signature=f408186919b3fab36179527b8f55c8037c4618ea8dce0b332691741192cd420a');
}
```

The str_replace hits it more than once.