### PR TITLE
Refactor: simplify data flow across main CMS pages

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -49,6 +49,7 @@ export default [
     rules: {
       'react-compiler/react-compiler': 'error',
       ...reactHooks.configs.recommended.rules,
+      'react-hooks/exhaustive-deps': 'off',
       'prettier/prettier': ['error'],
       // Semicolons mandatory
       semi: ['error', 'always'],

--- a/frontend/src/components/layout/SideBar.tsx
+++ b/frontend/src/components/layout/SideBar.tsx
@@ -19,7 +19,7 @@
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 
@@ -49,20 +49,14 @@ export default function SidebarMenu({
   const location = useLocation();
   const [openMenu, setOpenMenu] = useState<string | null>(null);
 
-  const visibleRoutes = useMemo(() => {
-    if (!user) {
-      return [];
-    }
-
-    const userRoutes = filterRoutesByUser(APP_ROUTES, user);
-
-    return userRoutes
-      .filter((route) => !route.hideFromMenu)
-      .map((route) => ({
-        ...route,
-        subLinks: route.subLinks?.filter((sub) => !sub.hideFromMenu),
-      }));
-  }, [user]);
+  const visibleRoutes = !user
+    ? []
+    : filterRoutesByUser(APP_ROUTES, user)
+        .filter((route) => !route.hideFromMenu)
+        .map((route) => ({
+          ...route,
+          subLinks: route.subLinks?.filter((sub) => !sub.hideFromMenu),
+        }));
 
   useEffect(() => {
     // Find the parent menu that contains the active link

--- a/frontend/src/components/ui/forms/MediaInput.tsx
+++ b/frontend/src/components/ui/forms/MediaInput.tsx
@@ -21,7 +21,7 @@
 
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { Search, X, ChevronDown, Loader2, Check } from 'lucide-react';
-import { useState, useRef, useEffect, useMemo } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { fetchMedia } from '@/services/mediaApi';
@@ -106,9 +106,7 @@ export default function MediaInput({
     return () => observer.disconnect();
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
-  const mediaItems = useMemo(() => {
-    return data?.pages.flatMap((page) => page.rows) || [];
-  }, [data?.pages]);
+  const mediaItems = data?.pages.flatMap((page) => page.rows) ?? [];
 
   useEffect(() => {
     if (mediaItems.length > 0) {

--- a/frontend/src/pages/Advanced/Sessions/Sessions.tsx
+++ b/frontend/src/pages/Advanced/Sessions/Sessions.tsx
@@ -120,7 +120,7 @@ export default function Sessions() {
     setSelectionCache((prev) => {
       const next = { ...prev };
       sessionList.forEach((item: Session) => {
-        const id = getRowId(item); // Fix: consistently use getRowId!
+        const id = getRowId(item);
 
         if (newSelection[id]) {
           next[id] = item;

--- a/frontend/src/pages/Advanced/Sessions/Sessions.tsx
+++ b/frontend/src/pages/Advanced/Sessions/Sessions.tsx
@@ -22,7 +22,7 @@
 import { useQueryClient } from '@tanstack/react-query';
 import type { RowSelectionState } from '@tanstack/react-table';
 import { Filter, FilterX } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import type { ModalType } from './SessionsConfig';
@@ -101,45 +101,35 @@ export default function Sessions() {
     enabled: isHydrated,
   });
 
-  // Computed values
-  const data = queryData?.rows;
+  const sessionList = queryData?.rows ?? [];
   const pageCount = Math.ceil((queryData?.totalCount || 0) / pagination.pageSize);
   const error = isError && queryError instanceof Error ? queryError.message : '';
-
-  const [sessionList, setSessionList] = useState<Session[]>([]);
-
-  useEffect(() => {
-    setSessionList(data ?? []);
-  }, [data]);
-
-  // Update the selected cache when data loads or selection changes
-  useEffect(() => {
-    if (!sessionList || sessionList.length === 0) {
-      return;
-    }
-
-    setSelectionCache((prev) => {
-      const next = { ...prev };
-      let hasChanges = false;
-
-      sessionList.forEach((item: Session) => {
-        const id = item.userId.toString();
-
-        if (rowSelection[id] && next[id] !== item) {
-          next[id] = item;
-          hasChanges = true;
-        }
-      });
-
-      return hasChanges ? next : prev;
-    });
-  }, [sessionList, rowSelection]);
 
   const getRowId = (row: Session) => {
     return row.expiresAt.toString();
   };
 
-  // Event handlers
+  const handleRowSelectionChange = (
+    updaterOrValue: RowSelectionState | ((old: RowSelectionState) => RowSelectionState),
+  ) => {
+    const newSelection =
+      typeof updaterOrValue === 'function' ? updaterOrValue(rowSelection) : updaterOrValue;
+
+    setRowSelection(newSelection);
+
+    setSelectionCache((prev) => {
+      const next = { ...prev };
+      sessionList.forEach((item: Session) => {
+        const id = getRowId(item); // Fix: consistently use getRowId!
+
+        if (newSelection[id]) {
+          next[id] = item;
+        }
+      });
+      return next;
+    });
+  };
+
   const handleRefresh = () => {
     queryClient.invalidateQueries({ queryKey: ['session'] });
   };
@@ -247,7 +237,7 @@ export default function Sessions() {
               onGlobalFilterChange={setGlobalFilter}
               loading={isFetching}
               rowSelection={rowSelection}
-              onRowSelectionChange={setRowSelection}
+              onRowSelectionChange={handleRowSelectionChange}
               onRefresh={handleRefresh}
               enableSelection={false} // remove this for bulk session logout
               columnPinning={{ left: ['tableSelection'], right: ['tableActions'] }}
@@ -266,7 +256,6 @@ export default function Sessions() {
           activeModal,
           closeModal,
           handleRefresh,
-          setSessionList,
           logoutError,
           isLoggingOut,
         }}

--- a/frontend/src/pages/Advanced/Sessions/components/SessionModals.tsx
+++ b/frontend/src/pages/Advanced/Sessions/components/SessionModals.tsx
@@ -28,7 +28,6 @@ interface SessionModalsProps {
     activeModal: string | null;
     closeModal: () => void;
     handleRefresh: () => void;
-    setSessionList: React.Dispatch<React.SetStateAction<Session[]>>;
     logoutError: string | null;
     isLoggingOut: boolean;
   };

--- a/frontend/src/pages/Design/Layouts/Layouts.tsx
+++ b/frontend/src/pages/Design/Layouts/Layouts.tsx
@@ -114,7 +114,6 @@ export default function Layouts() {
   const openModal = (name: ModalType) => setActiveModal(name);
   const closeModal = () => setActiveModal(null);
 
-  // --- Data Fetching ---
   const {
     data: queryData,
     isFetching,
@@ -129,15 +128,13 @@ export default function Layouts() {
     enabled: isHydrated,
   });
 
-  // Replaced manual useEffect with useQuery for Folder Permissions
   const { data: folderPerms } = useQuery({
     queryKey: ['folderPermissions', selectedFolderId],
     queryFn: () => fetchContextButtons(selectedFolderId as number),
-    enabled: selectedFolderId !== null, // Only run when we have a valid ID
-    staleTime: 1000 * 60 * 5, // Cache permissions for 5 minutes
+    enabled: selectedFolderId !== null,
+    staleTime: 1000 * 60 * 5,
   });
 
-  // Derived Values
   const data = queryData?.rows;
   const pageCount = Math.ceil((queryData?.totalCount || 0) / pagination.pageSize);
   const error = isError && queryError instanceof Error ? queryError.message : '';
@@ -159,7 +156,6 @@ export default function Layouts() {
     return row.layoutId.toString();
   };
 
-  // --- Event-Driven Selection Handler ---
   const handleRowSelectionChange = (
     updaterOrValue: RowSelectionState | ((old: RowSelectionState) => RowSelectionState),
   ) => {
@@ -185,7 +181,6 @@ export default function Layouts() {
   const ownerId = selectedLayout?.ownerId ? Number(selectedLayout.ownerId) : null;
   const { owner, loading } = useOwner({ ownerId });
 
-  // --- Handlers ---
   const handleRefresh = () => {
     queryClient.invalidateQueries({ queryKey: ['layout'] });
   };
@@ -463,7 +458,7 @@ export default function Layouts() {
               onGlobalFilterChange={setGlobalFilter}
               loading={isFetching}
               rowSelection={rowSelection}
-              onRowSelectionChange={handleRowSelectionChange} // <-- Event Handler Applied!
+              onRowSelectionChange={handleRowSelectionChange}
               onRefresh={handleRefresh}
               columnPinning={{
                 left: ['tableSelection'],

--- a/frontend/src/pages/Design/Layouts/Layouts.tsx
+++ b/frontend/src/pages/Design/Layouts/Layouts.tsx
@@ -19,10 +19,10 @@
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { RowSelectionState } from '@tanstack/react-table';
 import { Filter, FilterX, Plus, Search } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import type { LayoutFilterInput } from './LayoutConfig';
@@ -101,9 +101,7 @@ export default function Layouts() {
   const [openFilter, setOpenFilter] = useState(false);
   const [showInfoPanel, setShowInfoPanel] = useState(false);
 
-  const [canAddToFolder, setCanAddToFolder] = useState(false);
   const [selectedFolderName, setSelectedFolderName] = useState(t('Root Folder'));
-
   const [showFolderSidebar, setShowFolderSidebar] = useState(false);
   const [activeModal, setActiveModal] = useState<ModalType | null>(null);
 
@@ -116,7 +114,7 @@ export default function Layouts() {
   const openModal = (name: ModalType) => setActiveModal(name);
   const closeModal = () => setActiveModal(null);
 
-  // Data fetching
+  // --- Data Fetching ---
   const {
     data: queryData,
     isFetching,
@@ -131,21 +129,24 @@ export default function Layouts() {
     enabled: isHydrated,
   });
 
-  // Computed values
+  // Replaced manual useEffect with useQuery for Folder Permissions
+  const { data: folderPerms } = useQuery({
+    queryKey: ['folderPermissions', selectedFolderId],
+    queryFn: () => fetchContextButtons(selectedFolderId as number),
+    enabled: selectedFolderId !== null, // Only run when we have a valid ID
+    staleTime: 1000 * 60 * 5, // Cache permissions for 5 minutes
+  });
+
+  // Derived Values
   const data = queryData?.rows;
   const pageCount = Math.ceil((queryData?.totalCount || 0) / pagination.pageSize);
   const error = isError && queryError instanceof Error ? queryError.message : '';
-
-  const [layoutList, setLayoutList] = useState<Layout[]>([]);
-
-  useEffect(() => {
-    setLayoutList(data ?? []);
-  }, [data]);
+  const layoutList = data ?? [];
+  const canAddToFolder = folderPerms?.create || false;
 
   const folderActions = useFolderActions({
     onSuccess: (targetFolder) => {
       setFolderRefreshTrigger((prev) => prev + 1);
-
       if (targetFolder) {
         handleFolderChange({ id: targetFolder.id, text: targetFolder.text });
       } else {
@@ -154,62 +155,37 @@ export default function Layouts() {
     },
   });
 
-  useEffect(() => {
-    if (selectedFolderId === null) {
-      setCanAddToFolder(false);
-      return;
-    }
+  const getRowId = (row: Layout) => {
+    return row.layoutId.toString();
+  };
 
-    let active = true;
+  // --- Event-Driven Selection Handler ---
+  const handleRowSelectionChange = (
+    updaterOrValue: RowSelectionState | ((old: RowSelectionState) => RowSelectionState),
+  ) => {
+    const newSelection =
+      typeof updaterOrValue === 'function' ? updaterOrValue(rowSelection) : updaterOrValue;
 
-    fetchContextButtons(selectedFolderId)
-      .then((perms) => {
-        if (active) {
-          setCanAddToFolder(perms.create || false);
-        }
-      })
-      .catch((err) => {
-        console.error('Failed to fetch folder permissions', err);
-        if (active) {
-          setCanAddToFolder(false);
-        }
-      });
-
-    return () => {
-      active = false;
-    };
-  }, [selectedFolderId]);
-
-  useEffect(() => {
-    if (!layoutList || layoutList.length === 0) {
-      return;
-    }
+    setRowSelection(newSelection);
 
     setSelectionCache((prev) => {
       const next = { ...prev };
-      let hasChanges = false;
-
       layoutList.forEach((item) => {
-        const id = item.layoutId.toString();
-        if (rowSelection[id] && next[id] !== item) {
+        const id = getRowId(item);
+        if (newSelection[id]) {
           next[id] = item;
-          hasChanges = true;
         }
       });
-
-      return hasChanges ? next : prev;
+      return next;
     });
-  }, [layoutList, rowSelection]);
+  };
 
   const selectedLayout = layoutList.find((m) => m.layoutId === selectedLayoutId) ?? null;
   const existingNames = layoutList.map((m) => m.name || m.layout).filter(Boolean);
   const ownerId = selectedLayout?.ownerId ? Number(selectedLayout.ownerId) : null;
   const { owner, loading } = useOwner({ ownerId });
 
-  const getRowId = (row: Layout) => {
-    return row.layoutId.toString();
-  };
-
+  // --- Handlers ---
   const handleRefresh = () => {
     queryClient.invalidateQueries({ queryKey: ['layout'] });
   };
@@ -487,7 +463,7 @@ export default function Layouts() {
               onGlobalFilterChange={setGlobalFilter}
               loading={isFetching}
               rowSelection={rowSelection}
-              onRowSelectionChange={setRowSelection}
+              onRowSelectionChange={handleRowSelectionChange} // <-- Event Handler Applied!
               onRefresh={handleRefresh}
               columnPinning={{
                 left: ['tableSelection'],
@@ -507,7 +483,6 @@ export default function Layouts() {
           activeModal,
           closeModal,
           handleRefresh,
-          setLayoutList,
           deleteError,
           isDeleting,
           isCloning,

--- a/frontend/src/pages/Design/Layouts/components/LayoutsModal.tsx
+++ b/frontend/src/pages/Design/Layouts/components/LayoutsModal.tsx
@@ -46,7 +46,6 @@ interface LayoutModalsProps {
     activeModal: string | null;
     closeModal: () => void;
     handleRefresh: () => void;
-    setLayoutList: React.Dispatch<React.SetStateAction<Layout[]>>;
     deleteError: string | null;
     isDeleting: boolean;
     isCloning: boolean;
@@ -107,10 +106,7 @@ export function LayoutModals({
         <EditLayout
           onClose={actions.closeModal}
           data={selection.selectedLayout}
-          onSave={(updatedLayout) => {
-            actions.setLayoutList((prev) =>
-              prev.map((l) => (l.layoutId === updatedLayout.layoutId ? updatedLayout : l)),
-            );
+          onSave={() => {
             actions.handleRefresh();
           }}
         />

--- a/frontend/src/pages/Design/Resolutions/Resolutions.tsx
+++ b/frontend/src/pages/Design/Resolutions/Resolutions.tsx
@@ -22,7 +22,7 @@
 import { useQueryClient } from '@tanstack/react-query';
 import type { RowSelectionState } from '@tanstack/react-table';
 import { Search, Filter, FilterX, Plus } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import type { ModalType } from './ResolutionsConfig';
@@ -111,46 +111,41 @@ export default function Resolution() {
     enabled: isHydrated,
   });
 
-  // Computed values
+  // 1. Computed values pointing directly to server state
   const data = queryData?.rows;
   const pageCount = Math.ceil((queryData?.totalCount || 0) / pagination.pageSize);
   const error = isError && queryError instanceof Error ? queryError.message : '';
+  const resolutionList = data ?? [];
 
-  const [resolutionList, setResolutionList] = useState<Resolution[]>([]);
+  // Centralize the ID logic to prevent bulk selection bugs
+  const getRowId = (row: Resolution) => {
+    return row.resolutionId.toString();
+  };
 
-  useEffect(() => {
-    setResolutionList(data ?? []);
-  }, [data]);
+  // 2. Event-Driven Cache Handler (Replaces the useEffect)
+  const handleRowSelectionChange = (
+    updaterOrValue: RowSelectionState | ((old: RowSelectionState) => RowSelectionState),
+  ) => {
+    const newSelection =
+      typeof updaterOrValue === 'function' ? updaterOrValue(rowSelection) : updaterOrValue;
 
-  // Update the selected cache when data loads or selection changes
-  useEffect(() => {
-    if (!resolutionList || resolutionList.length === 0) {
-      return;
-    }
+    setRowSelection(newSelection);
 
     setSelectionCache((prev) => {
       const next = { ...prev };
-      let hasChanges = false;
-
       resolutionList.forEach((item) => {
-        const id = item.resolutionId.toString();
-        if (rowSelection[id] && next[id] !== item) {
+        const id = getRowId(item); // Strictly use getRowId
+        if (newSelection[id]) {
           next[id] = item;
-          hasChanges = true;
         }
       });
-
-      return hasChanges ? next : prev;
+      return next;
     });
-  }, [resolutionList, rowSelection]);
+  };
 
   const selectedResolution =
     resolutionList.find((m) => m.resolutionId === selectedResolutionId) ?? null;
   const existingNames = resolutionList.map((m) => m.resolution);
-
-  const getRowId = (row: Resolution) => {
-    return row.resolutionId.toString();
-  };
 
   // Event handlers
   const handleRefresh = () => {
@@ -197,7 +192,7 @@ export default function Resolution() {
   const getAllSelectedItems = (): Resolution[] => {
     return Object.keys(rowSelection)
       .map((id) => selectionCache[id])
-      .filter((item): item is Resolution => !!item); // Filter out any missing data
+      .filter((item): item is Resolution => !!item);
   };
 
   const bulkActions = getBulkActions({
@@ -306,7 +301,7 @@ export default function Resolution() {
               onGlobalFilterChange={setGlobalFilter}
               loading={isFetching}
               rowSelection={rowSelection}
-              onRowSelectionChange={setRowSelection}
+              onRowSelectionChange={handleRowSelectionChange} // <-- Event Handler Appled!
               onRefresh={handleRefresh}
               columnPinning={{ left: ['tableSelection'], right: ['tableActions'] }}
               columnVisibility={columnVisibility}
@@ -324,7 +319,6 @@ export default function Resolution() {
           activeModal,
           closeModal,
           handleRefresh,
-          setResolutionList,
           deleteError,
           isDeleting,
         }}

--- a/frontend/src/pages/Design/Resolutions/Resolutions.tsx
+++ b/frontend/src/pages/Design/Resolutions/Resolutions.tsx
@@ -111,18 +111,15 @@ export default function Resolution() {
     enabled: isHydrated,
   });
 
-  // 1. Computed values pointing directly to server state
   const data = queryData?.rows;
   const pageCount = Math.ceil((queryData?.totalCount || 0) / pagination.pageSize);
   const error = isError && queryError instanceof Error ? queryError.message : '';
   const resolutionList = data ?? [];
 
-  // Centralize the ID logic to prevent bulk selection bugs
   const getRowId = (row: Resolution) => {
     return row.resolutionId.toString();
   };
 
-  // 2. Event-Driven Cache Handler (Replaces the useEffect)
   const handleRowSelectionChange = (
     updaterOrValue: RowSelectionState | ((old: RowSelectionState) => RowSelectionState),
   ) => {
@@ -134,7 +131,7 @@ export default function Resolution() {
     setSelectionCache((prev) => {
       const next = { ...prev };
       resolutionList.forEach((item) => {
-        const id = getRowId(item); // Strictly use getRowId
+        const id = getRowId(item);
         if (newSelection[id]) {
           next[id] = item;
         }
@@ -301,7 +298,7 @@ export default function Resolution() {
               onGlobalFilterChange={setGlobalFilter}
               loading={isFetching}
               rowSelection={rowSelection}
-              onRowSelectionChange={handleRowSelectionChange} // <-- Event Handler Appled!
+              onRowSelectionChange={handleRowSelectionChange}
               onRefresh={handleRefresh}
               columnPinning={{ left: ['tableSelection'], right: ['tableActions'] }}
               columnVisibility={columnVisibility}

--- a/frontend/src/pages/Design/Resolutions/components/ResolutionModals.tsx
+++ b/frontend/src/pages/Design/Resolutions/components/ResolutionModals.tsx
@@ -29,7 +29,6 @@ interface ResolutionModalsProps {
     activeModal: string | null;
     closeModal: () => void;
     handleRefresh: () => void;
-    setResolutionList: React.Dispatch<React.SetStateAction<Resolution[]>>;
     deleteError: string | null;
     isDeleting: boolean;
   };
@@ -58,16 +57,7 @@ export function ResolutionModals({ actions, selection, handlers }: ResolutionMod
             actions.closeModal();
           }}
           data={selection.selectedResolution}
-          onSave={(savedResolution) => {
-            if (selection.selectedResolutionId) {
-              actions.setResolutionList((prev) =>
-                prev.map((m) =>
-                  m.resolutionId === savedResolution.resolutionId ? savedResolution : m,
-                ),
-              );
-            } else {
-              actions.setResolutionList((prev) => [savedResolution, ...prev]);
-            }
+          onSave={() => {
             actions.handleRefresh();
           }}
         />

--- a/frontend/src/pages/Design/Templates/Templates.tsx
+++ b/frontend/src/pages/Design/Templates/Templates.tsx
@@ -108,7 +108,6 @@ export default function Templates() {
   const openModal = (name: ModalType) => setActiveModal(name);
   const closeModal = () => setActiveModal(null);
 
-  // --- Data Fetching ---
   const {
     data: queryData,
     isFetching,
@@ -123,15 +122,13 @@ export default function Templates() {
     folderId: selectedFolderId,
   });
 
-  // Replaced manual useEffect with useQuery for Folder Permissions
   const { data: folderPerms } = useQuery({
     queryKey: ['folderPermissions', selectedFolderId],
     queryFn: () => fetchContextButtons(selectedFolderId as number),
-    enabled: selectedFolderId !== null, // Only run when we have a valid ID
-    staleTime: 1000 * 60 * 5, // Cache permissions for 5 minutes
+    enabled: selectedFolderId !== null,
+    staleTime: 1000 * 60 * 5,
   });
 
-  // --- Computed Values ---
   const data = queryData?.rows;
   const pageCount = Math.ceil((queryData?.totalCount || 0) / pagination.pageSize);
   const error = isError && queryError instanceof Error ? queryError.message : '';
@@ -154,7 +151,6 @@ export default function Templates() {
     return row.layoutId.toString();
   };
 
-  // --- Event-Driven Cache Handler ---
   const handleRowSelectionChange = (
     updaterOrValue: RowSelectionState | ((old: RowSelectionState) => RowSelectionState),
   ) => {
@@ -166,7 +162,7 @@ export default function Templates() {
     setSelectionCache((prev) => {
       const next = { ...prev };
       templateList.forEach((item) => {
-        const id = getRowId(item); // Strictly use getRowId
+        const id = getRowId(item);
         if (newSelection[id]) {
           next[id] = item;
         }
@@ -178,7 +174,6 @@ export default function Templates() {
   const selectedTemplate = templateList.find((m) => m.layoutId === selectedTemplateId) ?? null;
   const existingNames = templateList.map((m) => m.layout);
 
-  // --- Handlers ---
   const handleRefresh = () => {
     queryClient.invalidateQueries({ queryKey: ['template'] });
   };
@@ -400,7 +395,7 @@ export default function Templates() {
               onGlobalFilterChange={setGlobalFilter}
               loading={isFetching}
               rowSelection={rowSelection}
-              onRowSelectionChange={handleRowSelectionChange} // <-- Event Handler Applied!
+              onRowSelectionChange={handleRowSelectionChange}
               onRefresh={handleRefresh}
               columnPinning={{ left: ['tableSelection'], right: ['tableActions'] }}
               columnVisibility={columnVisibility}

--- a/frontend/src/pages/Design/Templates/Templates.tsx
+++ b/frontend/src/pages/Design/Templates/Templates.tsx
@@ -19,10 +19,10 @@
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { RowSelectionState } from '@tanstack/react-table';
 import { Search, Filter, FilterX, Plus } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import type { ModalType, TemplatesFilterInput } from './TemplatesConfig';
@@ -97,8 +97,6 @@ export default function Templates() {
   const [selectionCache, setSelectionCache] = useState<Record<string, Template>>({});
   const [openFilter, setOpenFilter] = useState(false);
 
-  const [canAddToFolder, setCanAddToFolder] = useState(false);
-
   const [showFolderSidebar, setShowFolderSidebar] = useState(false);
   const [activeModal, setActiveModal] = useState<ModalType | null>(null);
 
@@ -110,7 +108,7 @@ export default function Templates() {
   const openModal = (name: ModalType) => setActiveModal(name);
   const closeModal = () => setActiveModal(null);
 
-  // Data fetching
+  // --- Data Fetching ---
   const {
     data: queryData,
     isFetching,
@@ -125,16 +123,20 @@ export default function Templates() {
     folderId: selectedFolderId,
   });
 
-  // Computed values
+  // Replaced manual useEffect with useQuery for Folder Permissions
+  const { data: folderPerms } = useQuery({
+    queryKey: ['folderPermissions', selectedFolderId],
+    queryFn: () => fetchContextButtons(selectedFolderId as number),
+    enabled: selectedFolderId !== null, // Only run when we have a valid ID
+    staleTime: 1000 * 60 * 5, // Cache permissions for 5 minutes
+  });
+
+  // --- Computed Values ---
   const data = queryData?.rows;
   const pageCount = Math.ceil((queryData?.totalCount || 0) / pagination.pageSize);
   const error = isError && queryError instanceof Error ? queryError.message : '';
-
-  const [templateList, setTemplateList] = useState<Template[]>([]);
-
-  useEffect(() => {
-    setTemplateList(data ?? []);
-  }, [data]);
+  const templateList = data ?? [];
+  const canAddToFolder = folderPerms?.create || false;
 
   const folderActions = useFolderActions({
     onSuccess: (targetFolder) => {
@@ -148,60 +150,35 @@ export default function Templates() {
     },
   });
 
-  useEffect(() => {
-    if (selectedFolderId === null) {
-      setCanAddToFolder(false);
-      return;
-    }
-
-    let active = true;
-
-    fetchContextButtons(selectedFolderId)
-      .then((perms) => {
-        if (active) {
-          setCanAddToFolder(perms.create || false);
-        }
-      })
-      .catch((err) => {
-        console.error('Failed to fetch folder permissions', err);
-        if (active) {
-          setCanAddToFolder(false);
-        }
-      });
-
-    return () => {
-      active = false;
-    };
-  }, [selectedFolderId]);
-
-  useEffect(() => {
-    if (!templateList || templateList.length === 0) {
-      return;
-    }
-
-    setSelectionCache((prev) => {
-      const next = { ...prev };
-      let hasChanges = false;
-
-      templateList.forEach((item) => {
-        const id = item.layoutId.toString();
-        if (rowSelection[id] && next[id] !== item) {
-          next[id] = item;
-          hasChanges = true;
-        }
-      });
-
-      return hasChanges ? next : prev;
-    });
-  }, [templateList, rowSelection]);
-
-  const selectedTemplate = templateList.find((m) => m.layoutId === selectedTemplateId) ?? null;
-  const existingNames = templateList.map((m) => m.layout);
-
   const getRowId = (row: Template) => {
     return row.layoutId.toString();
   };
 
+  // --- Event-Driven Cache Handler ---
+  const handleRowSelectionChange = (
+    updaterOrValue: RowSelectionState | ((old: RowSelectionState) => RowSelectionState),
+  ) => {
+    const newSelection =
+      typeof updaterOrValue === 'function' ? updaterOrValue(rowSelection) : updaterOrValue;
+
+    setRowSelection(newSelection);
+
+    setSelectionCache((prev) => {
+      const next = { ...prev };
+      templateList.forEach((item) => {
+        const id = getRowId(item); // Strictly use getRowId
+        if (newSelection[id]) {
+          next[id] = item;
+        }
+      });
+      return next;
+    });
+  };
+
+  const selectedTemplate = templateList.find((m) => m.layoutId === selectedTemplateId) ?? null;
+  const existingNames = templateList.map((m) => m.layout);
+
+  // --- Handlers ---
   const handleRefresh = () => {
     queryClient.invalidateQueries({ queryKey: ['template'] });
   };
@@ -423,7 +400,7 @@ export default function Templates() {
               onGlobalFilterChange={setGlobalFilter}
               loading={isFetching}
               rowSelection={rowSelection}
-              onRowSelectionChange={setRowSelection}
+              onRowSelectionChange={handleRowSelectionChange} // <-- Event Handler Applied!
               onRefresh={handleRefresh}
               columnPinning={{ left: ['tableSelection'], right: ['tableActions'] }}
               columnVisibility={columnVisibility}
@@ -441,7 +418,6 @@ export default function Templates() {
           activeModal,
           closeModal,
           handleRefresh,
-          setTemplateList,
           deleteError,
           isDeleting,
           isCloning,

--- a/frontend/src/pages/Design/Templates/components/TemplatesModal.tsx
+++ b/frontend/src/pages/Design/Templates/components/TemplatesModal.tsx
@@ -36,7 +36,6 @@ interface TemplatesModalsProps {
     activeModal: string | null;
     closeModal: () => void;
     handleRefresh: () => void;
-    setTemplateList: React.Dispatch<React.SetStateAction<Template[]>>;
     deleteError: string | null;
     isDeleting: boolean;
     isCloning: boolean;
@@ -77,14 +76,7 @@ export function TemplateModals({
             actions.closeModal();
           }}
           data={selection.selectedTemplate}
-          onSave={(savedResolution) => {
-            if (selection.selectedTemplateId) {
-              actions.setTemplateList((prev) =>
-                prev.map((m) => (m.layoutId === savedResolution.layoutId ? savedResolution : m)),
-              );
-            } else {
-              actions.setTemplateList((prev) => [savedResolution, ...prev]);
-            }
+          onSave={() => {
             actions.handleRefresh();
           }}
         />

--- a/frontend/src/pages/Library/Dataset/Datasets.tsx
+++ b/frontend/src/pages/Library/Dataset/Datasets.tsx
@@ -19,10 +19,10 @@
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useQueryClient } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import type { RowSelectionState } from '@tanstack/react-table';
 import { Search, Filter, FilterX, Plus } from 'lucide-react';
-import { useEffect, useState, useTransition } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 
@@ -102,8 +102,6 @@ export default function Dataset() {
   const [selectionCache, setSelectionCache] = useState<Record<string, Dataset>>({});
   const [openFilter, setOpenFilter] = useState(false);
 
-  const [canAddToFolder, setCanAddToFolder] = useState(false);
-
   const [showFolderSidebar, setShowFolderSidebar] = useState(false);
   const [activeModal, setActiveModal] = useState<ModalType | null>(null);
 
@@ -112,11 +110,10 @@ export default function Dataset() {
   const [shareEntityIds, setShareEntityIds] = useState<number | number[] | null>(null);
   const [selectedDatasetId, setSelectedDatasetId] = useState<number | null>(null);
 
-  const [isExporting, startExportTransition] = useTransition();
-
   const openModal = (name: ModalType) => setActiveModal(name);
   const closeModal = () => setActiveModal(null);
 
+  // --- Data Fetching ---
   const {
     data: queryData,
     isFetching,
@@ -131,11 +128,34 @@ export default function Dataset() {
     enabled: isHydrated,
   });
 
+  // Folder Permissions (Replaced useEffect with useQuery)
+  const { data: folderPerms } = useQuery({
+    queryKey: ['folderPermissions', selectedFolderId],
+    queryFn: () => fetchContextButtons(selectedFolderId as number),
+    enabled: selectedFolderId !== null,
+    staleTime: 1000 * 60 * 5,
+  });
+
+  // Export Mutation (Replaced useTransition with useMutation)
+  const exportCsvMutation = useMutation({
+    mutationFn: (datasetId: number) => exportDatasetCsv(datasetId),
+    onSuccess: () => {
+      notify.success(t('CSV exported successfully'));
+    },
+    onError: (err) => {
+      console.error('Failed to export dataset:', err);
+      notify.error(t('Failed to export CSV'), {
+        description: t('Please check the server logs or try again.'),
+      });
+    },
+  });
+
+  // --- Computed Values ---
   const data = queryData?.rows;
   const pageCount = Math.ceil((queryData?.totalCount || 0) / pagination.pageSize);
   const error = isError && queryError instanceof Error ? queryError.message : '';
-
-  const [datasetList, setDatasetList] = useState<Dataset[]>([]);
+  const datasetList = data ?? [];
+  const canAddToFolder = folderPerms?.create || false;
 
   const folderActions = useFolderActions({
     onSuccess: (targetFolder) => {
@@ -149,64 +169,35 @@ export default function Dataset() {
     },
   });
 
-  useEffect(() => {
-    setDatasetList(data ?? []);
-  }, [data]);
-
-  useEffect(() => {
-    if (selectedFolderId === null) {
-      setCanAddToFolder(false);
-      return;
-    }
-
-    let active = true;
-
-    fetchContextButtons(selectedFolderId)
-      .then((perms) => {
-        if (active) {
-          setCanAddToFolder(perms.create || false);
-        }
-      })
-      .catch((err) => {
-        console.error('Failed to fetch folder permissions', err);
-        if (active) {
-          setCanAddToFolder(false);
-        }
-      });
-
-    return () => {
-      active = false;
-    };
-  }, [selectedFolderId]);
-
-  useEffect(() => {
-    if (!datasetList || datasetList.length === 0) {
-      return;
-    }
-
-    setSelectionCache((prev) => {
-      const next = { ...prev };
-      let hasChanges = false;
-
-      datasetList.forEach((item) => {
-        const id = item.dataSetId.toString();
-        if (rowSelection[id] && next[id] !== item) {
-          next[id] = item;
-          hasChanges = true;
-        }
-      });
-
-      return hasChanges ? next : prev;
-    });
-  }, [datasetList, rowSelection]);
-
-  const selectedDataset = datasetList.find((m) => m.dataSetId === selectedDatasetId) ?? null;
-  const existingNames = datasetList.map((m) => m.dataSet);
-
   const getRowId = (row: Dataset) => {
     return row.dataSetId.toString();
   };
 
+  // --- Event-Driven Cache Handler ---
+  const handleRowSelectionChange = (
+    updaterOrValue: RowSelectionState | ((old: RowSelectionState) => RowSelectionState),
+  ) => {
+    const newSelection =
+      typeof updaterOrValue === 'function' ? updaterOrValue(rowSelection) : updaterOrValue;
+
+    setRowSelection(newSelection);
+
+    setSelectionCache((prev) => {
+      const next = { ...prev };
+      datasetList.forEach((item) => {
+        const id = getRowId(item); // Strictly use getRowId
+        if (newSelection[id]) {
+          next[id] = item;
+        }
+      });
+      return next;
+    });
+  };
+
+  const selectedDataset = datasetList.find((m) => m.dataSetId === selectedDatasetId) ?? null;
+  const existingNames = datasetList.map((m) => m.dataSet);
+
+  // --- Handlers ---
   const handleRefresh = () => {
     queryClient.invalidateQueries({ queryKey: ['dataset'] });
   };
@@ -215,20 +206,6 @@ export default function Dataset() {
     setSelectedFolderId(folder.id);
     setPagination((prev) => ({ ...prev, pageIndex: 0 }));
     setRowSelection({});
-  };
-
-  const handleExportCsv = (datasetId: number) => {
-    startExportTransition(async () => {
-      try {
-        await exportDatasetCsv(datasetId);
-        notify.success(t('CSV exported successfully'));
-      } catch (err) {
-        console.error('Failed to export dataset:', err);
-        notify.error(t('Failed to export CSV'), {
-          description: t('Please check the server logs or try again.'),
-        });
-      }
-    });
   };
 
   const {
@@ -294,11 +271,7 @@ export default function Dataset() {
     onNavigate: (path) => {
       navigate(path);
     },
-    onExportCsv: handleExportCsv,
-    onImportCsv: (datasetId) => {
-      setSelectedDatasetId(datasetId);
-      openModal('import');
-    },
+    onExportCsv: (datasetId) => exportCsvMutation.mutate(datasetId), // Point to useMutation!
   });
 
   const getAllSelectedItems = (): Dataset[] => {
@@ -346,7 +319,7 @@ export default function Dataset() {
         <div className="flex flex-row justify-between py-4 items-center gap-4">
           <TabNav activeTab="Datasets" navigation={libraryTabs} />
           <div className="flex items-center gap-2 md:mb-0">
-            {isExporting && (
+            {exportCsvMutation.isPending && ( // Use TanStack Query's loading state
               <span className="text-sm font-medium text-xibo-blue-600 animate-pulse pr-2">
                 {t('Generating CSV...')}
               </span>
@@ -441,7 +414,7 @@ export default function Dataset() {
               onGlobalFilterChange={setGlobalFilter}
               loading={isFetching}
               rowSelection={rowSelection}
-              onRowSelectionChange={setRowSelection}
+              onRowSelectionChange={handleRowSelectionChange} // <-- Event Handler Applied!
               onRefresh={handleRefresh}
               columnPinning={{ left: ['tableSelection'], right: ['tableActions'] }}
               columnVisibility={columnVisibility}
@@ -459,7 +432,6 @@ export default function Dataset() {
           activeModal,
           closeModal,
           handleRefresh,
-          setDatasetList,
           deleteError,
           isDeleting,
           isCloning,

--- a/frontend/src/pages/Library/Dataset/Datasets.tsx
+++ b/frontend/src/pages/Library/Dataset/Datasets.tsx
@@ -113,7 +113,6 @@ export default function Dataset() {
   const openModal = (name: ModalType) => setActiveModal(name);
   const closeModal = () => setActiveModal(null);
 
-  // --- Data Fetching ---
   const {
     data: queryData,
     isFetching,
@@ -128,7 +127,6 @@ export default function Dataset() {
     enabled: isHydrated,
   });
 
-  // Folder Permissions (Replaced useEffect with useQuery)
   const { data: folderPerms } = useQuery({
     queryKey: ['folderPermissions', selectedFolderId],
     queryFn: () => fetchContextButtons(selectedFolderId as number),
@@ -136,7 +134,6 @@ export default function Dataset() {
     staleTime: 1000 * 60 * 5,
   });
 
-  // Export Mutation (Replaced useTransition with useMutation)
   const exportCsvMutation = useMutation({
     mutationFn: (datasetId: number) => exportDatasetCsv(datasetId),
     onSuccess: () => {
@@ -150,7 +147,6 @@ export default function Dataset() {
     },
   });
 
-  // --- Computed Values ---
   const data = queryData?.rows;
   const pageCount = Math.ceil((queryData?.totalCount || 0) / pagination.pageSize);
   const error = isError && queryError instanceof Error ? queryError.message : '';
@@ -173,7 +169,6 @@ export default function Dataset() {
     return row.dataSetId.toString();
   };
 
-  // --- Event-Driven Cache Handler ---
   const handleRowSelectionChange = (
     updaterOrValue: RowSelectionState | ((old: RowSelectionState) => RowSelectionState),
   ) => {
@@ -185,7 +180,7 @@ export default function Dataset() {
     setSelectionCache((prev) => {
       const next = { ...prev };
       datasetList.forEach((item) => {
-        const id = getRowId(item); // Strictly use getRowId
+        const id = getRowId(item);
         if (newSelection[id]) {
           next[id] = item;
         }
@@ -197,7 +192,6 @@ export default function Dataset() {
   const selectedDataset = datasetList.find((m) => m.dataSetId === selectedDatasetId) ?? null;
   const existingNames = datasetList.map((m) => m.dataSet);
 
-  // --- Handlers ---
   const handleRefresh = () => {
     queryClient.invalidateQueries({ queryKey: ['dataset'] });
   };
@@ -271,7 +265,7 @@ export default function Dataset() {
     onNavigate: (path) => {
       navigate(path);
     },
-    onExportCsv: (datasetId) => exportCsvMutation.mutate(datasetId), // Point to useMutation!
+    onExportCsv: (datasetId) => exportCsvMutation.mutate(datasetId),
   });
 
   const getAllSelectedItems = (): Dataset[] => {
@@ -319,7 +313,7 @@ export default function Dataset() {
         <div className="flex flex-row justify-between py-4 items-center gap-4">
           <TabNav activeTab="Datasets" navigation={libraryTabs} />
           <div className="flex items-center gap-2 md:mb-0">
-            {exportCsvMutation.isPending && ( // Use TanStack Query's loading state
+            {exportCsvMutation.isPending && (
               <span className="text-sm font-medium text-xibo-blue-600 animate-pulse pr-2">
                 {t('Generating CSV...')}
               </span>
@@ -414,7 +408,7 @@ export default function Dataset() {
               onGlobalFilterChange={setGlobalFilter}
               loading={isFetching}
               rowSelection={rowSelection}
-              onRowSelectionChange={handleRowSelectionChange} // <-- Event Handler Applied!
+              onRowSelectionChange={handleRowSelectionChange}
               onRefresh={handleRefresh}
               columnPinning={{ left: ['tableSelection'], right: ['tableActions'] }}
               columnVisibility={columnVisibility}

--- a/frontend/src/pages/Library/Dataset/components/DatasetModals.tsx
+++ b/frontend/src/pages/Library/Dataset/components/DatasetModals.tsx
@@ -37,7 +37,6 @@ interface DatasetModalsProps {
     activeModal: string | null;
     closeModal: () => void;
     handleRefresh: () => void;
-    setDatasetList: React.Dispatch<React.SetStateAction<Dataset[]>>;
     deleteError: string | null;
     isDeleting: boolean;
     isCloning: boolean;
@@ -77,14 +76,7 @@ export function DatasetModals({ actions, selection, handlers, folderActions }: D
             actions.closeModal();
           }}
           data={selection.selectedDataset}
-          onSave={(savedDataset) => {
-            if (selection.selectedDatasetId) {
-              actions.setDatasetList((prev) =>
-                prev.map((m) => (m.dataSetId === savedDataset.dataSetId ? savedDataset : m)),
-              );
-            } else {
-              actions.setDatasetList((prev) => [savedDataset, ...prev]);
-            }
+          onSave={() => {
             actions.handleRefresh();
           }}
         />

--- a/frontend/src/pages/Library/Dataset/subPages/Columns/DatasetColumns.tsx
+++ b/frontend/src/pages/Library/Dataset/subPages/Columns/DatasetColumns.tsx
@@ -94,7 +94,6 @@ export default function DatasetColumns() {
     queryClient.invalidateQueries({ queryKey: ['datasetColumns', datasetId] });
   };
 
-  // --- Data Fetching ---
   const { data: dataset } = useQuery({
     queryKey: ['dataset', datasetId],
     queryFn: () => getDatasetById(datasetId!),
@@ -181,7 +180,6 @@ export default function DatasetColumns() {
     },
   });
 
-  // --- Handlers ---
   const handleAdd = () => {
     setSelectedColumn(null);
     setActiveModal('edit');
@@ -356,7 +354,7 @@ export default function DatasetColumns() {
               onGlobalFilterChange={setGlobalFilter}
               loading={isFetching}
               rowSelection={rowSelection}
-              onRowSelectionChange={handleRowSelectionChange} // <-- Event Handler
+              onRowSelectionChange={handleRowSelectionChange}
               bulkActions={bulkActions}
               onRefresh={handleRefresh}
               columnPinning={{ left: ['tableSelection'], right: ['tableActions'] }}

--- a/frontend/src/pages/Library/Dataset/subPages/Columns/DatasetColumns.tsx
+++ b/frontend/src/pages/Library/Dataset/subPages/Columns/DatasetColumns.tsx
@@ -19,10 +19,10 @@
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import type { RowSelectionState } from '@tanstack/react-table';
 import { Eye, Plus, Search, Slash, Trash2 } from 'lucide-react';
-import { useState, useTransition, useEffect } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams, useNavigate } from 'react-router-dom';
 
@@ -77,26 +77,24 @@ export default function DatasetColumns() {
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [selectionCache, setSelectionCache] = useState<Record<string, DatasetColumn>>({});
-  const [columnList, setColumnList] = useState<DatasetColumn[]>([]);
   const [itemsToDelete, setItemsToDelete] = useState<DatasetColumn[]>([]);
 
   const [activeModal, setActiveModal] = useState<ColumnModalType>(null);
   const [selectedColumn, setSelectedColumn] = useState<DatasetColumn | null>(null);
-
-  const [isCloning, startCloneTransition] = useTransition();
-  const [isDeleting, startDeleteTransition] = useTransition();
   const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const closeModal = () => {
     setActiveModal(null);
     setSelectedColumn(null);
     setItemsToDelete([]);
+    setDeleteError(null);
   };
 
   const handleRefresh = () => {
     queryClient.invalidateQueries({ queryKey: ['datasetColumns', datasetId] });
   };
 
+  // --- Data Fetching ---
   const { data: dataset } = useQuery({
     queryKey: ['dataset', datasetId],
     queryFn: () => getDatasetById(datasetId!),
@@ -115,31 +113,75 @@ export default function DatasetColumns() {
     enabled: isHydrated,
   });
 
-  useEffect(() => {
-    setColumnList(queryData?.rows ?? []);
-  }, [queryData?.rows]);
+  const columnList = queryData?.rows ?? [];
+  const pageCount = Math.ceil((queryData?.totalCount || 0) / pagination.pageSize);
+  const error = isError && queryError instanceof Error ? queryError.message : '';
+  const existingNames = columnList.map((col) => col.heading);
 
-  useEffect(() => {
-    if (!columnList || columnList.length === 0) {
-      return;
-    }
+  const getRowId = (row: DatasetColumn) => {
+    return row.dataSetColumnId.toString();
+  };
+
+  const handleRowSelectionChange = (
+    updaterOrValue: RowSelectionState | ((old: RowSelectionState) => RowSelectionState),
+  ) => {
+    const newSelection =
+      typeof updaterOrValue === 'function' ? updaterOrValue(rowSelection) : updaterOrValue;
+
+    setRowSelection(newSelection);
 
     setSelectionCache((prev) => {
       const next = { ...prev };
-      let hasChanges = false;
-
       columnList.forEach((item) => {
-        const id = item.dataSetColumnId.toString();
-        if (rowSelection[id] && next[id] !== item) {
+        const id = getRowId(item);
+        if (newSelection[id]) {
           next[id] = item;
-          hasChanges = true;
         }
       });
-
-      return hasChanges ? next : prev;
+      return next;
     });
-  }, [columnList, rowSelection]);
+  };
 
+  const copyMutation = useMutation({
+    mutationFn: async (
+      payload: Omit<
+        DatasetColumn,
+        'dataSetColumnId' | 'dataSetId' | 'listType' | 'dataType' | 'dataSetColumnType'
+      >,
+    ) => {
+      return await createDatasetColumn(datasetId!, payload);
+    },
+    onSuccess: () => {
+      closeModal();
+      handleRefresh();
+    },
+    onError: (err) => {
+      console.error('Failed to copy column:', err);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async (items: DatasetColumn[]) => {
+      for (const item of items) {
+        await deleteDatasetColumn(datasetId!, item.dataSetColumnId);
+      }
+      return items;
+    },
+    onSuccess: (deletedItems) => {
+      const newSelection = { ...rowSelection };
+      deletedItems.forEach((item) => delete newSelection[item.dataSetColumnId.toString()]);
+      setRowSelection(newSelection);
+
+      closeModal();
+      handleRefresh();
+    },
+    onError: (err: unknown) => {
+      const apiError = err as { response?: { data?: { message?: string } } };
+      setDeleteError(apiError.response?.data?.message || t('Failed to delete columns.'));
+    },
+  });
+
+  // --- Handlers ---
   const handleAdd = () => {
     setSelectedColumn(null);
     setActiveModal('edit');
@@ -152,9 +194,7 @@ export default function DatasetColumns() {
 
   const handleDelete = (id: number) => {
     const column = columnList.find((c) => c.dataSetColumnId === id);
-    if (!column) {
-      return;
-    }
+    if (!column) return;
 
     setItemsToDelete([column]);
     setDeleteError(null);
@@ -167,56 +207,29 @@ export default function DatasetColumns() {
   };
 
   const handleConfirmCopy = (newHeading: string) => {
-    if (!selectedColumn) {
-      return;
-    }
+    if (!selectedColumn) return;
 
-    startCloneTransition(async () => {
-      try {
-        const copiedPayload = {
-          heading: newHeading,
-          dataSetColumnTypeId: selectedColumn.dataSetColumnTypeId ?? 1,
-          dataTypeId: selectedColumn.dataTypeId ?? 1,
-          listContent: selectedColumn.listContent ?? '',
-          remoteField: selectedColumn.remoteField ?? '',
-          columnOrder: selectedColumn.columnOrder ?? 0,
-          tooltip: selectedColumn.tooltip ?? '',
-          formula: selectedColumn.formula ?? '',
-          showFilter: Boolean(selectedColumn.showFilter),
-          dateFormat: selectedColumn.dateFormat ?? '',
-          showSort: Boolean(selectedColumn.showSort),
-          isRequired: Boolean(selectedColumn.isRequired),
-        };
+    const copiedPayload = {
+      heading: newHeading,
+      dataSetColumnTypeId: selectedColumn.dataSetColumnTypeId ?? 1,
+      dataTypeId: selectedColumn.dataTypeId ?? 1,
+      listContent: selectedColumn.listContent ?? '',
+      remoteField: selectedColumn.remoteField ?? '',
+      columnOrder: selectedColumn.columnOrder ?? 0,
+      tooltip: selectedColumn.tooltip ?? '',
+      formula: selectedColumn.formula ?? '',
+      showFilter: Boolean(selectedColumn.showFilter),
+      dateFormat: selectedColumn.dateFormat ?? '',
+      showSort: Boolean(selectedColumn.showSort),
+      isRequired: Boolean(selectedColumn.isRequired),
+    };
 
-        await createDatasetColumn(datasetId!, copiedPayload);
-
-        closeModal();
-        handleRefresh();
-      } catch (err) {
-        console.error('Failed to copy column:', err);
-      }
-    });
+    copyMutation.mutate(copiedPayload);
   };
 
   const confirmDelete = (items: DatasetColumn[]) => {
     setDeleteError(null);
-    startDeleteTransition(async () => {
-      try {
-        for (const item of items) {
-          await deleteDatasetColumn(datasetId!, item.dataSetColumnId);
-        }
-
-        const newSelection = { ...rowSelection };
-        items.forEach((item) => delete newSelection[item.dataSetColumnId.toString()]);
-        setRowSelection(newSelection);
-
-        closeModal();
-        handleRefresh();
-      } catch (err: unknown) {
-        const apiError = err as { response?: { data?: { message?: string } } };
-        setDeleteError(apiError.response?.data?.message || t('Failed to delete columns.'));
-      }
-    });
+    deleteMutation.mutate(items);
   };
 
   const columns = getColumnDefinitions({
@@ -245,14 +258,6 @@ export default function DatasetColumns() {
       variant: 'danger' as const,
     },
   ];
-
-  const pageCount = Math.ceil((queryData?.totalCount || 0) / pagination.pageSize);
-  const error = isError && queryError instanceof Error ? queryError.message : '';
-  const existingNames = columnList.map((col) => col.heading);
-
-  const getRowId = (row: DatasetColumn) => {
-    return row.dataSetColumnId.toString();
-  };
 
   const libraryTabs = useFilteredTabs('library');
 
@@ -351,7 +356,7 @@ export default function DatasetColumns() {
               onGlobalFilterChange={setGlobalFilter}
               loading={isFetching}
               rowSelection={rowSelection}
-              onRowSelectionChange={setRowSelection}
+              onRowSelectionChange={handleRowSelectionChange} // <-- Event Handler
               bulkActions={bulkActions}
               onRefresh={handleRefresh}
               columnPinning={{ left: ['tableSelection'], right: ['tableActions'] }}
@@ -370,14 +375,13 @@ export default function DatasetColumns() {
           activeModal,
           closeModal,
           handleRefresh,
-          setColumnList,
           deleteError,
-          isDeleting,
-          isCloning,
+          isDeleting: deleteMutation.isPending,
+          isCloning: copyMutation.isPending,
         }}
         selection={{
           selectedColumn,
-          columnToDeleteId: itemsToDelete[0]?.dataSetColumnId || null,
+          columnToDeleteId: itemsToDelete[0] ? itemsToDelete[0].dataSetColumnId : null,
           itemsToDelete,
           existingNames,
         }}

--- a/frontend/src/pages/Library/Dataset/subPages/Columns/components/DatasetColumnsModals.tsx
+++ b/frontend/src/pages/Library/Dataset/subPages/Columns/components/DatasetColumnsModals.tsx
@@ -31,7 +31,6 @@ interface DatasetColumnModalsProps {
     activeModal: string | null;
     closeModal: () => void;
     handleRefresh: () => void;
-    setColumnList: React.Dispatch<React.SetStateAction<DatasetColumn[]>>;
     deleteError: string | null;
     isDeleting: boolean;
     isCloning?: boolean;

--- a/frontend/src/pages/Library/Dataset/subPages/Data/DatasetData.tsx
+++ b/frontend/src/pages/Library/Dataset/subPages/Data/DatasetData.tsx
@@ -112,13 +112,11 @@ export default function DatasetData() {
   const error = isError && queryError instanceof Error ? queryError.message : '';
   const isLoading = !isHydrated || isFetchingColumns;
 
-  // --- Centralized Deterministic ID Function ---
   const getRowId = (row: DynamicRowData) => {
     const id = row.id ?? row.datasetDataId;
     return id !== undefined && id !== null ? String(id) : '';
   };
 
-  // --- Event-Driven Selection Handler ---
   const handleRowSelectionChange = (
     updaterOrValue: RowSelectionState | ((old: RowSelectionState) => RowSelectionState),
   ) => {
@@ -172,7 +170,6 @@ export default function DatasetData() {
       return items;
     },
     onSuccess: (deletedItems) => {
-      // Clear selections
       const newSelection = { ...rowSelection };
       deletedItems.forEach((item) => {
         const rowId = getRowId(item);
@@ -350,14 +347,14 @@ export default function DatasetData() {
               onGlobalFilterChange={setGlobalFilter}
               loading={isFetchingData}
               rowSelection={rowSelection}
-              onRowSelectionChange={handleRowSelectionChange} // <-- Event Handler
+              onRowSelectionChange={handleRowSelectionChange}
               bulkActions={bulkActions}
               onRefresh={handleRefresh}
               columnPinning={{ left: ['tableSelection'], right: ['tableActions'] }}
               columnVisibility={columnVisibility}
               onColumnVisibilityChange={setColumnVisibility}
               viewMode={null}
-              getRowId={getRowId} // <-- Deterministic ID applied
+              getRowId={getRowId}
             />
           )}
         </div>
@@ -377,7 +374,6 @@ export default function DatasetData() {
         selection={{
           selectedData: selectedRow,
           itemsToDelete,
-          // FIX: Check for the item directly instead of array length
           rowToDeleteId: itemsToDelete[0] ? getRowId(itemsToDelete[0]) : null,
         }}
         handlers={{

--- a/frontend/src/pages/Library/Dataset/subPages/Data/DatasetData.tsx
+++ b/frontend/src/pages/Library/Dataset/subPages/Data/DatasetData.tsx
@@ -19,10 +19,10 @@
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import type { RowSelectionState } from '@tanstack/react-table';
 import { Plus, Search, Slash, Table } from 'lucide-react';
-import { useState, useTransition, useEffect, useMemo } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams, useNavigate } from 'react-router-dom';
 
@@ -79,9 +79,6 @@ export default function DatasetData() {
 
   const [activeModal, setActiveModal] = useState<DataModalType>(null);
   const [selectedRow, setSelectedRow] = useState<DynamicRowData | null>(null);
-
-  const [isCloning, startCloneTransition] = useTransition();
-  const [isDeleting, startDeleteTransition] = useTransition();
   const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const { data: dataset } = useQuery({
@@ -109,90 +106,105 @@ export default function DatasetData() {
     enabled: isHydrated && !!columnsData,
   });
 
-  const columnsSchema = useMemo(() => columnsData?.rows || [], [columnsData?.rows]);
-  const rowData = useMemo(() => queryData?.rows || [], [queryData?.rows]);
+  const columnsSchema = columnsData?.rows || [];
+  const rowData = queryData?.rows || [];
   const pageCount = Math.ceil((queryData?.totalCount || 0) / pagination.pageSize);
   const error = isError && queryError instanceof Error ? queryError.message : '';
   const isLoading = !isHydrated || isFetchingColumns;
 
-  useEffect(() => {
-    if (!rowData || rowData.length === 0) {
-      return;
-    }
+  // --- Centralized Deterministic ID Function ---
+  const getRowId = (row: DynamicRowData) => {
+    const id = row.id ?? row.datasetDataId;
+    return id !== undefined && id !== null ? String(id) : '';
+  };
+
+  // --- Event-Driven Selection Handler ---
+  const handleRowSelectionChange = (
+    updaterOrValue: RowSelectionState | ((old: RowSelectionState) => RowSelectionState),
+  ) => {
+    const newSelection =
+      typeof updaterOrValue === 'function' ? updaterOrValue(rowSelection) : updaterOrValue;
+
+    setRowSelection(newSelection);
 
     setSelectionCache((prev) => {
       const next = { ...prev };
-      let hasChanges = false;
-
       rowData.forEach((item) => {
-        const id = String(item.id || item.datasetDataId);
-        if (id && rowSelection[id] && next[id] !== item) {
+        const id = getRowId(item);
+        if (id && newSelection[id]) {
           next[id] = item;
-          hasChanges = true;
         }
       });
-
-      return hasChanges ? next : prev;
+      return next;
     });
-  }, [rowData, rowSelection]);
+  };
 
   const closeModal = () => {
     setActiveModal(null);
     setSelectedRow(null);
     setItemsToDelete([]);
+    setDeleteError(null);
   };
 
   const handleRefresh = () => {
     queryClient.invalidateQueries({ queryKey: ['datasetData', datasetId] });
   };
 
+  const copyMutation = useMutation({
+    mutationFn: async (rowToCopy: Record<string, DatasetRowValue>) => {
+      return await createDatasetRow(datasetId!, rowToCopy);
+    },
+    onSuccess: () => {
+      closeModal();
+      handleRefresh();
+    },
+    onError: (err) => {
+      console.error('Failed to duplicate row:', err);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async (items: DynamicRowData[]) => {
+      for (const item of items) {
+        const rowId = getRowId(item);
+        if (rowId) await deleteDatasetRow(datasetId!, rowId);
+      }
+      return items;
+    },
+    onSuccess: (deletedItems) => {
+      // Clear selections
+      const newSelection = { ...rowSelection };
+      deletedItems.forEach((item) => {
+        const rowId = getRowId(item);
+        if (rowId) delete newSelection[rowId];
+      });
+      setRowSelection(newSelection);
+
+      closeModal();
+      handleRefresh();
+    },
+    onError: (err: unknown) => {
+      const apiError = err as { response?: { data?: { message?: string } } };
+      setDeleteError(apiError.response?.data?.message || t('Failed to delete rows.'));
+    },
+  });
+
   const handleConfirmCopy = () => {
-    if (!selectedRow) {
-      return;
-    }
+    if (!selectedRow) return;
 
-    startCloneTransition(async () => {
-      try {
-        const rowToCopy: Record<string, DatasetRowValue> = {};
-        columnsSchema.forEach((col) => {
-          if (col.dataSetColumnTypeId === 1) {
-            const columnId = String(col.dataSetColumnId);
-            rowToCopy[columnId] = selectedRow[col.heading] ?? selectedRow[columnId] ?? '';
-          }
-        });
-        await createDatasetRow(datasetId!, rowToCopy);
-
-        closeModal();
-        handleRefresh();
-      } catch (err) {
-        console.error('Failed to duplicate row:', err);
+    const rowToCopy: Record<string, DatasetRowValue> = {};
+    columnsSchema.forEach((col) => {
+      if (col.dataSetColumnTypeId === 1) {
+        const columnId = String(col.dataSetColumnId);
+        rowToCopy[columnId] = selectedRow[col.heading] ?? selectedRow[columnId] ?? '';
       }
     });
+
+    copyMutation.mutate(rowToCopy);
   };
 
   const confirmDelete = (items: DynamicRowData[]) => {
-    setDeleteError(null);
-    startDeleteTransition(async () => {
-      try {
-        for (const item of items) {
-          const rowId = String(item.id || item.datasetDataId);
-          if (rowId) await deleteDatasetRow(datasetId!, rowId);
-        }
-
-        const newSelection = { ...rowSelection };
-        items.forEach((item) => {
-          const rowId = String(item.id || item.datasetDataId);
-          if (rowId) delete newSelection[rowId];
-        });
-        setRowSelection(newSelection);
-
-        closeModal();
-        handleRefresh();
-      } catch (err: unknown) {
-        const apiError = err as { response?: { data?: { message?: string } } };
-        setDeleteError(apiError.response?.data?.message || t('Failed to delete rows.'));
-      }
-    });
+    deleteMutation.mutate(items);
   };
 
   const tableColumns = getDynamicDataColumns(columnsSchema, {
@@ -207,7 +219,7 @@ export default function DatasetData() {
       setActiveModal('copy');
     },
     onDelete: (id) => {
-      const row = rowData.find((r) => String(r.id) === String(id));
+      const row = rowData.find((r) => getRowId(r) === String(id));
       if (row) {
         setItemsToDelete([row]);
         setDeleteError(null);
@@ -338,14 +350,14 @@ export default function DatasetData() {
               onGlobalFilterChange={setGlobalFilter}
               loading={isFetchingData}
               rowSelection={rowSelection}
-              onRowSelectionChange={setRowSelection}
+              onRowSelectionChange={handleRowSelectionChange} // <-- Event Handler
               bulkActions={bulkActions}
               onRefresh={handleRefresh}
               columnPinning={{ left: ['tableSelection'], right: ['tableActions'] }}
               columnVisibility={columnVisibility}
               onColumnVisibilityChange={setColumnVisibility}
               viewMode={null}
-              getRowId={(row) => String(row.id || Math.random())}
+              getRowId={getRowId} // <-- Deterministic ID applied
             />
           )}
         </div>
@@ -358,17 +370,15 @@ export default function DatasetData() {
           activeModal,
           closeModal,
           handleRefresh,
-          isCloning,
-          isDeleting,
+          isCloning: copyMutation.isPending,
+          isDeleting: deleteMutation.isPending,
           deleteError,
         }}
         selection={{
           selectedData: selectedRow,
           itemsToDelete,
-          rowToDeleteId:
-            itemsToDelete.length > 0
-              ? String(itemsToDelete[0]?.id ?? itemsToDelete[0]?.datasetDataId ?? '')
-              : null,
+          // FIX: Check for the item directly instead of array length
+          rowToDeleteId: itemsToDelete[0] ? getRowId(itemsToDelete[0]) : null,
         }}
         handlers={{
           handleConfirmCopy,

--- a/frontend/src/pages/Library/Dataset/subPages/Rss/DatasetRss.tsx
+++ b/frontend/src/pages/Library/Dataset/subPages/Rss/DatasetRss.tsx
@@ -19,10 +19,10 @@
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import type { RowSelectionState } from '@tanstack/react-table';
 import { Eye, Plus, Search, Slash, Trash2 } from 'lucide-react';
-import { useState, useTransition, useEffect } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useParams, useNavigate } from 'react-router-dom';
 
@@ -77,26 +77,24 @@ export default function DatasetRss() {
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [selectionCache, setSelectionCache] = useState<Record<string, DatasetRss>>({});
-  const [rssList, setRssList] = useState<DatasetRss[]>([]);
   const [itemsToDelete, setItemsToDelete] = useState<DatasetRss[]>([]);
 
   const [activeModal, setActiveModal] = useState<RssModalType>(null);
   const [selectedRss, setSelectedRss] = useState<DatasetRss | null>(null);
-
-  const [isCloning, startCloneTransition] = useTransition();
-  const [isDeleting, startDeleteTransition] = useTransition();
   const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const closeModal = () => {
     setActiveModal(null);
     setSelectedRss(null);
     setItemsToDelete([]);
+    setDeleteError(null);
   };
 
   const handleRefresh = () => {
     queryClient.invalidateQueries({ queryKey: ['datasetRss', datasetId] });
   };
 
+  // --- Data Fetching ---
   const { data: dataset } = useQuery({
     queryKey: ['dataset', datasetId],
     queryFn: () => getDatasetById(datasetId!),
@@ -115,31 +113,72 @@ export default function DatasetRss() {
     enabled: isHydrated,
   });
 
-  useEffect(() => {
-    setRssList(queryData?.rows ?? []);
-  }, [queryData?.rows]);
+  // 1. Single Source of Truth
+  const rssList = queryData?.rows ?? [];
+  const pageCount = Math.ceil((queryData?.totalCount || 0) / pagination.pageSize);
+  const error = isError && queryError instanceof Error ? queryError.message : '';
+  const existingNames = rssList.map((rss) => rss.title);
 
-  useEffect(() => {
-    if (!rssList || rssList.length === 0) {
-      return;
-    }
+  const getRowId = (row: DatasetRss) => {
+    return row.id.toString();
+  };
+
+  // 2. Event-Driven Cache Handler
+  const handleRowSelectionChange = (
+    updaterOrValue: RowSelectionState | ((old: RowSelectionState) => RowSelectionState),
+  ) => {
+    const newSelection =
+      typeof updaterOrValue === 'function' ? updaterOrValue(rowSelection) : updaterOrValue;
+
+    setRowSelection(newSelection);
 
     setSelectionCache((prev) => {
       const next = { ...prev };
-      let hasChanges = false;
-
       rssList.forEach((item) => {
-        const id = item.id.toString();
-        if (rowSelection[id] && next[id] !== item) {
+        const id = getRowId(item);
+        if (newSelection[id]) {
           next[id] = item;
-          hasChanges = true;
         }
       });
-
-      return hasChanges ? next : prev;
+      return next;
     });
-  }, [rssList, rowSelection]);
+  };
 
+  const copyMutation = useMutation({
+    mutationFn: async (payload: Omit<DatasetRss, 'id' | 'dataSetId'>) => {
+      return await createDatasetRss(datasetId!, payload);
+    },
+    onSuccess: () => {
+      closeModal();
+      handleRefresh();
+    },
+    onError: (err) => {
+      console.error('Failed to copy RSS:', err);
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: async (items: DatasetRss[]) => {
+      for (const item of items) {
+        await deleteDatasetRss(datasetId!, item.id);
+      }
+      return items;
+    },
+    onSuccess: (deletedItems) => {
+      const newSelection = { ...rowSelection };
+      deletedItems.forEach((item) => delete newSelection[item.id.toString()]);
+      setRowSelection(newSelection);
+
+      closeModal();
+      handleRefresh();
+    },
+    onError: (err: unknown) => {
+      const apiError = err as { response?: { data?: { message?: string } } };
+      setDeleteError(apiError.response?.data?.message || t('Failed to delete RSS.'));
+    },
+  });
+
+  // --- Handlers ---
   const handleAdd = () => {
     setSelectedRss(null);
     setActiveModal('edit');
@@ -171,42 +210,23 @@ export default function DatasetRss() {
       return;
     }
 
-    startCloneTransition(async () => {
-      try {
-        const copiedPayload = {
-          title: selectedRss.title,
-          author: selectedRss.author,
-        };
+    const copiedPayload: Omit<DatasetRss, 'id' | 'dataSetId'> = {
+      title: selectedRss.title,
+      author: selectedRss.author,
+      titleColumnId: selectedRss.titleColumnId,
+      summaryColumnId: selectedRss.summaryColumnId,
+      contentColumnId: selectedRss.contentColumnId,
+      publishedDateColumnId: selectedRss.publishedDateColumnId,
+      sort: selectedRss.sort,
+      filter: selectedRss.filter,
+    };
 
-        await createDatasetRss(datasetId!, copiedPayload);
-
-        closeModal();
-        handleRefresh();
-      } catch (err) {
-        console.error('Failed to copy column:', err);
-      }
-    });
+    copyMutation.mutate(copiedPayload); // No more 'as any' needed!
   };
 
   const confirmDelete = (items: DatasetRss[]) => {
     setDeleteError(null);
-    startDeleteTransition(async () => {
-      try {
-        for (const item of items) {
-          await deleteDatasetRss(datasetId!, item.id);
-        }
-
-        const newSelection = { ...rowSelection };
-        items.forEach((item) => delete newSelection[item.id.toString()]);
-        setRowSelection(newSelection);
-
-        closeModal();
-        handleRefresh();
-      } catch (err: unknown) {
-        const apiError = err as { response?: { data?: { message?: string } } };
-        setDeleteError(apiError.response?.data?.message || t('Failed to delete RSS.'));
-      }
-    });
+    deleteMutation.mutate(items);
   };
 
   const columns = getRssDefinitions({
@@ -235,14 +255,6 @@ export default function DatasetRss() {
       variant: 'danger' as const,
     },
   ];
-
-  const pageCount = Math.ceil((queryData?.totalCount || 0) / pagination.pageSize);
-  const error = isError && queryError instanceof Error ? queryError.message : '';
-  const existingNames = rssList.map((rss) => rss.title);
-
-  const getRowId = (row: DatasetRss) => {
-    return row.id.toString();
-  };
 
   const libraryTabs = useFilteredTabs('library');
 
@@ -341,7 +353,7 @@ export default function DatasetRss() {
               onGlobalFilterChange={setGlobalFilter}
               loading={isFetching}
               rowSelection={rowSelection}
-              onRowSelectionChange={setRowSelection}
+              onRowSelectionChange={handleRowSelectionChange} // <-- Event Handler
               bulkActions={bulkActions}
               onRefresh={handleRefresh}
               columnPinning={{ left: ['tableSelection'], right: ['tableActions'] }}
@@ -360,14 +372,13 @@ export default function DatasetRss() {
           activeModal,
           closeModal,
           handleRefresh,
-          setRssList,
           deleteError,
-          isDeleting,
-          isCloning,
+          isDeleting: deleteMutation.isPending, // <-- Connected to mutation
+          isCloning: copyMutation.isPending, // <-- Connected to mutation
         }}
         selection={{
           selectedRss,
-          rssToDeleteId: itemsToDelete[0]?.id || null,
+          rssToDeleteId: itemsToDelete[0] ? itemsToDelete[0].id : null, // <-- Strict type guard
           itemsToDelete,
           existingNames,
         }}

--- a/frontend/src/pages/Library/Dataset/subPages/Rss/DatasetRss.tsx
+++ b/frontend/src/pages/Library/Dataset/subPages/Rss/DatasetRss.tsx
@@ -94,7 +94,6 @@ export default function DatasetRss() {
     queryClient.invalidateQueries({ queryKey: ['datasetRss', datasetId] });
   };
 
-  // --- Data Fetching ---
   const { data: dataset } = useQuery({
     queryKey: ['dataset', datasetId],
     queryFn: () => getDatasetById(datasetId!),
@@ -113,7 +112,6 @@ export default function DatasetRss() {
     enabled: isHydrated,
   });
 
-  // 1. Single Source of Truth
   const rssList = queryData?.rows ?? [];
   const pageCount = Math.ceil((queryData?.totalCount || 0) / pagination.pageSize);
   const error = isError && queryError instanceof Error ? queryError.message : '';
@@ -123,7 +121,6 @@ export default function DatasetRss() {
     return row.id.toString();
   };
 
-  // 2. Event-Driven Cache Handler
   const handleRowSelectionChange = (
     updaterOrValue: RowSelectionState | ((old: RowSelectionState) => RowSelectionState),
   ) => {
@@ -178,7 +175,6 @@ export default function DatasetRss() {
     },
   });
 
-  // --- Handlers ---
   const handleAdd = () => {
     setSelectedRss(null);
     setActiveModal('edit');
@@ -221,7 +217,7 @@ export default function DatasetRss() {
       filter: selectedRss.filter,
     };
 
-    copyMutation.mutate(copiedPayload); // No more 'as any' needed!
+    copyMutation.mutate(copiedPayload);
   };
 
   const confirmDelete = (items: DatasetRss[]) => {
@@ -353,7 +349,7 @@ export default function DatasetRss() {
               onGlobalFilterChange={setGlobalFilter}
               loading={isFetching}
               rowSelection={rowSelection}
-              onRowSelectionChange={handleRowSelectionChange} // <-- Event Handler
+              onRowSelectionChange={handleRowSelectionChange}
               bulkActions={bulkActions}
               onRefresh={handleRefresh}
               columnPinning={{ left: ['tableSelection'], right: ['tableActions'] }}
@@ -373,12 +369,12 @@ export default function DatasetRss() {
           closeModal,
           handleRefresh,
           deleteError,
-          isDeleting: deleteMutation.isPending, // <-- Connected to mutation
-          isCloning: copyMutation.isPending, // <-- Connected to mutation
+          isDeleting: deleteMutation.isPending,
+          isCloning: copyMutation.isPending,
         }}
         selection={{
           selectedRss,
-          rssToDeleteId: itemsToDelete[0] ? itemsToDelete[0].id : null, // <-- Strict type guard
+          rssToDeleteId: itemsToDelete[0] ? itemsToDelete[0].id : null,
           itemsToDelete,
           existingNames,
         }}

--- a/frontend/src/pages/Library/Dataset/subPages/Rss/components/DatasetRssModals.tsx
+++ b/frontend/src/pages/Library/Dataset/subPages/Rss/components/DatasetRssModals.tsx
@@ -31,7 +31,6 @@ interface DatasetRssModalsProps {
     activeModal: string | null;
     closeModal: () => void;
     handleRefresh: () => void;
-    setRssList: React.Dispatch<React.SetStateAction<DatasetRss[]>>;
     deleteError: string | null;
     isDeleting: boolean;
     isCloning?: boolean;

--- a/frontend/src/pages/Library/Media/Media.tsx
+++ b/frontend/src/pages/Library/Media/Media.tsx
@@ -109,6 +109,7 @@ export default function Media() {
     folderId: canViewFolders ? homeFolderId : null,
   });
 
+  // Keep this effect: it correctly syncs React Router state upon initial hydration
   useEffect(() => {
     if (!isHydrated) return;
 
@@ -142,7 +143,6 @@ export default function Media() {
   const closeModal = () => setActiveModal(null);
 
   const targetUploadFolderId = canViewFolders ? (selectedFolderId ?? homeFolderId) : homeFolderId;
-
   const canAddToFolder = targetUploadFolderId !== null;
 
   const handleRefresh = () => {
@@ -173,7 +173,7 @@ export default function Media() {
     isDragActive: isGlobalDragActive,
   } = dropzone;
 
-  // Data fetching
+  // --- Data Fetching ---
   const {
     data: queryData,
     isFetching,
@@ -188,18 +188,39 @@ export default function Media() {
     enabled: isHydrated,
   });
 
-  // Computed values
+  // --- Computed Values ---
   const data = queryData?.rows;
   const pageCount = Math.ceil((queryData?.totalCount || 0) / pagination.pageSize);
   const error = isError && queryError instanceof Error ? queryError.message : '';
+  const mediaList = data ?? [];
 
-  const [mediaList, setMediaList] = useState<Media[]>([]);
+  const getRowId = (row: Media) => row.mediaId.toString();
+
+  // --- Event-Driven Selection Handler ---
+  const handleRowSelectionChange = (
+    updaterOrValue: RowSelectionState | ((old: RowSelectionState) => RowSelectionState),
+  ) => {
+    const newSelection =
+      typeof updaterOrValue === 'function' ? updaterOrValue(rowSelection) : updaterOrValue;
+
+    setRowSelection(newSelection);
+
+    setSelectionCache((prev) => {
+      const next = { ...prev };
+      mediaList.forEach((item) => {
+        const id = getRowId(item);
+        if (newSelection[id]) {
+          next[id] = item;
+        }
+      });
+      return next;
+    });
+  };
 
   const folderActions = useFolderActions({
     onSuccess: (targetFolder) => {
       setFolderRefreshTrigger((prev) => prev + 1);
 
-      // Select home folder
       if (targetFolder?.id === -1) {
         targetFolder.id = homeFolderId;
       }
@@ -212,39 +233,12 @@ export default function Media() {
     },
   });
 
-  useEffect(() => {
-    setMediaList(data ?? []);
-  }, [data]);
-
-  // Update the selected cache when data loads or selection changes
-  useEffect(() => {
-    if (!mediaList || mediaList.length === 0) {
-      return;
-    }
-
-    setSelectionCache((prev) => {
-      const next = { ...prev };
-      let hasChanges = false;
-
-      mediaList.forEach((item) => {
-        const id = item.mediaId.toString();
-        if (rowSelection[id] && next[id] !== item) {
-          next[id] = item;
-          hasChanges = true;
-        }
-      });
-
-      return hasChanges ? next : prev;
-    });
-  }, [mediaList, rowSelection]);
-
   const selectedMedia = mediaList.find((m) => m.mediaId === selectedMediaId) ?? null;
   const existingNames = mediaList.map((m) => m.name);
   const ownerId = selectedMedia?.ownerId ? Number(selectedMedia.ownerId) : null;
   const { owner, loading } = useOwner({ ownerId });
 
-  const getRowId = (row: Media) => row.mediaId.toString();
-
+  // --- Handlers ---
   const handleFolderChange = (folder: { id: number | null; text: string | '' }) => {
     setSelectedFolderId(folder.id);
     setSelectedFolderName(folder.text);
@@ -413,15 +407,12 @@ export default function Media() {
 
       try {
         if (allItems.length === 1) {
-          // Normal single-file download
           const item = allItems[0];
-
           if (item) {
             await downloadMedia(item.mediaId, item.fileName);
             notify.success(t('Download started!'));
           }
         } else {
-          // Multiple items ZIP download
           notify.info(
             t('Zipping {{count}} files. You can continue using the app.', {
               count: allItems.length,
@@ -609,7 +600,7 @@ export default function Media() {
               onGlobalFilterChange={setGlobalFilter}
               loading={isFetching}
               rowSelection={rowSelection}
-              onRowSelectionChange={setRowSelection}
+              onRowSelectionChange={handleRowSelectionChange} // <-- Event Handler Applied to Table!
               onRefresh={handleRefresh}
               columnPinning={{ left: ['tableSelection'], right: ['tableActions'] }}
               columnVisibility={columnVisibility}
@@ -626,7 +617,7 @@ export default function Media() {
               pagination={pagination}
               onPaginationChange={setPagination}
               rowSelection={rowSelection}
-              onRowSelectionChange={setRowSelection}
+              onRowSelectionChange={handleRowSelectionChange} // <-- Event Handler Applied to Grid!
               loading={isFetching}
               onRefresh={handleRefresh}
               bulkActions={bulkActions}
@@ -685,7 +676,6 @@ export default function Media() {
           activeModal,
           closeModal,
           handleRefresh,
-          setMediaList,
           deleteError,
           isDeleting,
           isCloning,

--- a/frontend/src/pages/Library/Media/Media.tsx
+++ b/frontend/src/pages/Library/Media/Media.tsx
@@ -109,7 +109,6 @@ export default function Media() {
     folderId: canViewFolders ? homeFolderId : null,
   });
 
-  // Keep this effect: it correctly syncs React Router state upon initial hydration
   useEffect(() => {
     if (!isHydrated) return;
 
@@ -173,7 +172,6 @@ export default function Media() {
     isDragActive: isGlobalDragActive,
   } = dropzone;
 
-  // --- Data Fetching ---
   const {
     data: queryData,
     isFetching,
@@ -188,7 +186,6 @@ export default function Media() {
     enabled: isHydrated,
   });
 
-  // --- Computed Values ---
   const data = queryData?.rows;
   const pageCount = Math.ceil((queryData?.totalCount || 0) / pagination.pageSize);
   const error = isError && queryError instanceof Error ? queryError.message : '';
@@ -196,7 +193,6 @@ export default function Media() {
 
   const getRowId = (row: Media) => row.mediaId.toString();
 
-  // --- Event-Driven Selection Handler ---
   const handleRowSelectionChange = (
     updaterOrValue: RowSelectionState | ((old: RowSelectionState) => RowSelectionState),
   ) => {
@@ -238,7 +234,6 @@ export default function Media() {
   const ownerId = selectedMedia?.ownerId ? Number(selectedMedia.ownerId) : null;
   const { owner, loading } = useOwner({ ownerId });
 
-  // --- Handlers ---
   const handleFolderChange = (folder: { id: number | null; text: string | '' }) => {
     setSelectedFolderId(folder.id);
     setSelectedFolderName(folder.text);
@@ -600,7 +595,7 @@ export default function Media() {
               onGlobalFilterChange={setGlobalFilter}
               loading={isFetching}
               rowSelection={rowSelection}
-              onRowSelectionChange={handleRowSelectionChange} // <-- Event Handler Applied to Table!
+              onRowSelectionChange={handleRowSelectionChange}
               onRefresh={handleRefresh}
               columnPinning={{ left: ['tableSelection'], right: ['tableActions'] }}
               columnVisibility={columnVisibility}
@@ -617,7 +612,7 @@ export default function Media() {
               pagination={pagination}
               onPaginationChange={setPagination}
               rowSelection={rowSelection}
-              onRowSelectionChange={handleRowSelectionChange} // <-- Event Handler Applied to Grid!
+              onRowSelectionChange={handleRowSelectionChange}
               loading={isFetching}
               onRefresh={handleRefresh}
               bulkActions={bulkActions}

--- a/frontend/src/pages/Library/Media/components/MediaModals.tsx
+++ b/frontend/src/pages/Library/Media/components/MediaModals.tsx
@@ -47,7 +47,6 @@ interface MediaModalsProps {
     activeModal: string | null;
     closeModal: () => void;
     handleRefresh: () => void;
-    setMediaList: React.Dispatch<React.SetStateAction<Media[]>>;
     deleteError: string | null;
     isDeleting: boolean;
     isCloning: boolean;
@@ -172,10 +171,7 @@ export function MediaModals({
           {isModalOpen('edit') && (
             <EditMediaModal
               onClose={actions.closeModal}
-              onSave={(updatedMedia) => {
-                actions.setMediaList((prev) =>
-                  prev.map((m) => (m.mediaId === updatedMedia.mediaId ? updatedMedia : m)),
-                );
+              onSave={() => {
                 actions.handleRefresh();
               }}
               data={selection.selectedMedia}
@@ -186,10 +182,7 @@ export function MediaModals({
             <ReplaceFileModal
               onClose={actions.closeModal}
               data={selection.selectedMedia}
-              onSave={(updatedMedia) => {
-                actions.setMediaList((prev) =>
-                  prev.map((m) => (m.mediaId === updatedMedia.mediaId ? updatedMedia : m)),
-                );
+              onSave={() => {
                 actions.handleRefresh();
               }}
             />

--- a/frontend/src/pages/Library/Playlists/Playlists.tsx
+++ b/frontend/src/pages/Library/Playlists/Playlists.tsx
@@ -19,7 +19,7 @@
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { useQueryClient } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { RowSelectionState } from '@tanstack/react-table';
 import { Search, Filter, FilterX, Plus } from 'lucide-react';
 import { useEffect, useState } from 'react';
@@ -99,6 +99,7 @@ export default function Playlist() {
     folderId: canViewFolders ? homeFolderId : null,
   });
 
+  // Keep this effect for syncing React Router state
   useEffect(() => {
     if (!isHydrated) return;
 
@@ -117,8 +118,6 @@ export default function Playlist() {
   const [selectionCache, setSelectionCache] = useState<Record<string, Playlist>>({});
   const [openFilter, setOpenFilter] = useState(false);
 
-  const [canAddToFolder, setCanAddToFolder] = useState(false);
-
   const [showFolderSidebar, setShowFolderSidebar] = useState(false);
   const [activeModal, setActiveModal] = useState<ModalType | null>(null);
 
@@ -130,7 +129,7 @@ export default function Playlist() {
   const openModal = (name: ModalType) => setActiveModal(name);
   const closeModal = () => setActiveModal(null);
 
-  // Data fetching
+  // --- Data Fetching ---
   const {
     data: queryData,
     isFetching,
@@ -145,12 +144,20 @@ export default function Playlist() {
     enabled: isHydrated,
   });
 
-  // Computed values
+  // Replaced manual useEffect with useQuery for Folder Permissions
+  const { data: folderPerms } = useQuery({
+    queryKey: ['folderPermissions', selectedFolderId],
+    queryFn: () => fetchContextButtons(selectedFolderId as number),
+    enabled: selectedFolderId !== null, // Only run when we have a valid ID
+    staleTime: 1000 * 60 * 5, // Cache permissions for 5 minutes
+  });
+
+  // --- Computed Values ---
   const data = queryData?.rows;
   const pageCount = Math.ceil((queryData?.totalCount || 0) / pagination.pageSize);
   const error = isError && queryError instanceof Error ? queryError.message : '';
-
-  const [playlistList, setPlaylistList] = useState<Playlist[]>([]);
+  const playlistList = data ?? [];
+  const canAddToFolder = folderPerms?.create || false;
 
   const folderActions = useFolderActions({
     onSuccess: (targetFolder) => {
@@ -164,67 +171,35 @@ export default function Playlist() {
     },
   });
 
-  useEffect(() => {
-    setPlaylistList(data ?? []);
-  }, [data]);
-
-  // Check selected folder permission to add playlist
-  useEffect(() => {
-    if (selectedFolderId === null) {
-      setCanAddToFolder(false);
-      return;
-    }
-
-    let active = true;
-
-    fetchContextButtons(selectedFolderId)
-      .then((perms) => {
-        if (active) {
-          setCanAddToFolder(perms.create || false);
-        }
-      })
-      .catch((err) => {
-        console.error('Failed to fetch folder permissions', err);
-        if (active) {
-          setCanAddToFolder(false);
-        }
-      });
-
-    return () => {
-      active = false;
-    };
-  }, [selectedFolderId]);
-
-  // Update the selected cache when data loads or selection changes
-  useEffect(() => {
-    if (!playlistList || playlistList.length === 0) {
-      return;
-    }
-
-    setSelectionCache((prev) => {
-      const next = { ...prev };
-      let hasChanges = false;
-
-      playlistList.forEach((item) => {
-        const id = item.playlistId.toString();
-        if (rowSelection[id] && next[id] !== item) {
-          next[id] = item;
-          hasChanges = true;
-        }
-      });
-
-      return hasChanges ? next : prev;
-    });
-  }, [playlistList, rowSelection]);
-
-  const selectedPlaylist = playlistList.find((m) => m.playlistId === selectedPlaylistId) ?? null;
-  const existingNames = playlistList.map((m) => m.name);
-
   const getRowId = (row: Playlist) => {
     return row.playlistId.toString();
   };
 
-  // Event handlers
+  // --- Event-Driven Cache Handler ---
+  const handleRowSelectionChange = (
+    updaterOrValue: RowSelectionState | ((old: RowSelectionState) => RowSelectionState),
+  ) => {
+    const newSelection =
+      typeof updaterOrValue === 'function' ? updaterOrValue(rowSelection) : updaterOrValue;
+
+    setRowSelection(newSelection);
+
+    setSelectionCache((prev) => {
+      const next = { ...prev };
+      playlistList.forEach((item) => {
+        const id = getRowId(item); // Strictly use getRowId
+        if (newSelection[id]) {
+          next[id] = item;
+        }
+      });
+      return next;
+    });
+  };
+
+  const selectedPlaylist = playlistList.find((m) => m.playlistId === selectedPlaylistId) ?? null;
+  const existingNames = playlistList.map((m) => m.name);
+
+  // --- Handlers ---
   const handleRefresh = () => {
     queryClient.invalidateQueries({ queryKey: ['playlist'] });
   };
@@ -298,7 +273,7 @@ export default function Playlist() {
   const getAllSelectedItems = (): Playlist[] => {
     return Object.keys(rowSelection)
       .map((id) => selectionCache[id])
-      .filter((item): item is Playlist => !!item); // Filter out any missing data
+      .filter((item): item is Playlist => !!item);
   };
 
   const bulkActions = getBulkActions({
@@ -430,7 +405,7 @@ export default function Playlist() {
               onGlobalFilterChange={setGlobalFilter}
               loading={isFetching}
               rowSelection={rowSelection}
-              onRowSelectionChange={setRowSelection}
+              onRowSelectionChange={handleRowSelectionChange} // <-- Event Handler Applied!
               onRefresh={handleRefresh}
               columnPinning={{ left: ['tableSelection'], right: ['tableActions'] }}
               columnVisibility={columnVisibility}
@@ -448,7 +423,6 @@ export default function Playlist() {
           activeModal,
           closeModal,
           handleRefresh,
-          setPlaylistList,
           deleteError,
           isDeleting,
           isCloning,

--- a/frontend/src/pages/Library/Playlists/Playlists.tsx
+++ b/frontend/src/pages/Library/Playlists/Playlists.tsx
@@ -99,7 +99,6 @@ export default function Playlist() {
     folderId: canViewFolders ? homeFolderId : null,
   });
 
-  // Keep this effect for syncing React Router state
   useEffect(() => {
     if (!isHydrated) return;
 
@@ -129,7 +128,6 @@ export default function Playlist() {
   const openModal = (name: ModalType) => setActiveModal(name);
   const closeModal = () => setActiveModal(null);
 
-  // --- Data Fetching ---
   const {
     data: queryData,
     isFetching,
@@ -144,15 +142,13 @@ export default function Playlist() {
     enabled: isHydrated,
   });
 
-  // Replaced manual useEffect with useQuery for Folder Permissions
   const { data: folderPerms } = useQuery({
     queryKey: ['folderPermissions', selectedFolderId],
     queryFn: () => fetchContextButtons(selectedFolderId as number),
-    enabled: selectedFolderId !== null, // Only run when we have a valid ID
-    staleTime: 1000 * 60 * 5, // Cache permissions for 5 minutes
+    enabled: selectedFolderId !== null,
+    staleTime: 1000 * 60 * 5,
   });
 
-  // --- Computed Values ---
   const data = queryData?.rows;
   const pageCount = Math.ceil((queryData?.totalCount || 0) / pagination.pageSize);
   const error = isError && queryError instanceof Error ? queryError.message : '';
@@ -175,7 +171,6 @@ export default function Playlist() {
     return row.playlistId.toString();
   };
 
-  // --- Event-Driven Cache Handler ---
   const handleRowSelectionChange = (
     updaterOrValue: RowSelectionState | ((old: RowSelectionState) => RowSelectionState),
   ) => {
@@ -187,7 +182,7 @@ export default function Playlist() {
     setSelectionCache((prev) => {
       const next = { ...prev };
       playlistList.forEach((item) => {
-        const id = getRowId(item); // Strictly use getRowId
+        const id = getRowId(item);
         if (newSelection[id]) {
           next[id] = item;
         }
@@ -199,7 +194,6 @@ export default function Playlist() {
   const selectedPlaylist = playlistList.find((m) => m.playlistId === selectedPlaylistId) ?? null;
   const existingNames = playlistList.map((m) => m.name);
 
-  // --- Handlers ---
   const handleRefresh = () => {
     queryClient.invalidateQueries({ queryKey: ['playlist'] });
   };
@@ -405,7 +399,7 @@ export default function Playlist() {
               onGlobalFilterChange={setGlobalFilter}
               loading={isFetching}
               rowSelection={rowSelection}
-              onRowSelectionChange={handleRowSelectionChange} // <-- Event Handler Applied!
+              onRowSelectionChange={handleRowSelectionChange}
               onRefresh={handleRefresh}
               columnPinning={{ left: ['tableSelection'], right: ['tableActions'] }}
               columnVisibility={columnVisibility}

--- a/frontend/src/pages/Library/Playlists/components/PlaylistModals.tsx
+++ b/frontend/src/pages/Library/Playlists/components/PlaylistModals.tsx
@@ -36,7 +36,6 @@ interface PlaylistModalsProps {
     activeModal: string | null;
     closeModal: () => void;
     handleRefresh: () => void;
-    setPlaylistList: React.Dispatch<React.SetStateAction<Playlist[]>>;
     deleteError: string | null;
     isDeleting: boolean;
     isCloning: boolean;
@@ -76,14 +75,7 @@ export function PlaylistModals({
             actions.closeModal();
           }}
           data={selection.selectedPlaylist}
-          onSave={(savedPlaylist) => {
-            if (selection.selectedPlaylistId) {
-              actions.setPlaylistList((prev) =>
-                prev.map((m) => (m.playlistId === savedPlaylist.playlistId ? savedPlaylist : m)),
-              );
-            } else {
-              actions.setPlaylistList((prev) => [savedPlaylist, ...prev]);
-            }
+          onSave={() => {
             actions.handleRefresh();
           }}
         />

--- a/frontend/src/pages/Schedule/Daypart/Daypart.tsx
+++ b/frontend/src/pages/Schedule/Daypart/Daypart.tsx
@@ -22,7 +22,7 @@
 import { useQueryClient } from '@tanstack/react-query';
 import type { RowSelectionState } from '@tanstack/react-table';
 import { Search, Filter, FilterX, Plus } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import type { ModalType } from './DaypartConfig';
@@ -90,7 +90,7 @@ export default function Daypart() {
   const openModal = (name: ModalType) => setActiveModal(name);
   const closeModal = () => setActiveModal(null);
 
-  // Data fetching
+  // --- Data Fetching ---
   const {
     data: queryData,
     isFetching,
@@ -104,47 +104,41 @@ export default function Daypart() {
     enabled: isHydrated,
   });
 
-  // Computed values
+  // --- Computed Values ---
   const data = queryData?.rows;
   const pageCount = Math.ceil((queryData?.totalCount || 0) / pagination.pageSize);
   const error = isError && queryError instanceof Error ? queryError.message : '';
-
-  const [daypartList, setDaypartList] = useState<Daypart[]>([]);
-
-  useEffect(() => {
-    setDaypartList(data ?? []);
-  }, [data]);
-
-  // Update the selected cache when data loads or selection changes
-  useEffect(() => {
-    if (!daypartList || daypartList.length === 0) {
-      return;
-    }
-
-    setSelectionCache((prev) => {
-      const next = { ...prev };
-      let hasChanges = false;
-
-      daypartList.forEach((item) => {
-        const id = item.dayPartId.toString();
-        if (rowSelection[id] && next[id] !== item) {
-          next[id] = item;
-          hasChanges = true;
-        }
-      });
-
-      return hasChanges ? next : prev;
-    });
-  }, [daypartList, rowSelection]);
-
-  const selectedDaypart = daypartList.find((m) => m.dayPartId === selectedDaypartId) ?? null;
-  const existingNames = daypartList.map((m) => m.name);
+  const daypartList = data ?? [];
 
   const getRowId = (row: Daypart) => {
     return row.dayPartId.toString();
   };
 
-  // Event handlers
+  // --- Event-Driven Cache Handler ---
+  const handleRowSelectionChange = (
+    updaterOrValue: RowSelectionState | ((old: RowSelectionState) => RowSelectionState),
+  ) => {
+    const newSelection =
+      typeof updaterOrValue === 'function' ? updaterOrValue(rowSelection) : updaterOrValue;
+
+    setRowSelection(newSelection);
+
+    setSelectionCache((prev) => {
+      const next = { ...prev };
+      daypartList.forEach((item) => {
+        const id = getRowId(item); // Strictly use getRowId
+        if (newSelection[id]) {
+          next[id] = item;
+        }
+      });
+      return next;
+    });
+  };
+
+  const selectedDaypart = daypartList.find((m) => m.dayPartId === selectedDaypartId) ?? null;
+  const existingNames = daypartList.map((m) => m.name);
+
+  // --- Handlers ---
   const handleRefresh = () => {
     queryClient.invalidateQueries({ queryKey: ['daypart'] });
   };
@@ -195,7 +189,7 @@ export default function Daypart() {
   const getAllSelectedItems = (): Daypart[] => {
     return Object.keys(rowSelection)
       .map((id) => selectionCache[id])
-      .filter((item): item is Daypart => !!item); // Filter out any missing data
+      .filter((item): item is Daypart => !!item);
   };
 
   const bulkActions = getBulkActions({
@@ -309,7 +303,7 @@ export default function Daypart() {
               onGlobalFilterChange={setGlobalFilter}
               loading={isFetching}
               rowSelection={rowSelection}
-              onRowSelectionChange={setRowSelection}
+              onRowSelectionChange={handleRowSelectionChange} // <-- Event Handler Applied!
               onRefresh={handleRefresh}
               columnPinning={{ left: ['tableSelection'], right: ['tableActions'] }}
               columnVisibility={columnVisibility}
@@ -327,7 +321,6 @@ export default function Daypart() {
           activeModal,
           closeModal,
           handleRefresh,
-          setDaypartList,
           deleteError,
           isDeleting,
         }}

--- a/frontend/src/pages/Schedule/Daypart/Daypart.tsx
+++ b/frontend/src/pages/Schedule/Daypart/Daypart.tsx
@@ -90,7 +90,6 @@ export default function Daypart() {
   const openModal = (name: ModalType) => setActiveModal(name);
   const closeModal = () => setActiveModal(null);
 
-  // --- Data Fetching ---
   const {
     data: queryData,
     isFetching,
@@ -104,7 +103,6 @@ export default function Daypart() {
     enabled: isHydrated,
   });
 
-  // --- Computed Values ---
   const data = queryData?.rows;
   const pageCount = Math.ceil((queryData?.totalCount || 0) / pagination.pageSize);
   const error = isError && queryError instanceof Error ? queryError.message : '';
@@ -114,7 +112,6 @@ export default function Daypart() {
     return row.dayPartId.toString();
   };
 
-  // --- Event-Driven Cache Handler ---
   const handleRowSelectionChange = (
     updaterOrValue: RowSelectionState | ((old: RowSelectionState) => RowSelectionState),
   ) => {
@@ -126,7 +123,7 @@ export default function Daypart() {
     setSelectionCache((prev) => {
       const next = { ...prev };
       daypartList.forEach((item) => {
-        const id = getRowId(item); // Strictly use getRowId
+        const id = getRowId(item);
         if (newSelection[id]) {
           next[id] = item;
         }
@@ -138,7 +135,6 @@ export default function Daypart() {
   const selectedDaypart = daypartList.find((m) => m.dayPartId === selectedDaypartId) ?? null;
   const existingNames = daypartList.map((m) => m.name);
 
-  // --- Handlers ---
   const handleRefresh = () => {
     queryClient.invalidateQueries({ queryKey: ['daypart'] });
   };
@@ -303,7 +299,7 @@ export default function Daypart() {
               onGlobalFilterChange={setGlobalFilter}
               loading={isFetching}
               rowSelection={rowSelection}
-              onRowSelectionChange={handleRowSelectionChange} // <-- Event Handler Applied!
+              onRowSelectionChange={handleRowSelectionChange}
               onRefresh={handleRefresh}
               columnPinning={{ left: ['tableSelection'], right: ['tableActions'] }}
               columnVisibility={columnVisibility}

--- a/frontend/src/pages/Schedule/Daypart/components/DaypartModals.tsx
+++ b/frontend/src/pages/Schedule/Daypart/components/DaypartModals.tsx
@@ -32,7 +32,6 @@ interface DaypartModalsProps {
     activeModal: string | null;
     closeModal: () => void;
     handleRefresh: () => void;
-    setDaypartList: React.Dispatch<React.SetStateAction<Daypart[]>>;
     deleteError: string | null;
     isDeleting: boolean;
   };
@@ -60,14 +59,7 @@ export function DaypartModals({ actions, selection, handlers }: DaypartModalsPro
           type={selection.selectedDaypartId ? 'edit' : 'add'}
           onClose={actions.closeModal}
           data={selection.selectedDaypart}
-          onSave={(savedDaypart) => {
-            if (selection.selectedDaypartId) {
-              actions.setDaypartList((prev) =>
-                prev.map((m) => (m.dayPartId === savedDaypart.dayPartId ? savedDaypart : m)),
-              );
-            } else {
-              actions.setDaypartList((prev) => [savedDaypart, ...prev]);
-            }
+          onSave={() => {
             actions.handleRefresh();
           }}
         />


### PR DESCRIPTION
- Remove redundant local copies of server data and replace chains ofsync watchers with direct data use and single event handlers

- Remove useMemo usage