### PR TITLE
feat: add linux clientType to isWebSocketXmrSupported()

### DIFF
--- a/lib/Entity/Display.php
+++ b/lib/Entity/Display.php
@@ -704,6 +704,7 @@ class Display implements \JsonSerializable
     public function isWebSocketXmrSupported(): bool
     {
         return $this->clientType === 'chromeOS'
+            || $this->clientType === 'linux'
             || ($this->clientType === 'windows' && $this->clientCode >= 407)
             || ($this->clientType === 'android' && $this->clientCode >= 408);
     }


### PR DESCRIPTION
## Summary

Add `linux` to the list of client types that support WebSocket XMR in `Display::isWebSocketXmrSupported()`.

This is a **one-line change** to `lib/Entity/Display.php` that enables real-time push notifications for Linux-based players registering with `clientType='linux'`.

## Motivation

We maintain [xiboplayer](https://github.com/xibo-players/xiboplayer), an open-source SDK + set of players (Electron, Chromium kiosk, PWA) for Xibo CMS. Our players register with `clientType='linux'` via XMDS, but currently fall back to long-polling because `isWebSocketXmrSupported()` doesn't include `linux`.

Adding this single condition gives Linux players the same real-time XMR channel that chromeOS, Windows (v407+), and Android (v408+) already have — reducing latency for schedule changes and commands, and lowering unnecessary polling load on the CMS.

## Changes

```php
// lib/Entity/Display.php — isWebSocketXmrSupported()
return $this->clientType === 'chromeOS'
+   || $this->clientType === 'linux'
    || ($this->clientType === 'windows' && $this->clientCode >= 407)
    || ($this->clientType === 'android' && $this->clientCode >= 408);
```

## Risk

Minimal — only affects displays that explicitly register as `clientType='linux'`. No existing client types are affected. The XMR WebSocket infrastructure is already in place and battle-tested with chromeOS/Windows/Android.

Resolves #3830