### PR TITLE
fix: PdfProvider page count fallback when FPDI fails (wrong duration)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,6 +97,7 @@ RUN LC_ALL=C.UTF-8 DEBIAN_FRONTEND=noninteractive apt update && apt upgrade -y &
     openssl \
     cron \
     default-mysql-client \
+    qpdf \
     && dpkg-reconfigure --frontend noninteractive tzdata \
     && rm -rf /var/lib/apt/lists/*
 

--- a/lib/Widget/PdfProvider.php
+++ b/lib/Widget/PdfProvider.php
@@ -55,12 +55,23 @@ class PdfProvider implements WidgetProviderInterface
                     $this->getLog()->debug('fetchDuration: loading PDF file to get the number of pages, file: '
                         . $sourceFile);
 
-                    $mPdf = new Mpdf([
-                        'tempDir' => $widget->getLibraryTempPath(),
-                    ]);
-                    $pageCount = $mPdf->setSourceFile($sourceFile);
+                    // Try mPdf/FPDI first (works for unencrypted PDFs)
+                    try {
+                        $mPdf = new Mpdf([
+                            'tempDir' => $widget->getLibraryTempPath(),
+                        ]);
+                        $pageCount = $mPdf->setSourceFile($sourceFile);
+                    } catch (\Exception $fpdiException) {
+                        // FPDI fails on encrypted/password-protected PDFs.
+                        // Fall back to counting page objects in the raw PDF.
+                        $this->getLog()->info('fetchDuration: FPDI failed (' . $fpdiException->getMessage()
+                            . '), trying raw page count for: ' . $sourceFile);
+                        $pageCount = $this->countPdfPages($sourceFile);
+                    }
 
-                    $widget->setOptionValue('pageCount', 'attrib', $pageCount);
+                    if ($pageCount >= 1) {
+                        $widget->setOptionValue('pageCount', 'attrib', $pageCount);
+                    }
                 } catch (\Exception $e) {
                     $this->getLog()->error('fetchDuration: unable to get PDF page count, e: ' . $e->getMessage());
                 }
@@ -71,6 +82,40 @@ class PdfProvider implements WidgetProviderInterface
             $durationProvider->setDuration($durationProvider->getWidget()->calculatedDuration * $pageCount);
         }
         return $this;
+    }
+
+    /**
+     * Count pages in a PDF by parsing its raw bytes.
+     * Works with encrypted/password-protected PDFs where FPDI fails.
+     */
+    private function countPdfPages(string $filePath): int
+    {
+        $content = @file_get_contents($filePath);
+        if ($content === false) {
+            return 1;
+        }
+
+        // Method 1: Count /Type /Page leaf nodes (not /Type /Pages tree nodes)
+        $count = preg_match_all('/\/Type\s*\/Page[^s]/i', $content);
+        if ($count > 0) {
+            return $count;
+        }
+
+        // Method 2: Find /Count N in page tree root (largest value = total pages)
+        if (preg_match_all('/\/Count\s+(\d+)/', $content, $matches)) {
+            return (int)max($matches[1]);
+        }
+
+        // Method 3: Use qpdf if available (handles all encryption types)
+        $qpdfPath = trim(@shell_exec('which qpdf 2>/dev/null') ?? '');
+        if (!empty($qpdfPath)) {
+            $result = trim(@shell_exec($qpdfPath . ' --show-npages ' . escapeshellarg($filePath) . ' 2>/dev/null') ?? '');
+            if (is_numeric($result) && (int)$result > 0) {
+                return (int)$result;
+            }
+        }
+
+        return 1;
     }
 
     public function getDataCacheKey(DataProviderInterface $dataProvider): ?string


### PR DESCRIPTION
## Summary

Fixes xibosignage/xibo#3834 — `PdfProvider::fetchDuration()` silently falls back to `pageCount=1` when FPDI fails on encrypted PDFs, producing incorrect `calculatedDuration` in the XLF.

Previously reported as xibosignage/xibo#944 and xibosignage/xibo#2629, closed with a player-side workaround (`xiboIC.setWidgetDuration()` in the HTML template). That workaround does not help players with native PDF rendering, and the root cause in PdfProvider remains.

## Changes

### `lib/Widget/PdfProvider.php`

Wrap FPDI call in inner try/catch, add `countPdfPages()` fallback with 3 strategies:

1. Regex `/Type /Page` leaf nodes in raw bytes — works for PDFs with unencrypted object structure
2. `/Count N` from page tree root — works for PDFs with unencrypted cross-reference tables
3. **`qpdf --show-npages`** — handles all encryption types including fully encrypted object streams where methods 1-2 return 0

Note: PDFs with owner-password encryption and encrypted object streams (e.g. PDF 1.6+) encrypt the entire object structure, not just content streams. In this case raw byte parsing cannot find `/Type /Page` markers. `qpdf` is the only reliable method for these files.

### `Dockerfile`

Add `qpdf` package to the container image for method 3 fallback.

## Workaround

Use **total duration** instead of **duration per page** for encrypted PDF widgets until this is fixed.

## Test plan

- [ ] Upload unencrypted PDF with `durationIsPerItem=1` — FPDI counts pages (existing behavior unchanged)
- [ ] Upload encrypted PDF (owner-password, encrypted object streams) with `durationIsPerItem=1` — fallback counts pages via qpdf
- [ ] Verify `calculatedDuration = duration × pageCount` in both cases
- [ ] Verify XLF contains correct total duration after layout rebuild