### PR TITLE
Feat: add more components to Layouts Page

### DIFF
--- a/frontend/src/components/ui/forms/PublishDateSelect.tsx
+++ b/frontend/src/components/ui/forms/PublishDateSelect.tsx
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+  useFloating,
+  autoUpdate,
+  offset,
+  flip,
+  shift,
+  size,
+  useClick,
+  useDismiss,
+  useInteractions,
+  FloatingPortal,
+} from '@floating-ui/react';
+import { CalendarClock, ChevronDown, ChevronRight } from 'lucide-react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { twMerge } from 'tailwind-merge';
+
+import DatePicker from '../DatePicker';
+
+export type PublishValue = { type: 'now' } | { type: 'scheduled'; date: Date };
+
+interface PublishDateSelectProps {
+  value?: PublishValue;
+  onSelect: (value: PublishValue) => void;
+}
+
+export default function PublishDateSelect({ value, onSelect }: PublishDateSelectProps) {
+  const { t } = useTranslation();
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [openDatePicker, setOpenDatePicker] = useState(false);
+
+  const { refs, floatingStyles, context } = useFloating({
+    open: isOpen,
+    onOpenChange: (open) => {
+      setIsOpen(open);
+      if (!open) {
+        setOpenDatePicker(false);
+      }
+    },
+    placement: 'bottom-start',
+    whileElementsMounted: autoUpdate,
+    middleware: [
+      offset(4),
+      flip(),
+      shift(),
+      size({
+        apply({ rects, elements }) {
+          Object.assign(elements.floating.style, {
+            minWidth: `${rects.reference.width}px`,
+          });
+        },
+      }),
+    ],
+  });
+
+  const click = useClick(context);
+  const dismiss = useDismiss(context);
+  const { getReferenceProps, getFloatingProps } = useInteractions([click, dismiss]);
+
+  return (
+    <div className="relative overflow-visible">
+      <label className="text-sm font-semibold text-gray-500">{t('Expiry Date')}</label>
+
+      <div
+        ref={refs.setReference}
+        {...getReferenceProps()}
+        className="w-full border border-gray-200 rounded-lg flex items-center cursor-pointer bg-white"
+      >
+        <span className="p-3 text-gray-500 border-r text-sm border-gray-200">
+          <CalendarClock size={16} />
+        </span>
+        <span className="p-3 flex-1 text-sm">
+          {value?.type === 'now'
+            ? t('Publish Now')
+            : value?.type === 'scheduled'
+              ? value.date.toLocaleString()
+              : t('Select publish option')}
+        </span>
+        <button
+          type="button"
+          className={twMerge(
+            'p-3 text-gray-500 transition-transform duration-300 ease-in-out',
+            isOpen ? 'rotate-180' : 'rotate-0',
+          )}
+        >
+          <ChevronDown size={14} />
+        </button>
+      </div>
+
+      <FloatingPortal>
+        {isOpen && (
+          <div
+            ref={refs.setFloating}
+            style={floatingStyles}
+            {...getFloatingProps()}
+            className="z-9999 bg-white shadow-xl rounded-lg border border-gray-100 overflow-hidden flex flex-col"
+          >
+            <div className="flex">
+              <div className="flex flex-col text-sm p-3 flex-1">
+                {/* Publish Now */}
+                <button
+                  type="button"
+                  className="text-left p-2 rounded-lg hover:bg-gray-100 font-medium"
+                  onClick={() => {
+                    onSelect({ type: 'now' });
+                    setIsOpen(false);
+                  }}
+                >
+                  {t('Publish Now')}
+                </button>
+
+                {/* TODO: Schedule publish date is still not implemented in the BE */}
+                <button
+                  type="button"
+                  className="text-left p-2 rounded-lg hover:bg-gray-100 font-medium flex justify-between items-center"
+                  onClick={() => setOpenDatePicker((prev) => !prev)}
+                >
+                  {t('Custom Date')}
+                  <ChevronRight size={14} className="text-gray-500" />
+                </button>
+              </div>
+              {openDatePicker && (
+                <DatePicker
+                  mode="single"
+                  value={{
+                    date: value?.type === 'scheduled' ? value.date : undefined,
+                  }}
+                  disablePastDates={true}
+                  onCancel={() => {
+                    setOpenDatePicker(false);
+                  }}
+                  onApply={(val) => {
+                    if (val.type === 'single') {
+                      onSelect({
+                        type: 'scheduled',
+                        date: val.date,
+                      });
+                    }
+                    setIsOpen(false);
+                  }}
+                />
+              )}
+            </div>
+          </div>
+        )}
+      </FloatingPortal>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/forms/SelectDropdown.tsx
+++ b/frontend/src/components/ui/forms/SelectDropdown.tsx
@@ -58,6 +58,7 @@ interface SelectDropdownProps {
   addOptionAvatar?: boolean;
   className?: string;
   error?: string;
+  isLoading?: boolean;
 }
 
 export default function SelectDropdown({
@@ -73,6 +74,7 @@ export default function SelectDropdown({
   className,
   addOptionAvatar,
   error,
+  isLoading,
 }: SelectDropdownProps) {
   const { t } = useTranslation();
 
@@ -117,7 +119,12 @@ export default function SelectDropdown({
             {leftLabelContent}
           </div>
         )}
-        <span className="py-2 px-3 flex-1 text-sm capitalize">
+        <span
+          className={twMerge(
+            'py-2 px-3 flex-1 text-sm',
+            isLoading ? 'text-gray-400 italic' : 'text-gray-800 capitalize',
+          )}
+        >
           {selectedLabel || t(placeholder)}
         </span>
         <span

--- a/frontend/src/components/ui/modals/PublishModal.tsx
+++ b/frontend/src/components/ui/modals/PublishModal.tsx
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { UploadCloud } from 'lucide-react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { PublishValue } from '../forms/PublishDateSelect';
+import PublishDateSelect from '../forms/PublishDateSelect';
+
+import Modal from '@/components/ui/modals/Modal';
+
+interface PublishModalProps {
+  isOpen?: boolean;
+  onClose: () => void;
+  fileName?: string;
+  error?: string | null;
+  isLoading?: boolean;
+  titleText: string;
+  onPublish: (id: number, value: PublishValue) => void;
+  layoutId?: number;
+}
+
+export default function PublishModal({
+  isOpen = true,
+  onClose,
+  fileName,
+  isLoading,
+  error,
+  titleText,
+  onPublish,
+  layoutId,
+}: PublishModalProps) {
+  const { t } = useTranslation();
+
+  const [publishValue, setPublishValue] = useState<PublishValue>({
+    type: 'now',
+  });
+
+  const handlePublish = () => {
+    if (!layoutId) return;
+
+    if (publishValue.type === 'scheduled' && !publishValue.date) {
+      return;
+    }
+
+    onPublish(layoutId, publishValue);
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      isPending={isLoading}
+      onClose={isLoading ? () => {} : onClose}
+      actions={[
+        {
+          label: t('Cancel'),
+          onClick: onClose,
+          variant: 'secondary',
+          disabled: isLoading,
+        },
+        {
+          label: isLoading ? t('Publishing…') : t('Publish'),
+          onClick: handlePublish,
+          disabled: isLoading,
+        },
+      ]}
+      size="md"
+    >
+      <div className="flex flex-col p-5 gap-3">
+        <div className="flex justify-center">
+          <div className="bg-blue-100 w-15.5 h-15.5 text-blue-800 border-blue-50 border-[7px] rounded-full p-3">
+            <UploadCloud size={26} />
+          </div>
+        </div>
+
+        <h2 className="text-center text-lg font-semibold text-gray-800">{titleText}</h2>
+
+        <p className="text-center text-gray-500">
+          {t('Are you sure you want to publish ')}"<strong>{fileName}</strong>?"
+          {t(' If it is already in use the update will automatically get pushed.')}
+        </p>
+
+        <PublishDateSelect value={publishValue} onSelect={setPublishValue} />
+
+        {error && (
+          <div className="text-center">
+            <p className="text-sm font-medium text-red-600">{error}</p>
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/components/ui/table/DataTableRowActions.tsx
+++ b/frontend/src/components/ui/table/DataTableRowActions.tsx
@@ -29,6 +29,7 @@ import {
   useDismiss,
   useInteractions,
   FloatingPortal,
+  size,
 } from '@floating-ui/react';
 import type { LucideIcon } from 'lucide-react';
 import { ChevronRight, MoreVertical } from 'lucide-react';
@@ -40,6 +41,7 @@ export interface DataTableRowAction<TData> {
   label?: string;
   onClick?: (row: TData) => void;
   icon?: LucideIcon;
+  rightIcon?: LucideIcon;
   isNavigation?: boolean;
   variant?: 'default' | 'primary' | 'danger';
   isSeparator?: boolean;
@@ -63,7 +65,19 @@ export default function DataTableRowActions<TData>({
     onOpenChange: setOpen,
     placement: 'bottom-end',
     whileElementsMounted: autoUpdate,
-    middleware: [offset(4), flip(), shift()],
+    middleware: [
+      offset(4),
+      flip(),
+      shift(),
+      size({
+        apply({ availableHeight, elements }) {
+          Object.assign(elements.floating.style, {
+            maxHeight: `${availableHeight}px`,
+          });
+        },
+        padding: 8,
+      }),
+    ],
   });
 
   const click = useClick(context);
@@ -87,7 +101,7 @@ export default function DataTableRowActions<TData>({
             ref={refs.setFloating}
             style={floatingStyles}
             {...getFloatingProps()}
-            className="z-100 bg-white shadow-lg rounded-xl overflow-hidden min-w-40"
+            className="z-100 bg-white shadow-lg rounded-xl overflow-hidden min-w-40 overflow-y-auto"
           >
             <div className="p-2">
               {actions.map((action, idx) => {
@@ -121,6 +135,11 @@ export default function DataTableRowActions<TData>({
                     {action.isNavigation && (
                       <span className="w-4 h-4 flex items-center justify-center shrink-0 text-gray-400">
                         <ChevronRight />
+                      </span>
+                    )}
+                    {action.rightIcon && (
+                      <span className="w-4 h-4 flex items-center justify-center">
+                        <action.rightIcon />
                       </span>
                     )}
                   </button>

--- a/frontend/src/pages/Design/Layouts/LayoutConfig.tsx
+++ b/frontend/src/pages/Design/Layouts/LayoutConfig.tsx
@@ -30,6 +30,12 @@ import {
   Trash2,
   PaletteIcon,
   CloudUpload,
+  DownloadCloud,
+  Redo2,
+  FileCheck,
+  Download,
+  FileX,
+  ArrowRight,
   Info,
 } from 'lucide-react';
 import type { ComponentProps } from 'react';
@@ -119,7 +125,195 @@ export interface LayoutActionsProps {
   copyLayout?: (row: number) => void;
   openDetails?: (id: number) => void;
   openLayout?: (id: number) => void;
+  openPublish?: (id: number) => void;
+  checkoutLayout?: (id: number) => void;
+  discardLayout?: (id: number) => void;
+  assignModal?: (layout: Layout) => void;
+  jumpToPlaylists?: (layoutId: number) => void;
+  exportLayout?: (row: Layout) => void;
+  openTemplateModal?: (layoutId: number) => void;
+  jumpToCampaigns?: (layoutId: number) => void;
+  jumpToMedia?: (layoutId: number) => void;
+  openRetireModal?: (layout: Layout) => void;
+  openEnableStatsModal?: (layout: Layout) => void;
 }
+
+export const getLayoutItemActions = ({
+  t,
+  onDelete,
+  openEditModal,
+  openShareModal,
+  openMoveModal,
+  copyLayout,
+  openDetails,
+  openLayout,
+  openPublish,
+  checkoutLayout,
+  discardLayout,
+  assignModal,
+  jumpToPlaylists,
+  jumpToCampaigns,
+  jumpToMedia,
+  exportLayout,
+  openTemplateModal,
+  openRetireModal,
+  openEnableStatsModal,
+}: LayoutActionsProps): ((layout: Layout) => ActionItem[]) => {
+  return (layout: Layout) => {
+    const actions: ActionItem[] = [];
+
+    // TODO: Set all true for now. Add userPermission to layout data
+    const canEdit = layout.userPermissions?.edit ?? 1;
+    const canDelete = layout.userPermissions?.delete ?? 1;
+    const canShare = layout.userPermissions?.modifyPermissions ?? 1;
+
+    actions.push({
+      label: t('Design'),
+      icon: PaletteIcon,
+      isQuickAction: true,
+      variant: 'primary',
+
+      onClick: () => openLayout && openLayout(layout.layoutId),
+    });
+
+    if (canEdit) {
+      actions.push({
+        label: t('Edit'),
+        icon: Edit,
+        onClick: () => openEditModal(layout),
+        isQuickAction: true,
+      });
+    }
+
+    actions.push({
+      label: t('Design'),
+      icon: PaletteIcon,
+      onClick: () => openLayout && openLayout(layout.layoutId),
+    });
+
+    if (layout.publishedStatus !== 'Published') {
+      actions.push({
+        label: t('Publish'),
+        icon: CloudUpload,
+        onClick: () => openPublish && openPublish(layout.layoutId),
+      });
+      actions.push({
+        label: t('Discard'),
+        icon: Redo2,
+        onClick: () => discardLayout && discardLayout(layout.layoutId),
+      });
+    } else {
+      actions.push({
+        label: t('Checkout'),
+        icon: DownloadCloud,
+        onClick: () => checkoutLayout && checkoutLayout(layout.layoutId),
+      });
+      actions.push({
+        label: t('Save as Template'),
+        icon: FileCheck,
+        onClick: () => openTemplateModal && openTemplateModal(layout.layoutId),
+      });
+    }
+
+    actions.push({ isSeparator: true });
+
+    if (canEdit) {
+      actions.push({
+        label: t('Edit'),
+        icon: Edit,
+        onClick: () => openEditModal(layout),
+      });
+    }
+
+    if (canEdit && openMoveModal) {
+      actions.push({
+        label: t('Move'),
+        icon: FolderInput,
+        onClick: () => openMoveModal(layout),
+      });
+    }
+
+    if (canEdit && copyLayout) {
+      actions.push({
+        label: t('Make a Copy'),
+        icon: CopyCheck,
+        onClick: () => copyLayout(layout.layoutId),
+      });
+    }
+
+    if (canShare && openShareModal && layout.campaignId) {
+      actions.push({
+        label: t('Share'),
+        icon: UserPlus2,
+        onClick: () => openShareModal(layout.campaignId),
+      });
+    }
+
+    actions.push({
+      label: t('Export'),
+      icon: Download,
+      onClick: () => exportLayout && exportLayout(layout),
+    });
+
+    actions.push({
+      label: t('Schedule'),
+      icon: CalendarClock,
+      onClick: () => console.log('Schedule', layout.layoutId),
+    });
+
+    actions.push({
+      label: t('Retire'),
+      icon: FileX,
+      onClick: () => openRetireModal && openRetireModal(layout),
+    });
+    actions.push({
+      label: t('Details'),
+      icon: Info,
+      onClick: () => openDetails && openDetails(layout.layoutId),
+    });
+
+    actions.push({ isSeparator: true });
+
+    actions.push({
+      label: t('Jump to Playlists'),
+      onClick: () => jumpToPlaylists && jumpToPlaylists(layout.layoutId),
+      rightIcon: ArrowRight,
+    });
+    actions.push({
+      label: t('Jump to Campaigns'),
+      onClick: () => jumpToCampaigns && jumpToCampaigns(layout.layoutId),
+      rightIcon: ArrowRight,
+    });
+    actions.push({
+      label: t('Jump to Media'),
+      onClick: () => jumpToMedia && jumpToMedia(layout.layoutId),
+      rightIcon: ArrowRight,
+    });
+
+    actions.push({
+      label: t('Assign to Campaign'),
+      onClick: () => assignModal && assignModal(layout),
+    });
+
+    actions.push({
+      label: t('Enable Stats Collection'),
+      onClick: () => openEnableStatsModal && openEnableStatsModal(layout),
+    });
+
+    if (canDelete) {
+      actions.push({ isSeparator: true });
+
+      actions.push({
+        label: t('Delete'),
+        icon: Trash2,
+        onClick: () => onDelete(layout.layoutId),
+        variant: 'danger',
+      });
+    }
+
+    return actions;
+  };
+};
 
 export const getLayoutColumns = (props: LayoutActionsProps): ColumnDef<Layout>[] => {
   const { t } = props;
@@ -251,6 +445,12 @@ export const getLayoutColumns = (props: LayoutActionsProps): ColumnDef<Layout>[]
       cell: (info) => <TextCell>{info.getValue<number>()}</TextCell>,
     },
     {
+      accessorKey: 'code',
+      header: t('Code'),
+      size: 100,
+      cell: (info) => <TextCell>{info.getValue<number>() || '-'}</TextCell>,
+    },
+    {
       id: 'tableActions',
       header: '',
       size: 120,
@@ -303,133 +503,4 @@ export const getBulkActions = ({
       onClick: onDelete,
     },
   ];
-};
-
-export const getLayoutItemActions = ({
-  t,
-  onDelete,
-  openEditModal,
-  openShareModal,
-  openMoveModal,
-  copyLayout,
-  openDetails,
-  openLayout,
-}: LayoutActionsProps): ((layout: Layout) => ActionItem[]) => {
-  return (layout: Layout) => {
-    const actions: ActionItem[] = [];
-
-    // TODO: Set all true for now. Add userPermission to layout data
-    const canEdit = layout.userPermissions?.edit ?? 1;
-    const canDelete = layout.userPermissions?.delete ?? 1;
-    const canShare = layout.userPermissions?.modifyPermissions ?? 1;
-
-    if (canEdit) {
-      actions.push({
-        label: t('Edit'),
-        icon: Edit,
-        onClick: () => openEditModal(layout),
-        isQuickAction: true,
-        variant: 'primary',
-      });
-    }
-
-    actions.push({
-      label: t('Details'),
-      icon: Info,
-      onClick: () => openDetails && openDetails(layout.layoutId),
-      isQuickAction: true,
-      variant: 'primary',
-    });
-
-    actions.push({
-      label: t('Design'),
-      icon: PaletteIcon,
-      onClick: () => openLayout && openLayout(layout.layoutId),
-    });
-
-    actions.push({ isSeparator: true });
-
-    actions.push({
-      label: t('Publish'),
-      icon: CloudUpload,
-      onClick: () => console.log('Publish', layout.layoutId),
-    });
-
-    actions.push({ isSeparator: true });
-
-    actions.push({
-      label: t('Schedule'),
-      icon: CalendarClock,
-      onClick: () => console.log('Schedule', layout.layoutId),
-    });
-
-    actions.push({ isSeparator: true });
-
-    if (canEdit) {
-      actions.push({
-        label: t('Edit'),
-        icon: Edit,
-        onClick: () => openEditModal(layout),
-      });
-    }
-
-    if (canEdit && openMoveModal) {
-      actions.push({
-        label: t('Move'),
-        icon: FolderInput,
-        onClick: () => openMoveModal(layout),
-      });
-    }
-
-    if (canEdit && copyLayout) {
-      actions.push({
-        label: t('Make a Copy'),
-        icon: CopyCheck,
-        onClick: () => copyLayout(layout.layoutId),
-      });
-    }
-
-    if (canShare && openShareModal && layout.campaignId) {
-      actions.push({
-        label: t('Share'),
-        icon: UserPlus2,
-        onClick: () => openShareModal(layout.campaignId),
-      });
-    }
-
-    actions.push({ isSeparator: true });
-
-    actions.push({
-      label: t('Assign to Campaign'),
-      onClick: () => console.log('Assign to Campaign', layout.layoutId),
-    });
-
-    actions.push({
-      label: t('Discard'),
-      onClick: () => console.log('Discard', layout.layoutId),
-    });
-
-    actions.push({
-      label: t('Enable Stats Collection'),
-      onClick: () => console.log('Enable Stats', layout.layoutId),
-    });
-
-    actions.push({
-      label: t('Retire'),
-      onClick: () => console.log('Retire', layout.layoutId),
-    });
-
-    if (canDelete) {
-      actions.push({ isSeparator: true });
-
-      actions.push({
-        label: t('Delete'),
-        icon: Trash2,
-        onClick: () => onDelete(layout.layoutId),
-        variant: 'danger',
-      });
-    }
-
-    return actions;
-  };
 };

--- a/frontend/src/pages/Design/Layouts/Layouts.tsx
+++ b/frontend/src/pages/Design/Layouts/Layouts.tsx
@@ -87,6 +87,7 @@ export default function Layouts() {
       status: true,
       modifiedDt: false,
       layoutId: false,
+      code: false,
     },
     viewMode: 'table',
     globalFilter: '',
@@ -225,11 +226,23 @@ export default function Layouts() {
     deleteError,
     setDeleteError,
     isCloning,
+    isPublishing,
+    isAssigning,
     confirmDelete,
     handleConfirmClone,
     handleConfirmMove,
     handleCreateLayout,
     handleOpenLayout,
+    confirmPublish,
+    handleCheckoutLayout,
+    isDiscarding,
+    handleConfirmDiscard,
+    handleConfirmAssign,
+    handleJumpToPlaylists,
+    handleJumpToCampaigns,
+    handleJumpToMedia,
+    isExporting,
+    handleExportLayout,
   } = useLayoutActions({
     t,
     handleRefresh,
@@ -271,6 +284,36 @@ export default function Layouts() {
     openModal('copy');
   };
 
+  const openPublish = (layoutId: number) => {
+    setSelectedLayoutId(layoutId);
+    openModal('publish');
+  };
+
+  const handleDiscardModal = (layoutId: number) => {
+    setSelectedLayoutId(layoutId);
+    openModal('discard');
+  };
+
+  const handleExportModal = (layoutId: number) => {
+    setSelectedLayoutId(layoutId);
+    openModal('export');
+  };
+
+  const openTemplateModal = (layoutId: number) => {
+    setSelectedLayoutId(layoutId);
+    openModal('template');
+  };
+
+  const openRetireModal = (row: Layout) => {
+    setSelectedLayoutId(row.layoutId);
+    openModal('retire');
+  };
+
+  const openEnableStatsModal = (row: Layout) => {
+    setSelectedLayoutId(row.layoutId);
+    openModal('enableStats');
+  };
+
   const columns = getLayoutColumns({
     t,
     onDelete: handleDelete,
@@ -291,6 +334,24 @@ export default function Layouts() {
     openLayout: (layoutId) => {
       handleOpenLayout(layoutId);
     },
+    openPublish,
+    checkoutLayout: (layoutId) => {
+      handleCheckoutLayout(layoutId);
+    },
+    discardLayout: handleDiscardModal,
+    assignModal: (layout) => {
+      setSelectedLayoutId(layout.layoutId);
+      openModal('campaign');
+    },
+    jumpToPlaylists: handleJumpToPlaylists,
+    jumpToCampaigns: handleJumpToCampaigns,
+    jumpToMedia: handleJumpToMedia,
+    exportLayout: (layout) => {
+      handleExportModal(layout.layoutId);
+    },
+    openTemplateModal,
+    openRetireModal,
+    openEnableStatsModal,
   });
 
   const getAllSelectedItems = (): Layout[] => {
@@ -450,6 +511,10 @@ export default function Layouts() {
           deleteError,
           isDeleting,
           isCloning,
+          isPublishing,
+          isDiscarding,
+          isAssigning,
+          isExporting,
         }}
         selection={{
           selectedLayout,
@@ -464,6 +529,10 @@ export default function Layouts() {
           handleConfirmClone: (name, description, copyMedia) =>
             handleConfirmClone(selectedLayout, name, description, copyMedia),
           handleConfirmMove: (folderId) => handleConfirmMove(itemsToMove, folderId),
+          confirmPublish,
+          confirmDiscard: handleConfirmDiscard,
+          handleConfirmAssign,
+          handleExportLayout,
         }}
         infoPanel={{
           isOpen: showInfoPanel,

--- a/frontend/src/pages/Design/Layouts/components/AssignCampaignModal.tsx
+++ b/frontend/src/pages/Design/Layouts/components/AssignCampaignModal.tsx
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { SelectOption } from '@/components/ui/forms/SelectDropdown';
+import SelectDropdown from '@/components/ui/forms/SelectDropdown';
+import Modal from '@/components/ui/modals/Modal';
+import type { Campaign } from '@/services/campaignApi';
+import { fetchCampaigns } from '@/services/campaignApi';
+
+interface AssignCampaignModalProps {
+  isOpen?: boolean;
+  onClose: () => void;
+  onConfirm: (campaignId: number) => void;
+  isLoading?: boolean;
+}
+
+export default function AssignCampaignModal({
+  isOpen = true,
+  onClose,
+  onConfirm,
+  isLoading,
+}: AssignCampaignModalProps) {
+  const { t } = useTranslation();
+  const [selectedCampaign, setSelectedCampaign] = useState<string>('');
+  const [campaigns, setCampaigns] = useState<Campaign[]>([]);
+  const [error, setError] = useState<string | undefined>();
+
+  const [isFetching, setIsFetching] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    setSelectedCampaign('');
+    setError(undefined);
+    setCampaigns([]);
+    setIsFetching(true);
+
+    fetchCampaigns()
+      .then((res) => setCampaigns(res.rows))
+      .catch((err) => {
+        console.error(err);
+        setError(t('Failed to load campaigns'));
+      })
+      .finally(() => setIsFetching(false));
+  }, [isOpen, t]);
+
+  const campaignOptions: SelectOption[] = campaigns.map((c) => ({
+    label: c.campaign,
+    value: String(c.campaignId),
+  }));
+
+  const handleSave = () => {
+    if (!selectedCampaign) {
+      setError(t('Please select a campaign'));
+      return;
+    }
+
+    setError(undefined);
+    onConfirm(Number(selectedCampaign));
+  };
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      title={t('Assign Layout to Campaign')}
+      onClose={onClose}
+      size="md"
+      actions={[
+        {
+          label: t('Cancel'),
+          onClick: onClose,
+          variant: 'secondary',
+          disabled: isLoading,
+        },
+        {
+          label: isLoading ? t('Saving…') : t('Save'),
+          onClick: handleSave,
+          disabled: isLoading,
+        },
+      ]}
+    >
+      <div className="px-8 pb-8 space-y-4">
+        <SelectDropdown
+          label="Campaign"
+          placeholder={
+            isFetching
+              ? t('Loading campaigns...')
+              : campaignOptions.length
+                ? t('Select campaign')
+                : t('No campaigns available')
+          }
+          value={selectedCampaign}
+          options={campaignOptions}
+          onSelect={(value) => {
+            setSelectedCampaign(value);
+            setError(undefined);
+          }}
+          searchable={!isFetching}
+          error={error}
+          isLoading={isFetching}
+        />
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/pages/Design/Layouts/components/DiscardLayoutModal.tsx
+++ b/frontend/src/pages/Design/Layouts/components/DiscardLayoutModal.tsx
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { AlertTriangle } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import Modal from '@/components/ui/modals/Modal';
+
+interface DiscardLayoutModalProps {
+  isOpen?: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  layoutName?: string;
+  isLoading?: boolean;
+  error?: string | null;
+}
+
+export default function DiscardLayoutModal({
+  isOpen,
+  onClose,
+  onConfirm,
+  layoutName,
+  isLoading,
+  error,
+}: DiscardLayoutModalProps) {
+  const { t } = useTranslation();
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      isPending={isLoading}
+      onClose={isLoading ? () => {} : onClose}
+      actions={[
+        {
+          label: t('Cancel'),
+          onClick: onClose,
+          variant: 'secondary',
+          disabled: isLoading,
+        },
+        {
+          label: isLoading ? t('Discarding…') : t('Discard'),
+          onClick: onConfirm,
+          disabled: isLoading,
+        },
+      ]}
+      size="md"
+    >
+      <div className="flex flex-col p-5 gap-3 text-center">
+        <div className="flex justify-center mb-2">
+          <div className="bg-red-100 w-15.5 h-15.5 text-red-600 border-red-50 border-[7px] rounded-full p-3">
+            <AlertTriangle size={26} />
+          </div>
+        </div>
+
+        <h2 className="text-lg font-semibold text-gray-800">{t('Discard Changes?')}</h2>
+
+        <p className="text-gray-500">
+          {t('Are you sure you want to discard changes for ')}
+          <strong>{layoutName}</strong>?
+        </p>
+
+        <p className="text-sm text-gray-400">
+          {t('This will restore the original layout and cannot be undone.')}
+        </p>
+
+        {error && <p className="text-sm font-medium text-red-600">{error}</p>}
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/pages/Design/Layouts/components/EditLayout.tsx
+++ b/frontend/src/pages/Design/Layouts/components/EditLayout.tsx
@@ -197,23 +197,6 @@ export default function EditLayout({ isOpen = true, onClose, data, onSave }: Edi
             error={formErrors.name}
           />
 
-          <TextInput
-            name="description"
-            label={t('Description')}
-            value={draft.description ?? ''}
-            placeholder={t('Add description')}
-            helpText={t('Optional description for this layout')}
-            onChange={(value) => {
-              setDraft((prev) => ({
-                ...prev,
-                description: value,
-              }));
-              clearError('description');
-            }}
-            multiline
-            rows={3}
-            error={formErrors.description}
-          />
           {/* Tags */}
           <TagInput
             value={draft.tags}
@@ -236,22 +219,40 @@ export default function EditLayout({ isOpen = true, onClose, data, onSave }: Edi
             error={formErrors.code}
           />
 
+          <TextInput
+            name="description"
+            label={t('Description')}
+            value={draft.description ?? ''}
+            placeholder={t('Add description')}
+            helpText={t('(Optional) | Up to 250 characters.')}
+            onChange={(value) => {
+              setDraft((prev) => ({
+                ...prev,
+                description: value,
+              }));
+              clearError('description');
+            }}
+            multiline
+            rows={3}
+            error={formErrors.description}
+          />
+
           {/* Retired */}
           <Checkbox
             id="retired"
             className="items-center px-3 py-2.5"
-            title={t('Retire this media?')}
-            label={t(
-              `Retired media remains on existing Layouts but is not available to assign to new Layouts.`,
-            )}
+            title={t('Retire Layout')}
+            label={t(`It will no longer be visible in the lists.`)}
             checked={draft.retired}
             onChange={() => setDraft((prev) => ({ ...prev, retired: !prev.retired }))}
           />
           <Checkbox
             id="update"
             className="items-center px-3 py-2.5"
-            title={t('Update this media in all layouts it is assigned to')}
-            label={t(`Note: It will only be updated in layouts you have permission to edit.`)}
+            title={t('Enable Stats Collections')}
+            label={t(
+              `Collect Proof of Play statistics. Requires 'Enable Stats Collection' to be set to 'On' in Display Settings.`,
+            )}
             checked={draft.enableStat}
             onChange={() => setDraft((prev) => ({ ...prev, enableStat: !prev.enableStat }))}
           />

--- a/frontend/src/pages/Design/Layouts/components/EnableStatsLayoutModal.tsx
+++ b/frontend/src/pages/Design/Layouts/components/EnableStatsLayoutModal.tsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import Checkbox from '@/components/ui/forms/Checkbox';
+import Modal from '@/components/ui/modals/Modal';
+import { updateLayout } from '@/services/layoutsApi';
+import type { Layout } from '@/types/layout';
+
+interface EnableStatsLayoutModalProps {
+  layout: Layout | null;
+  isOpen?: boolean;
+  onClose: () => void;
+  onSuccess?: (layout: Layout) => void;
+}
+
+export function EnableStatsLayoutModal({
+  layout,
+  isOpen = true,
+  onClose,
+  onSuccess,
+}: EnableStatsLayoutModalProps) {
+  const { t } = useTranslation();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string>();
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    if (layout) {
+      setEnabled(!!layout.enableStat);
+    }
+  }, [layout]);
+
+  const handleConfirm = async () => {
+    if (!layout || isLoading) return;
+
+    try {
+      setIsLoading(true);
+
+      const updated = await updateLayout(layout.layoutId, {
+        enableStat: enabled ? 1 : 0,
+      });
+
+      onSuccess?.(updated);
+      onClose();
+    } catch (err) {
+      console.error(err);
+      setError(t('Failed to update stats setting'));
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (!layout) return null;
+
+  return (
+    <Modal
+      title={t('Retire Layout')}
+      isOpen={isOpen}
+      onClose={onClose}
+      isPending={isLoading}
+      error={error}
+      actions={[
+        {
+          label: t('Cancel'),
+          onClick: onClose,
+          variant: 'secondary',
+        },
+        {
+          label: t('Retire'),
+          onClick: handleConfirm,
+          disabled: isLoading,
+        },
+      ]}
+    >
+      <div className="p-4 flex flex-col gap-3">
+        <Checkbox
+          id="update"
+          className="items-center px-3 py-2.5"
+          title={t('Enable Stats Collections')}
+          label={t(
+            `Collect Proof of Play statistics. Requires 'Enable Stats Collection' to be set to 'On' in Display Settings.`,
+          )}
+          checked={enabled}
+          onChange={(e) => setEnabled(e.target.checked)}
+        />
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/pages/Design/Layouts/components/ExportLayoutModal.tsx
+++ b/frontend/src/pages/Design/Layouts/components/ExportLayoutModal.tsx
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Download } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import Checkbox from '@/components/ui/forms/Checkbox';
+import TextInput from '@/components/ui/forms/TextInput';
+import Modal from '@/components/ui/modals/Modal';
+
+interface ExportLayoutModalProps {
+  isOpen?: boolean;
+  onClose: () => void;
+  onConfirm: (options: {
+    includeData: boolean;
+    includeFallback: boolean;
+    fileName: string;
+  }) => void;
+  layoutName?: string;
+  isLoading?: boolean;
+  error?: string | null;
+}
+
+export default function ExportLayoutModal({
+  isOpen = true,
+  onClose,
+  onConfirm,
+  layoutName,
+  isLoading,
+  error,
+}: ExportLayoutModalProps) {
+  const { t } = useTranslation();
+  const [includeData, setIncludeData] = useState(false);
+  const [includeFallback, setIncludeFallback] = useState(false);
+  const [fileName, setFileName] = useState('');
+
+  useEffect(() => {
+    if (layoutName) {
+      setFileName(`export_${layoutName}`);
+    }
+  }, [layoutName]);
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      isPending={isLoading}
+      onClose={isLoading ? () => {} : onClose}
+      actions={[
+        {
+          label: t('Cancel'),
+          onClick: onClose,
+          variant: 'secondary',
+          disabled: isLoading,
+        },
+        {
+          label: isLoading ? t('Exporting...') : t('Export'),
+          onClick: () =>
+            onConfirm({
+              includeData,
+              includeFallback,
+              fileName,
+            }),
+          disabled: isLoading,
+        },
+      ]}
+      size="md"
+      error={error || undefined}
+    >
+      <div className="flex flex-col p-5 gap-3">
+        <div className="flex justify-center mb-2">
+          <div className="bg-blue-100 w-15.5 h-15.5 text-blue-800 border-blue-50 border-[7px] rounded-full p-3">
+            <Download size={26} />
+          </div>
+        </div>
+
+        <h2 className="text-lg font-semibold text-gray-800 text-center">{t('Discard Changes?')}</h2>
+
+        <p className="text-gray-500 text-center">
+          {t(
+            'The downloaded ZIP file will include the layout, widgets, media, and associated DataSet structures.',
+          )}
+          <strong>{layoutName}</strong>?
+        </p>
+
+        <TextInput
+          name="name"
+          label={t('Name')}
+          value={fileName}
+          onChange={(value) => setFileName(value)}
+          helpText={t('Enter a custom name for the downloaded file.')}
+        />
+        <Checkbox
+          id="retired"
+          className="items-center px-3 py-2.5"
+          title={t('Datasets Data')}
+          label={t(`Enable to include Dataset data.`)}
+          checked={includeData}
+          onChange={(e) => setIncludeData(e.target.checked)}
+        />
+        <Checkbox
+          id="update"
+          className="items-center px-3 py-2.5"
+          title={t('Widget Fallback Data')}
+          label={t(`Include fallback content added to Widgets within this Layout.`)}
+          checked={includeFallback}
+          onChange={(e) => setIncludeFallback(e.target.checked)}
+        />
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/pages/Design/Layouts/components/LayoutsModal.tsx
+++ b/frontend/src/pages/Design/Layouts/components/LayoutsModal.tsx
@@ -21,13 +21,21 @@
 
 import { useTranslation } from 'react-i18next';
 
+import AssignCampaignModal from './AssignCampaignModal';
 import CopyLayoutModal from './CopyLayoutModal';
 import DeleteLayoutModal from './DeleteLayoutModal';
+import DiscardLayoutModal from './DiscardLayoutModal';
 import EditLayout from './EditLayout';
+import { EnableStatsLayoutModal } from './EnableStatsLayoutModal';
+import ExportLayoutModal from './ExportLayoutModal';
 import { LayoutInfoPanel } from './LayoutInfoPannel';
+import { RetireLayoutModal } from './RetireLayoutModal';
+import SaveAsTemplateModal from './SaveAsTemplateModal';
 
 import FolderActionModals from '@/components/ui/FolderActionModals';
+import type { PublishValue } from '@/components/ui/forms/PublishDateSelect';
 import MoveModal from '@/components/ui/modals/MoveModal';
+import PublishModal from '@/components/ui/modals/PublishModal';
 import ShareModal from '@/components/ui/modals/ShareModal';
 import type { useFolderActions } from '@/hooks/useFolderActions';
 import type { Layout } from '@/types/layout';
@@ -42,6 +50,10 @@ interface LayoutModalsProps {
     deleteError: string | null;
     isDeleting: boolean;
     isCloning: boolean;
+    isPublishing: boolean;
+    isDiscarding: boolean;
+    isAssigning: boolean;
+    isExporting: boolean;
   };
   selection: {
     selectedLayout: Layout | null;
@@ -55,6 +67,17 @@ interface LayoutModalsProps {
     confirmDelete: (items: Layout[]) => void;
     handleConfirmClone: (newName: string, description: string, copyMedia: boolean) => void;
     handleConfirmMove: (newFolderId: number) => void;
+    confirmPublish: (itemId: number, value: PublishValue) => void;
+    confirmDiscard: (layoutId: number) => void;
+    handleConfirmAssign: (campaignId: number, layoutId: number) => void;
+    handleExportLayout: (
+      layoutId: number,
+      options: {
+        includeData: boolean;
+        includeFallback: boolean;
+        fileName: string;
+      },
+    ) => void;
   };
   infoPanel: {
     isOpen: boolean;
@@ -142,6 +165,58 @@ export function LayoutModals({
           isLoading={actions.isCloning}
           existingNames={selection.existingNames}
         />
+      )}
+      {isModalOpen('publish') && (
+        <PublishModal
+          onClose={actions.closeModal}
+          fileName={selection.selectedLayout?.layout}
+          titleText={t('Publish Layout?')}
+          isLoading={actions.isPublishing}
+          onPublish={handlers.confirmPublish}
+          layoutId={selection.selectedLayout?.layoutId}
+        />
+      )}
+      {isModalOpen('discard') && (
+        <DiscardLayoutModal
+          onClose={actions.closeModal}
+          onConfirm={() =>
+            selection.selectedLayout && handlers.confirmDiscard(selection.selectedLayout.layoutId)
+          }
+          layoutName={selection.selectedLayout?.name || selection.selectedLayout?.layout}
+          isLoading={actions.isDiscarding}
+        />
+      )}
+      {isModalOpen('campaign') && (
+        <AssignCampaignModal
+          onClose={actions.closeModal}
+          onConfirm={(campaignId) =>
+            selection.selectedLayout &&
+            handlers.handleConfirmAssign(campaignId, selection.selectedLayout.layoutId)
+          }
+          isLoading={actions.isAssigning}
+        />
+      )}
+      {isModalOpen('export') && (
+        <ExportLayoutModal
+          onClose={actions.closeModal}
+          onConfirm={(options) =>
+            selection.selectedLayout &&
+            handlers.handleExportLayout(selection.selectedLayout.layoutId, options)
+          }
+          layoutName={selection.selectedLayout?.name || selection.selectedLayout?.layout}
+          isLoading={actions.isExporting}
+        />
+      )}
+      {isModalOpen('template') && selection.selectedLayout && (
+        <SaveAsTemplateModal onClose={actions.closeModal} layout={selection.selectedLayout} />
+      )}
+
+      {isModalOpen('retire') && selection.selectedLayout && (
+        <RetireLayoutModal layout={selection.selectedLayout} onClose={actions.closeModal} />
+      )}
+
+      {isModalOpen('enableStats') && selection.selectedLayout && (
+        <EnableStatsLayoutModal layout={selection.selectedLayout} onClose={actions.closeModal} />
       )}
 
       {infoPanel.isOpen && (

--- a/frontend/src/pages/Design/Layouts/components/RetireLayoutModal.tsx
+++ b/frontend/src/pages/Design/Layouts/components/RetireLayoutModal.tsx
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import Checkbox from '@/components/ui/forms/Checkbox';
+import Modal from '@/components/ui/modals/Modal';
+import { updateLayout } from '@/services/layoutsApi';
+import type { Layout } from '@/types/layout';
+
+interface RetireLayoutModalProps {
+  layout: Layout | null;
+  isOpen?: boolean;
+  onClose: () => void;
+  onSuccess?: (layout: Layout) => void;
+}
+
+export function RetireLayoutModal({
+  layout,
+  isOpen = true,
+  onClose,
+  onSuccess,
+}: RetireLayoutModalProps) {
+  const { t } = useTranslation();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string>();
+  const [confirmed, setConfirmed] = useState(false);
+
+  const handleConfirm = async () => {
+    if (!layout || isLoading || !confirmed) return;
+
+    try {
+      setIsLoading(true);
+
+      const updated = await updateLayout(layout.layoutId, {
+        retired: 1,
+      });
+
+      onSuccess?.(updated);
+      onClose();
+    } catch (err) {
+      console.error(err);
+      setError(t('Failed to retire layout'));
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (!layout) return null;
+
+  return (
+    <Modal
+      title={t('Retire Layout')}
+      isOpen={isOpen}
+      onClose={onClose}
+      isPending={isLoading}
+      error={error}
+      actions={[
+        {
+          label: t('Cancel'),
+          onClick: onClose,
+          variant: 'secondary',
+        },
+        {
+          label: t('Retire'),
+          onClick: handleConfirm,
+          disabled: !confirmed || isLoading,
+        },
+      ]}
+    >
+      <div className="p-4 flex flex-col gap-3">
+        <Checkbox
+          id="retired"
+          className="items-center px-3 py-2.5"
+          title={t('Retire Layout')}
+          label={t(`It will no longer be visible in the lists.`)}
+          checked={confirmed}
+          onChange={(e) => setConfirmed(e.target.checked)}
+        />
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/pages/Design/Layouts/components/SaveAsTemplateModal.tsx
+++ b/frontend/src/pages/Design/Layouts/components/SaveAsTemplateModal.tsx
@@ -1,0 +1,200 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import Checkbox from '@/components/ui/forms/Checkbox';
+import SelectFolder from '@/components/ui/forms/SelectFolder';
+import TagInput from '@/components/ui/forms/TagInput';
+import TextInput from '@/components/ui/forms/TextInput';
+import Modal from '@/components/ui/modals/Modal';
+import { getTemplateSchema } from '@/schema/templates';
+import { saveLayoutAsTemplate } from '@/services/layoutsApi';
+import type { Layout } from '@/types/layout';
+import type { Tag } from '@/types/tag';
+
+interface SaveAsTemplateModalProps {
+  isOpen?: boolean;
+  layout: Layout | null;
+  onClose: () => void;
+}
+
+export default function SaveAsTemplateModal({
+  isOpen = true,
+  layout,
+  onClose,
+}: SaveAsTemplateModalProps) {
+  const { t } = useTranslation();
+
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState(layout?.description ?? '');
+  const [tags, setTags] = useState<Tag[]>(layout?.tags?.map((t) => ({ ...t })) ?? []);
+  const [includeWidgets, setIncludeWidgets] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [formErrors, setFormErrors] = useState<{ name?: string }>({});
+  const [apiError, setApiError] = useState<string | undefined>();
+  const [folderId, setFolderId] = useState<number | undefined>(layout?.folderId);
+
+  useEffect(() => {
+    if (layout) {
+      const baseName = layout.name || layout.layout;
+
+      setName((prev) => {
+        if (prev && prev !== '') return prev;
+
+        return `${baseName} Template`;
+      });
+      setDescription(layout.description ?? '');
+      setTags(layout.tags?.map((t) => ({ ...t })) ?? []);
+      setFolderId(layout.folderId);
+    }
+  }, [layout]);
+
+  const handleSave = async () => {
+    if (!layout || isSaving) return;
+
+    const schema = getTemplateSchema(t);
+
+    const result = schema.safeParse({
+      name,
+      description,
+      tags,
+      includeWidgets,
+    });
+
+    if (!result.success) {
+      const fieldErrors = result.error.flatten().fieldErrors;
+
+      setFormErrors({
+        name: fieldErrors.name?.[0],
+      });
+
+      return;
+    }
+
+    setFormErrors({});
+    setApiError(undefined);
+
+    try {
+      setIsSaving(true);
+
+      const serializedTags = tags.map((t) => (t.value ? `${t.tag}|${t.value}` : t.tag)).join(',');
+
+      await saveLayoutAsTemplate(layout.layoutId, {
+        name,
+        includeWidgets,
+        description,
+        tags: serializedTags,
+        folderId,
+      });
+
+      onClose();
+    } catch (err) {
+      console.error(err);
+
+      const apiErr = err as { response?: { data?: { message?: string } } };
+
+      if (apiErr.response?.data?.message) {
+        setApiError(apiErr.response.data.message);
+      } else if (err instanceof Error) {
+        setApiError(err.message);
+      } else {
+        setApiError(t('Failed to create template'));
+      }
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (!layout) return null;
+
+  return (
+    <Modal
+      title={t('Save as Template')}
+      onClose={onClose}
+      isOpen={isOpen}
+      isPending={isSaving}
+      error={apiError}
+      actions={[
+        {
+          label: t('Cancel'),
+          onClick: onClose,
+          variant: 'secondary',
+          disabled: isSaving,
+        },
+        {
+          label: isSaving ? t('Saving…') : t('Save'),
+          onClick: handleSave,
+          disabled: isSaving || !name.trim(),
+        },
+      ]}
+    >
+      <div className="flex flex-col h-full overflow-y-hidden overflow-x-visible gap-3 p-4 pt-0">
+        <div className="flex flex-col gap-3 flex-1 min-h-0 p-4 overflow-y-auto pb-20">
+          <div className="relative z-20">
+            <SelectFolder
+              selectedId={folderId}
+              onSelect={(folder) => {
+                setFolderId(folder?.id ? Number(folder.id) : undefined);
+              }}
+            />
+          </div>
+
+          <TextInput
+            name="name"
+            label={t('Template Name')}
+            value={name}
+            onChange={(value) => {
+              setName(value);
+              setFormErrors((prev) => ({ ...prev, name: undefined }));
+            }}
+            error={formErrors.name}
+          />
+
+          <TextInput
+            name="description"
+            label={t('Description')}
+            value={description}
+            onChange={setDescription}
+            multiline
+            rows={3}
+          />
+
+          <TagInput
+            value={tags}
+            helpText={t('Tags separated by commas. Use Tag|Value for tagged attributes.')}
+            onChange={(tags) => setTags(tags)}
+          />
+
+          <Checkbox
+            id="includeWidgets"
+            className="items-center px-3 py-2.5"
+            title={t('Include Widgets')}
+            label={t('Include widgets from this layout in the template')}
+            checked={includeWidgets}
+            onChange={(e) => setIncludeWidgets(e.target.checked)}
+          />
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/pages/Design/Layouts/hooks/useLayoutActions.ts
+++ b/frontend/src/pages/Design/Layouts/hooks/useLayoutActions.ts
@@ -24,10 +24,21 @@ import { isAxiosError } from 'axios';
 import type { TFunction } from 'i18next';
 import type { Dispatch, SetStateAction } from 'react';
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import { notify } from '@/components/ui/Notification';
+import type { PublishValue } from '@/components/ui/forms/PublishDateSelect';
 import { selectFolder } from '@/services/folderApi';
-import { copyLayout, createLayout, deleteLayout } from '@/services/layoutsApi';
+import {
+  assignLayoutToCampaign,
+  checkoutLayout,
+  copyLayout,
+  createLayout,
+  deleteLayout,
+  discardLayout,
+  exportLayout,
+  publishLayout,
+} from '@/services/layoutsApi';
 import type { Layout } from '@/types/layout';
 
 interface UsePlaylistActionsProps {
@@ -48,6 +59,12 @@ export function useLayoutActions({
   const [isDeleting, setIsDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [isCloning, setIsCloning] = useState(false);
+  const [isPublishing, setIsPublishing] = useState(false);
+  const [isDiscarding, setIsDiscarding] = useState(false);
+  const [isAssigning, setIsAssigning] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
+
+  const navigate = useNavigate();
 
   const confirmDelete = async (itemsToDelete: Layout[]) => {
     if (itemsToDelete.length === 0 || isDeleting) {
@@ -178,15 +195,168 @@ export function useLayoutActions({
     window.open(`/layout/designer/${layoutId}`, '_blank');
   };
 
+  const handleCheckoutLayout = async (layoutId: number) => {
+    notify.info(t('Preparing layout for editing...'));
+
+    try {
+      await checkoutLayout(layoutId);
+
+      window.open(`/layout/designer/${layoutId}`, '_blank');
+
+      notify.success(t('Layout checked out successfully'));
+    } catch (error) {
+      console.error(error);
+      notify.error(t('Failed to checkout layout'));
+    }
+  };
+
+  const handleConfirmDiscard = async (layoutId: number | null) => {
+    if (!layoutId || isDiscarding) return;
+
+    try {
+      setIsDiscarding(true);
+
+      notify.info(t('Discarding layout changes...'));
+
+      await discardLayout(layoutId);
+
+      notify.success(t('Layout restored successfully'));
+
+      setRowSelection({});
+      handleRefresh();
+      closeModal();
+    } catch (error) {
+      console.error(error);
+      notify.error(t('Failed to discard layout changes'));
+    } finally {
+      setIsDiscarding(false);
+    }
+  };
+  const confirmPublish = async (layoutId: number, value: PublishValue) => {
+    if (!layoutId || isPublishing) return;
+
+    try {
+      setIsPublishing(true);
+
+      await publishLayout(layoutId, {
+        publishNow: value.type === 'now' ? 1 : 0,
+        publishDate: value.type === 'scheduled' ? value.date.toISOString() : undefined,
+      });
+
+      notify.success(t('Layout published successfully'));
+
+      setRowSelection({});
+      handleRefresh();
+      closeModal();
+    } catch (error) {
+      console.error(error);
+      notify.error(t('Failed to publish layout'));
+    } finally {
+      setIsPublishing(false);
+    }
+  };
+
+  const handleConfirmAssign = async (campaignId: number, layoutId: number | null) => {
+    if (!layoutId || isAssigning) return;
+
+    try {
+      setIsAssigning(true);
+
+      await assignLayoutToCampaign(campaignId, layoutId);
+
+      notify.success(t('Layout assigned to campaign'));
+
+      setRowSelection({});
+      handleRefresh();
+      closeModal();
+    } catch (error) {
+      console.error(error);
+      notify.error(t('Failed to assign layout'));
+    } finally {
+      setIsAssigning(false);
+    }
+  };
+
+  const handleExportLayout = async (
+    layoutId: number,
+    options: {
+      includeData: boolean;
+      includeFallback: boolean;
+      fileName: string;
+    },
+  ) => {
+    if (!layoutId || isExporting) return;
+
+    try {
+      setIsExporting(true);
+
+      const blob = await exportLayout(layoutId, {
+        includeData: options.includeData,
+        includeFallback: options.includeFallback,
+      });
+
+      const url = window.URL.createObjectURL(blob);
+
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${options.fileName}.zip`;
+      a.click();
+
+      window.URL.revokeObjectURL(url);
+
+      const text = await blob.text();
+      console.log('TEXT RESPONSE:', text);
+
+      notify.success(t('Layout exported successfully'));
+      closeModal();
+    } catch (error) {
+      console.error(error);
+      notify.error(t('Failed to export layout'));
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  const handleJumpToPlaylists = (layoutId: number) => {
+    navigate('/library/playlists', {
+      state: { layoutId },
+    });
+  };
+
+  // TODO: Page is not yet available
+  const handleJumpToCampaigns = (layoutId: number) => {
+    navigate('/design/campaigns', {
+      state: { layoutId },
+    });
+  };
+
+  const handleJumpToMedia = (layoutId: number) => {
+    navigate('/library/media', {
+      state: { layoutId },
+    });
+  };
+
   return {
     isDeleting,
     deleteError,
     setDeleteError,
     isCloning,
+    isPublishing,
+    isAssigning,
     confirmDelete,
     handleConfirmClone,
     handleConfirmMove,
     handleCreateLayout,
     handleOpenLayout,
+    confirmPublish,
+    handleCheckoutLayout,
+    isDiscarding,
+    handleConfirmDiscard,
+    handleConfirmAssign,
+    handleJumpToPlaylists,
+    handleExportLayout,
+    isExporting,
+    handleJumpToCampaigns,
+    handleJumpToMedia,
   };
 }

--- a/frontend/src/pages/Library/Media/Media.tsx
+++ b/frontend/src/pages/Library/Media/Media.tsx
@@ -24,6 +24,7 @@ import type { RowSelectionState } from '@tanstack/react-table';
 import { Search, Filter, Folder, FilterX, Plus, Upload } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router-dom';
 
 import type { MediaActionsProps, ModalType } from './MediaConfig';
 import {
@@ -65,6 +66,8 @@ export default function Media() {
   const queryClient = useQueryClient();
   const canViewFolders = usePermissions()?.canViewFolders;
   const homeFolderId = user?.homeFolderId ?? 1;
+  const location = useLocation();
+  const layoutId = location.state?.layoutId;
 
   const {
     pagination,
@@ -105,6 +108,19 @@ export default function Media() {
     filterInputs: INITIAL_FILTER_STATE,
     folderId: canViewFolders ? homeFolderId : null,
   });
+
+  useEffect(() => {
+    if (!isHydrated) return;
+
+    if (layoutId) {
+      setFilterInputs((prev) => ({
+        ...prev,
+        layoutId,
+      }));
+
+      setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+    }
+  }, [layoutId, isHydrated, setFilterInputs, setPagination]);
 
   const [folderRefreshTrigger, setFolderRefreshTrigger] = useState(0);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});

--- a/frontend/src/pages/Library/Media/MediaConfig.tsx
+++ b/frontend/src/pages/Library/Media/MediaConfig.tsx
@@ -93,7 +93,18 @@ export const getMediaIcon = (mediaType: string) => {
 
 type MediaType = 'image' | 'video' | 'audio' | 'pdf' | 'archive' | 'other';
 
-export type ModalType = BaseModalType | 'replace' | null;
+// TODO: This should be moved to a more central location
+export type ModalType =
+  | BaseModalType
+  | 'replace'
+  | 'publish'
+  | 'discard'
+  | 'campaign'
+  | 'export'
+  | 'template'
+  | 'retire'
+  | 'enableStats'
+  | null;
 
 export const INITIAL_FILTER_STATE: MediaFilterInput = {
   type: '',

--- a/frontend/src/pages/Library/Playlists/Playlists.tsx
+++ b/frontend/src/pages/Library/Playlists/Playlists.tsx
@@ -24,6 +24,7 @@ import type { RowSelectionState } from '@tanstack/react-table';
 import { Search, Filter, FilterX, Plus } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useLocation } from 'react-router-dom';
 
 import type { ModalType } from './PlaylistsConfig';
 import {
@@ -57,6 +58,8 @@ export default function Playlist() {
   const queryClient = useQueryClient();
   const canViewFolders = usePermissions()?.canViewFolders;
   const homeFolderId = user?.homeFolderId ?? 1;
+  const location = useLocation();
+  const layoutId = location.state?.layoutId;
 
   const {
     pagination,
@@ -95,6 +98,19 @@ export default function Playlist() {
     filterInputs: INITIAL_FILTER_STATE,
     folderId: canViewFolders ? homeFolderId : null,
   });
+
+  useEffect(() => {
+    if (!isHydrated) return;
+
+    if (layoutId) {
+      setFilterInputs((prev) => ({
+        ...prev,
+        layoutId,
+      }));
+
+      setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+    }
+  }, [layoutId, isHydrated, setFilterInputs, setPagination]);
 
   const [folderRefreshTrigger, setFolderRefreshTrigger] = useState(0);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});

--- a/frontend/src/schema/templates.ts
+++ b/frontend/src/schema/templates.ts
@@ -36,10 +36,10 @@ export const getTemplateSchema = (t: TFunction) =>
       .array(
         z.object({
           tag: z.string(),
-          value: z.string().optional().nullable(),
+          value: z.union([z.string(), z.number()]).optional().nullable(),
         }),
       )
       .optional(),
 
-    retired: z.boolean().optional(),
+    includeWidgets: z.boolean(),
   });

--- a/frontend/src/services/campaignApi.ts
+++ b/frontend/src/services/campaignApi.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import http from '@/lib/api';
+
+// TODO: Will transfer when Campaign page is created
+export interface Campaign {
+  campaignId: number;
+  type?: string;
+  folderId?: number;
+  retired?: number;
+  campaign: string;
+}
+
+export interface FetchCampaignRequest {
+  name?: string;
+  folderId?: number;
+  retired?: number;
+  signal?: AbortSignal;
+}
+
+export interface FetchCampaignResponse {
+  rows: Campaign[];
+  totalCount: number;
+}
+
+export async function fetchCampaigns(
+  options: FetchCampaignRequest = {},
+): Promise<FetchCampaignResponse> {
+  const { signal, ...queryParams } = options;
+
+  const response = await http.get('/campaign', {
+    params: queryParams,
+    signal,
+  });
+
+  const rows = response.data;
+
+  const totalCountHeader = response.headers['x-total-count'];
+  const totalCount = totalCountHeader ? parseInt(totalCountHeader, 10) : rows.length;
+
+  return {
+    rows,
+    totalCount,
+  };
+}

--- a/frontend/src/services/layoutsApi.ts
+++ b/frontend/src/services/layoutsApi.ts
@@ -21,6 +21,7 @@
 
 import http from '@/lib/api';
 import type { Layout } from '@/types/layout';
+import type { Template } from '@/types/templates';
 
 export interface FetchLayoutRequest {
   start: number;
@@ -75,7 +76,7 @@ export async function createLayout() {
 }
 
 export interface UpdateLayoutRequest {
-  name: string;
+  name?: string;
   description?: string | null;
   tags?: string;
   retired?: number;
@@ -111,8 +112,34 @@ export async function deleteLayout(layoutId: number | string): Promise<void> {
   });
 }
 
-export async function exportLayout(layoutId: number | string): Promise<Blob> {
-  const response = await http.get(`/layout/export/${layoutId}`, {
+export interface ExportLayoutRequest {
+  includeData?: boolean;
+  includeFallback?: boolean;
+  fileName?: string;
+}
+
+export async function exportLayout(
+  layoutId: number | string,
+  payload: ExportLayoutRequest,
+): Promise<Blob> {
+  const params = new URLSearchParams();
+
+  if (payload.includeData !== undefined) {
+    params.append('includeData', payload.includeData ? '1' : '0');
+  }
+
+  if (payload.includeFallback !== undefined) {
+    params.append('includeFallback', payload.includeFallback ? '1' : '0');
+  }
+
+  if (payload.fileName) {
+    params.append('fileName', payload.fileName);
+  }
+
+  const response = await http.post(`/layout/export/${layoutId}`, params, {
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
     responseType: 'blob',
   });
 
@@ -144,4 +171,106 @@ export async function copyLayout(
   });
 
   return data;
+}
+
+export interface PublishLayoutRequest {
+  publishNow?: number;
+  publishDate?: string;
+}
+
+export async function publishLayout(
+  layoutId: number | string,
+  payload: PublishLayoutRequest,
+): Promise<Layout> {
+  const params = new URLSearchParams();
+
+  Object.entries(payload).forEach(([key, value]) => {
+    if (value !== undefined && value !== null) {
+      params.append(key, String(value));
+    }
+  });
+
+  const { data } = await http.put(`/layout/publish/${layoutId}`, params, {
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+  });
+
+  return data;
+}
+
+export async function checkoutLayout(layoutId: number | string): Promise<Layout> {
+  const { data } = await http.put(`/layout/checkout/${layoutId}`);
+  return data;
+}
+
+export async function discardLayout(layoutId: number | string): Promise<Layout> {
+  const { data } = await http.put(`/layout/discard/${layoutId}`);
+  return data;
+}
+
+export async function assignLayoutToCampaign(campaignId: number, layoutId: number): Promise<void> {
+  const params = new URLSearchParams();
+  params.append('layoutId', String(layoutId));
+
+  await http.post(`/campaign/layout/assign/${campaignId}`, params, {
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+  });
+}
+
+export interface SaveAsTemplateRequest {
+  name: string;
+  includeWidgets: boolean;
+  description?: string;
+  tags?: string;
+  folderId?: number;
+}
+
+export async function saveLayoutAsTemplate(
+  layoutId: number | string,
+  payload: SaveAsTemplateRequest,
+): Promise<Template> {
+  const params = new URLSearchParams();
+
+  params.append('name', payload.name);
+  params.append('includeWidgets', payload.includeWidgets ? '1' : '0');
+
+  if (payload.description) {
+    params.append('description', payload.description);
+  }
+
+  if (payload.tags) {
+    params.append('tags', payload.tags);
+  }
+
+  if (payload.folderId !== undefined) {
+    params.append('folderId', String(payload.folderId));
+  }
+
+  const { data } = await http.post(`/template/${layoutId}`, params, {
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+  });
+
+  let result = data;
+
+  if (typeof result === 'string') {
+    const jsonStart = (result as string).indexOf('{');
+    const jsonEnd = (result as string).lastIndexOf('}');
+
+    if (jsonStart !== -1 && jsonEnd !== -1) {
+      try {
+        result = JSON.parse((result as string).slice(jsonStart, jsonEnd + 1));
+      } catch {
+        throw new Error('Failed to parse template response');
+      }
+    } else {
+      throw new Error('Invalid response from save as template');
+    }
+  }
+
+  return result;
 }

--- a/frontend/src/services/templatesApi.ts
+++ b/frontend/src/services/templatesApi.ts
@@ -51,7 +51,27 @@ export async function fetchTemplates(
     signal,
   });
 
-  const rows = response.data;
+  let rows = response.data;
+
+  // TODO: Temporary fix for API returning string instead of array, should be removed once backend is fixed
+  if (typeof rows === 'string') {
+    const jsonStart = rows.indexOf('[');
+    const jsonEnd = rows.lastIndexOf(']');
+
+    if (jsonStart !== -1 && jsonEnd !== -1) {
+      try {
+        rows = JSON.parse(rows.slice(jsonStart, jsonEnd + 1));
+      } catch {
+        rows = [];
+      }
+    } else {
+      rows = [];
+    }
+  }
+
+  if (!Array.isArray(rows)) {
+    rows = [];
+  }
 
   const totalCountHeader = response.headers['x-total-count'];
   const totalCount = totalCountHeader ? parseInt(totalCountHeader, 10) : rows.length;

--- a/frontend/src/types/table.ts
+++ b/frontend/src/types/table.ts
@@ -29,6 +29,7 @@ export type ActionItem =
       onClick?: never;
       variant?: never;
       isQuickAction?: never;
+      rightIcon?: never;
     }
   | {
       isSeparator?: false | undefined;
@@ -37,6 +38,7 @@ export type ActionItem =
       onClick?: () => void;
       variant?: 'default' | 'primary' | 'danger';
       isQuickAction?: boolean;
+      rightIcon?: ElementType;
     };
 
 export type BaseModalType = 'edit' | 'share' | 'delete' | 'copy' | 'move' | 'logout' | 'import';

--- a/lib/Controller/Campaign.php
+++ b/lib/Controller/Campaign.php
@@ -277,7 +277,7 @@ class Campaign extends Base
                 $campaign->excludeProperty('layouts');
             }
 
-            if ($this->isApi($request)) {
+            if ($this->isApi($request) || $this->isJson($request)) {
                 continue;
             }
 

--- a/lib/routes-web.php
+++ b/lib/routes-web.php
@@ -147,10 +147,6 @@ $app->group('', function(\Slim\Routing\RouteCollectorProxy $group) {
     $group->get('/layout/form/retire/{id}', ['\Xibo\Controller\Layout', 'retireForm'])->setName('layout.retire.form');
 })->addMiddleware(new FeatureAuth($app->getContainer(), ['layout.modify', 'template.modify']));
 
-$app->group('', function(\Slim\Routing\RouteCollectorProxy $group) {
-    $group->get('/layout/export/{id}', ['\Xibo\Controller\Layout', 'export'])->setName('layout.export');
-})->addMiddleware(new FeatureAuth($app->getContainer(), ['layout.export']));
-
 // Layout with Codes
 $app->get('/layout/codes', ['\Xibo\Controller\Layout', 'getLayoutCodes'])->setName('layout.code.search');
 

--- a/lib/routes.php
+++ b/lib/routes.php
@@ -120,6 +120,10 @@ $app->group('', function (RouteCollectorProxy $group) {
     $group->put('/layout/setenablestat/{id}',['\Xibo\Controller\Layout', 'setEnableStat'])->setName('layout.setenablestat');
 })->addMiddleware(new FeatureAuth($app->getContainer(), ['layout.modify']));
 
+$app->group('', function(\Slim\Routing\RouteCollectorProxy $group) {
+    $group->post('/layout/export/{id}', ['\Xibo\Controller\Layout', 'export'])->setName('layout.export');
+})->addMiddleware(new FeatureAuth($app->getContainer(), ['layout.export']));
+
 // Tagging
 $app->group('', function (RouteCollectorProxy $group) {
     $group->post('/layout/{id}/tag', ['\Xibo\Controller\Layout', 'tag'])->setName('layout.tag');


### PR DESCRIPTION
relates to: https://github.com/xibosignageltd/xibo-private/issues/1266

New Changes:

Added Modals for:
- Publish
- Discard
- Save as Template
- Assign to Campaign
- Retire
- Enable stats collection?
- Export

Added functions for

- Jump to Playlists included on this Layout
- Jump to Campaigns containing this Layout
- Jump to Media included on this Layout
___________
- Remove `get` route for export and added `post`
___________
_Note:_
Backend changes request: 
- Needs to connect on "Publish Date" (New feature)
- Save as Template - because of new changes, data when you Save as Template is not sync on Template
