### PR TITLE
feat: add pwa clientType to isPwa() and isWebSocketXmrSupported()

### DIFF
--- a/lib/Entity/Display.php
+++ b/lib/Entity/Display.php
@@ -695,7 +695,8 @@ class Display implements \JsonSerializable
      */
     public function isPwa(): bool
     {
-        return $this->clientType === 'chromeOS';
+        return $this->clientType === 'chromeOS'
+            || $this->clientType === 'pwa';
     }
 
     /**
@@ -704,6 +705,7 @@ class Display implements \JsonSerializable
     public function isWebSocketXmrSupported(): bool
     {
         return $this->clientType === 'chromeOS'
+            || $this->clientType === 'pwa'
             || ($this->clientType === 'linux' && $this->clientCode >= 400)
             || ($this->clientType === 'windows' && $this->clientCode >= 407)
             || ($this->clientType === 'android' && $this->clientCode >= 408);

--- a/tests/Unit/DisplayEntityTest.php
+++ b/tests/Unit/DisplayEntityTest.php
@@ -1,0 +1,106 @@
+<?php
+/*
+ * Copyright (C) 2026 Xibo Players
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ */
+
+namespace Xibo\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Xibo\Entity\Display;
+
+/**
+ * Unit tests for Display::isPwa() and Display::isWebSocketXmrSupported()
+ */
+class DisplayEntityTest extends TestCase
+{
+    private function makeDisplay(string $clientType, int $clientCode = 0): Display
+    {
+        // Use reflection to create Display without constructor (avoids DI dependencies)
+        $ref = new \ReflectionClass(Display::class);
+        $display = $ref->newInstanceWithoutConstructor();
+        $display->clientType = $clientType;
+        $display->clientCode = $clientCode;
+        return $display;
+    }
+
+    // ── isPwa() ──────────────────────────────────────────────────
+
+    public function testIsPwaReturnsTrueForChromeOS(): void
+    {
+        $this->assertTrue($this->makeDisplay('chromeOS')->isPwa());
+    }
+
+    public function testIsPwaReturnsTrueForPwa(): void
+    {
+        $this->assertTrue($this->makeDisplay('pwa')->isPwa());
+    }
+
+    public function testIsPwaReturnsFalseForLinux(): void
+    {
+        $this->assertFalse($this->makeDisplay('linux', 400)->isPwa());
+    }
+
+    public function testIsPwaReturnsFalseForWindows(): void
+    {
+        $this->assertFalse($this->makeDisplay('windows', 407)->isPwa());
+    }
+
+    public function testIsPwaReturnsFalseForAndroid(): void
+    {
+        $this->assertFalse($this->makeDisplay('android', 408)->isPwa());
+    }
+
+    // ── isWebSocketXmrSupported() ────────────────────────────────
+
+    public function testXmrSupportedForChromeOS(): void
+    {
+        $this->assertTrue($this->makeDisplay('chromeOS')->isWebSocketXmrSupported());
+    }
+
+    public function testXmrSupportedForPwa(): void
+    {
+        $this->assertTrue($this->makeDisplay('pwa')->isWebSocketXmrSupported());
+    }
+
+    public function testXmrSupportedForLinuxAbove400(): void
+    {
+        $this->assertTrue($this->makeDisplay('linux', 400)->isWebSocketXmrSupported());
+    }
+
+    public function testXmrNotSupportedForLinuxBelow400(): void
+    {
+        $this->assertFalse($this->makeDisplay('linux', 399)->isWebSocketXmrSupported());
+    }
+
+    public function testXmrSupportedForWindowsAbove407(): void
+    {
+        $this->assertTrue($this->makeDisplay('windows', 407)->isWebSocketXmrSupported());
+    }
+
+    public function testXmrNotSupportedForWindowsBelow407(): void
+    {
+        $this->assertFalse($this->makeDisplay('windows', 406)->isWebSocketXmrSupported());
+    }
+
+    public function testXmrSupportedForAndroidAbove408(): void
+    {
+        $this->assertTrue($this->makeDisplay('android', 408)->isWebSocketXmrSupported());
+    }
+
+    public function testXmrNotSupportedForAndroidBelow408(): void
+    {
+        $this->assertFalse($this->makeDisplay('android', 407)->isWebSocketXmrSupported());
+    }
+
+    public function testXmrNotSupportedForUnknownType(): void
+    {
+        $this->assertFalse($this->makeDisplay('unknown', 999)->isWebSocketXmrSupported());
+    }
+}


### PR DESCRIPTION
## Summary

Add a dedicated `pwa` clientType for web-based players, as suggested in the review.

This keeps clean separation:
- PWA players register as `pwa` — gets PWA URL handling and WebSocket XMR
- Native Linux players stay as `linux` — completely unaffected
- chromeOS unchanged

## Changes

- `isPwa()`: add `|| $this->clientType === 'pwa'`
- `isWebSocketXmrSupported()`: add `|| $this->clientType === 'pwa'`

## Why

Web-based players need `isPwa()` to return true for correct URL handling in `decorateForPlayer()`. Using a dedicated `pwa` clientType avoids any impact on the official native Linux player.

Fixes xibosignage/xibo#3830