### PR TITLE
Preview: fix usage reports on Library/Playlist

### DIFF
--- a/lib/Controller/Library.php
+++ b/lib/Controller/Library.php
@@ -55,8 +55,10 @@ use Xibo\Factory\WidgetFactory;
 use Xibo\Helper\ByteFormatter;
 use Xibo\Helper\DateFormatHelper;
 use Xibo\Helper\Environment;
+use Xibo\Helper\HttpsDetect;
 use Xibo\Helper\XiboUploadHandler;
 use Xibo\Middleware\TokenAuthMiddleware;
+use Xibo\Service\JwtServiceInterface;
 use Xibo\Service\MediaService;
 use Xibo\Service\MediaServiceInterface;
 use Xibo\Support\Exception\AccessDeniedException;
@@ -161,7 +163,8 @@ class Library extends Base
         $userGroupFactory,
         $displayFactory,
         $scheduleFactory,
-        $folderFactory
+        $folderFactory,
+        private readonly JwtServiceInterface $jwtService,
     ) {
         $this->moduleFactory = $moduleFactory;
         $this->mediaFactory = $mediaFactory;
@@ -2163,6 +2166,9 @@ class Library extends Base
         );
 
         if (!$this->isApi($request)) {
+            // We need to generate preview URLs, base URL doesn't chagen between layouts
+            $baseUrl = (new HttpsDetect())->getBaseUrl($request);
+
             foreach ($layouts as $layout) {
                 $layout->includeProperty('buttons');
 
@@ -2172,20 +2178,30 @@ class Library extends Base
                     $layout->buttons[] = array(
                         'id' => 'layout_button_design',
                         'linkType' => '_self', 'external' => true,
-                        'url' => $this->urlFor($request,'layout.designer', ['id' => $layout->layoutId]),
+                        'url' => $this->urlFor($request, 'layout.designer', ['id' => $layout->layoutId]),
                         'text' => __('Design')
                     );
                 }
 
                 // Preview
-                $layout->buttons[] = array(
+                // generate a JWT
+                $jwt = $this->jwtService->generateJwt(
+                    'Preview',
+                    'layout',
+                    $layout->layoutId,
+                    '/preview/layout/preview/' . $layout->layoutId,
+                    3600,
+                )->toString();
+
+                // Add it as a button
+                $layout->buttons[] = [
                     'id' => 'layout_button_preview',
                     'external' => true,
                     'url' => '#',
                     'onclick' => 'createMiniLayoutPreview',
-                    'onclickParam' => $this->urlFor($request, 'layout.preview', ['id' => $layout->layoutId]),
-                    'text' => __('Preview Layout')
-                );
+                    'onclickParam' => $baseUrl . '/preview/layout/preview/' . $layout->layoutId . '?jwt=' . $jwt,
+                    'text' => __('Preview Layout'),
+                ];
             }
         }
 

--- a/lib/Controller/Playlist.php
+++ b/lib/Controller/Playlist.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2024 Xibo Signage Ltd
+ * Copyright (C) 2026 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -38,6 +38,8 @@ use Xibo\Factory\UserFactory;
 use Xibo\Factory\UserGroupFactory;
 use Xibo\Factory\WidgetFactory;
 use Xibo\Helper\DateFormatHelper;
+use Xibo\Helper\HttpsDetect;
+use Xibo\Service\JwtServiceInterface;
 use Xibo\Support\Exception\AccessDeniedException;
 use Xibo\Support\Exception\GeneralException;
 use Xibo\Support\Exception\InvalidArgumentException;
@@ -113,7 +115,8 @@ class Playlist extends Base
         $displayFactory,
         $scheduleFactory,
         $folderFactory,
-        $regionFactory
+        $regionFactory,
+        private readonly JwtServiceInterface $jwtService,
     ) {
         $this->playlistFactory = $playlistFactory;
         $this->mediaFactory = $mediaFactory;
@@ -1716,6 +1719,9 @@ class Playlist extends Base
         $layouts = $this->layoutFactory->query(null, ['playlistId' => $id]);
 
         if (!$this->isApi($request)) {
+            // We need to generate preview URLs, base URL doesn't chagen between layouts
+            $baseUrl = (new HttpsDetect())->getBaseUrl($request);
+
             foreach ($layouts as $layout) {
                 $layout->includeProperty('buttons');
 
@@ -1725,19 +1731,28 @@ class Playlist extends Base
                     $layout->buttons[] = array(
                         'id' => 'layout_button_design',
                         'linkType' => '_self', 'external' => true,
-                        'url' => $this->urlFor($request,'layout.designer', array('id' => $layout->layoutId)),
+                        'url' => $this->urlFor($request, 'layout.designer', array('id' => $layout->layoutId)),
                         'text' => __('Design')
                     );
                 }
 
                 // Preview
+                // generate a JWT
+                $jwt = $this->jwtService->generateJwt(
+                    'Preview',
+                    'layout',
+                    $layout->layoutId,
+                    '/preview/layout/preview/' . $layout->layoutId,
+                    3600,
+                )->toString();
+
                 $layout->buttons[] = array(
                     'id' => 'layout_button_preview',
                     'external' => true,
                     'url' => '#',
                     'onclick' => 'createMiniLayoutPreview',
-                    'onclickParam' => $this->urlFor($request, 'layout.preview', ['id' => $layout->layoutId]),
-                    'text' => __('Preview Layout')
+                    'onclickParam' => $baseUrl . '/preview/layout/preview/' . $layout->layoutId . '?jwt=' . $jwt,
+                    'text' => __('Preview Layout'),
                 );
             }
         }

--- a/lib/Controller/Preview.php
+++ b/lib/Controller/Preview.php
@@ -102,6 +102,7 @@ class Preview extends Base
                     $this->getConfig()->getApiKeyDetails()['encryptionKey'],
                 ),
                 'loaderUrl' => $this->getConfig()->uri('img/loader.gif'),
+                // We can use layout.preview here because this route is inside the Preview end point
                 'layoutPreviewUrl' => $this->urlFor($request, 'layout.preview', ['id' => '[layoutCode]']),
             ],
             'previewJwt' => $this->jwtService->generateJwt(

--- a/lib/Dependencies/Controllers.php
+++ b/lib/Dependencies/Controllers.php
@@ -272,7 +272,8 @@ class Controllers
                     $c->get('userGroupFactory'),
                     $c->get('displayFactory'),
                     $c->get('scheduleFactory'),
-                    $c->get('folderFactory')
+                    $c->get('folderFactory'),
+                    $c->get('jwtService'),
                 );
                 $controller->useMediaService($c->get('mediaService'));
                 $controller->useBaseDependenciesService($c->get('ControllerBaseDependenciesService'));
@@ -405,7 +406,8 @@ class Controllers
                     $c->get('displayFactory'),
                     $c->get('scheduleFactory'),
                     $c->get('folderFactory'),
-                    $c->get('regionFactory')
+                    $c->get('regionFactory'),
+                    $c->get('jwtService'),
                 );
                 $controller->useBaseDependenciesService($c->get('ControllerBaseDependenciesService'));
                 return $controller;


### PR DESCRIPTION
fixes xibosignage/xibo#3842

Adds the JWT and URL routing needed for loading layout previews in 4.1

---
Security Review

No findings above confidence threshold                                                                                                                                                                                                                                                                           
                  
No vulnerabilities exceeded the required confidence threshold of 8/10. The JWT implementation is correctly scoped: tokens are bound to specific layout IDs via the identifiedBy claim, validated in Preview.php at both the show() and getXlf() endpoints, and can only be generated by authenticated users who  already hold permissions on the layout. The preview-sharing model is intentional and consistent with standard CMS functionality.
