### PR TITLE
IA: Previewing "Navigate to Layout" actions

### DIFF
--- a/lib/Controller/Preview.php
+++ b/lib/Controller/Preview.php
@@ -63,22 +63,43 @@ class Preview extends Base
     {
         $sanitizedParams = $this->getSanitizer($request->getParams());
 
-        // Get the layout
-        if ($sanitizedParams->getInt('findByCode') === 1) {
-            $layout = $this->layoutFactory->getByCode($id);
-        } else {
-            $layout = $this->layoutFactory->getById($id);
-        }
-
+        // Check token authentication
         /** @var \Lcobucci\JWT\Token $token */
         $token = $request->getAttribute('authedToken');
         if (empty($token)) {
             throw new AccessDeniedException();
         }
 
-        // Check the token allows access to this layout.
-        if (!$token->isPermittedFor('layout') || !$token->isIdentifiedBy($layout->layoutId)) {
-            throw new AccessDeniedException();
+        // Get the layout
+        if ($sanitizedParams->getInt('findByCode') === 1) {
+            $this->getlog()->debug('show: findByCode: ' . $id);
+
+            $layout = $this->layoutFactory->getByCode($id);
+
+            // Check that this layout is a navigate to layout action on the layout we're authed against
+            $tokenLayout = $this->layoutFactory->getById($token->claims()->get('jti'));
+            $tokenLayout->load();
+
+            $isActionFound = false;
+            foreach ($tokenLayout->getActions(true) as $action) {
+                if ($action->actionType === 'navLayout' && $action->layoutCode === $layout->code) {
+                    $isActionFound = true;
+                    break;
+                }
+            }
+
+            if (!$isActionFound) {
+                $this->getlog()->debug('show: findByCode: no actions found on authenticated layout '
+                    . $tokenLayout->layoutId);
+                throw new AccessDeniedException();
+            }
+        } else {
+            $layout = $this->layoutFactory->getById($id);
+
+            // Check the token allows access to this layout.
+            if (!$token->isPermittedFor('layout') || !$token->isIdentifiedBy($layout->layoutId)) {
+                throw new AccessDeniedException();
+            }
         }
 
         // Do we want to preview the draft version of this Layout?

--- a/lib/Entity/Layout.php
+++ b/lib/Entity/Layout.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2024 Xibo Signage Ltd
+ * Copyright (C) 2026 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -2921,6 +2921,27 @@ class Layout implements \JsonSerializable
                 }
             }
         }
+    }
+
+    /**
+     * @param bool $includeWidgets Also include actions from each widget?
+     * @return \Xibo\Entity\Action[]
+     * @throws \Xibo\Support\Exception\NotFoundException
+     */
+    public function getActions(bool $includeWidgets = false): array
+    {
+        $actions = $this->actions;
+        if ($includeWidgets) {
+            foreach ($this->regions as $region) {
+                foreach ($region->getPlaylist()->widgets as $widget) {
+                    $widget->load();
+                    foreach ($widget->actions as $action) {
+                        $actions[] = $action;
+                    }
+                }
+            }
+        }
+        return $actions;
     }
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@mapbox/leaflet-pip": "^1.1.0",
         "@popperjs/core": "^2.11.8",
         "@ssddanbrown/codemirror-lang-twig": "^1.0.0",
-        "@xibosignage/xibo-layout-renderer": "^1.0.22",
+        "@xibosignage/xibo-layout-renderer": "git+https://github.com/xibosignage/xibo-layout-renderer.git#dc469b62de6603d48c06c25ffd03cded75d128dc",
         "@xiechao/codemirror-lang-handlebars": "^1.0.4",
         "ajax-bootstrap-select": "^1.4.5",
         "blueimp-file-upload": "^10.32.0",
@@ -3653,9 +3653,9 @@
       }
     },
     "node_modules/@xibosignage/xibo-layout-renderer": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/@xibosignage/xibo-layout-renderer/-/xibo-layout-renderer-1.0.22.tgz",
-      "integrity": "sha512-LOl5xKjgYyw9QoIvdyARTRhbsyVtOZ2ir06kB399KdRcQNZILOXjmogKMRyPyaN9p1Py52G4xgw9DiDUPH5EkQ==",
+      "version": "1.0.24",
+      "resolved": "git+ssh://git@github.com/xibosignage/xibo-layout-renderer.git#dc469b62de6603d48c06c25ffd03cded75d128dc",
+      "integrity": "sha512-7TpX3JWhoC/WZkUA9d1q1r8D2ll3ZcqeSebYcV+s3uDUNNjB0LTrz96xwWxm35xPZoz+KmM+8rutl9ofLud6Xw==",
       "license": "LGPL-3.0",
       "dependencies": {
         "@types/xml2js": "^0.4.14",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@mapbox/leaflet-pip": "^1.1.0",
     "@popperjs/core": "^2.11.8",
     "@ssddanbrown/codemirror-lang-twig": "^1.0.0",
-    "@xibosignage/xibo-layout-renderer": "^1.0.22",
+    "@xibosignage/xibo-layout-renderer": "git+https://github.com/xibosignage/xibo-layout-renderer.git#dc469b62de6603d48c06c25ffd03cded75d128dc",
     "@xiechao/codemirror-lang-handlebars": "^1.0.4",
     "ajax-bootstrap-select": "^1.4.5",
     "blueimp-file-upload": "^10.32.0",

--- a/ui/src/core/xibo-cms.js
+++ b/ui/src/core/xibo-cms.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Xibo Signage Ltd
+ * Copyright (C) 2026 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -2854,6 +2854,11 @@ window.createMiniLayoutPreview = function(previewUrl) {
     }));
   }
 
+  // Set the previewJWT on the window.
+  const previewUrlUrl = new URL(previewUrl, window.location.origin);
+  window.previewJwt = previewUrlUrl.searchParams.get('jwt');
+
+  // Create the mini preview
   const $layoutPreview = $('.mini-layout-preview');
   const $layoutPreviewContent = $layoutPreview.find('#content');
 

--- a/views/base.twig
+++ b/views/base.twig
@@ -30,6 +30,15 @@
             var CALENDAR_TYPE = "{{ settings.CALENDAR_TYPE }}";
             var jsLocale = "{{ translate.jsLocale }}";
             var jsShortLocale = "{{ translate.jsShortLocale }}";
+
+            window.addEventListener('message', function(e) {
+              if (event.data?.type === 'xlr:navLayout') {
+                if (confirm("{{ "Navigate to layout with code [layoutTag]?"|trans }}"
+                  .replace('[layoutTag]', event.data.layoutCode))) {
+                  window.open(event.data.url + '&jwt=' + previewJwt, '_blank');
+                }
+              }
+            });
         </script>
 
         {# Import JS bundle from dist #}


### PR DESCRIPTION
Pull in new beta XLR (requires test). This XLR supports post message, which we then capture in base.twig and use to open a new tab (https://github.com/xibosignage/xibo-layout-renderer/pull/94)

Preview: controller updated to allow viewing related layouts via layout code relates to xibosignage/xibo#3840

Fixes xibosignage/xibo#3840

---                                                                                                                                                                                                                                                                                                              
No security vulnerabilities meeting the confidence threshold (≥8/10) were identified in this PR.                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                   
Summary of analysis:
                                                                                                                                                                                                                                                                                                                   
The most notable pattern reviewed was the postMessage handler added in base.twig that appends previewJwt to a caller-supplied URL. While this lacks origin validation, the false-positive analysis determined:                                                                                                   
                                                                                                                                                                                                                                                                                                                   
  - previewJwt is only defined on the layout designer/preview pages — not broadly across all pages extending base.twig. On other pages it evaluates to undefined.                                                                                                                                                  
  - The legitimate message source is an internal same-origin preview iframe. An external attacker cannot send this message without first gaining XSS or some other foothold in the application.                                                                                                                  
  - The confirm() dialog reflects layoutCode as plain text — no XSS vector there.                                                                                                                                                                                                                                  
  - Per filtering precedents, open redirect findings require extremely high confidence to report; the attack path here has multiple prerequisites that cannot be satisfied externally.                                                                                                                             
                                                                                                                                                                                                                                                                                                                   
The findByCode authorization flow in Preview.php correctly validates the JWT before using jti to load the token layout, and cross-checks that a navLayout action exists linking the two layouts before granting access. No bypass was identified.