### PR TITLE
Refactor layout handling and add layout and template actions

### DIFF
--- a/frontend/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/frontend/src/components/layout/__tests__/Sidebar.test.tsx
@@ -132,96 +132,42 @@ describe('Sidebar Menu (The Navigation Bar)', () => {
       </UserProvider>,
     );
 
-    const menuStructure = [
-      {
-        main: 'Schedule',
-        subs: [
-          { name: 'Event', href: '/schedule/view' },
-          { name: 'Dayparting', href: '/dayparting/view' },
-        ],
-      },
-      {
-        main: 'Design',
-        subs: [
-          { name: 'Campaign', href: '/campaign/view' },
-          { name: 'Layouts', href: '/design/layout' },
-          { name: 'Templates', href: '/template/view' },
-          { name: 'Resolutions', href: '/design/resolutions' },
-        ],
-      },
-      {
-        main: 'Library',
-        subs: [
-          { name: 'Playlists', href: '/library/playlists' },
-          { name: 'Media', href: '/library/media' },
-          { name: 'Datasets', href: '/dataset/view' },
-        ],
-      },
-      {
-        main: 'Displays',
-        subs: [
-          { name: 'Add Displays', href: '/display/view' },
-          { name: 'Display Groups', href: '/displaygroup/view' },
-          { name: 'Sync Groups', href: '/syncgroup/view' },
-          { name: 'Commands', href: '/command/view' },
-        ],
-      },
-      {
-        main: 'Administration',
-        subs: [
-          { name: 'Users', href: '/user/view' },
-          { name: 'User Groups', href: '/group/view' },
-          { name: 'Applications', href: '/application/view' },
-          { name: 'Modules', href: '/module/view' },
-          { name: 'Transitions', href: '/transition/view' },
-          { name: 'Tasks', href: '/task/view' },
-          { name: 'Tags', href: '/tag/view' },
-          { name: 'Folders', href: '/folders/view' },
-          { name: 'Fonts', href: '/fonts/view' },
-        ],
-      },
-      {
-        main: 'Reporting',
-        subs: [
-          { name: 'All Reports', href: '/report/view' },
-          { name: 'Report Schedules', href: '/report/reportschedule/view' },
-          { name: 'Saved Reports', href: '/report/savedreport/view' },
-        ],
-      },
-      {
-        main: 'Advanced',
-        subs: [
-          // Note: "Log" usually points to savedreport based on your earlier HTML dump
-          { name: 'Log', href: '/log/view' },
-          { name: 'Sessions', href: '/advanced/sessions' },
-          { name: 'Audit Trail', href: '/audit/view' },
-          { name: 'Report Fault', href: '/fault/view' },
-        ],
-      },
-      {
-        main: 'Developer',
-        subs: [{ name: 'Developer', href: '/developer/template/view' }],
-      },
+    // Representative sample — one link per group, mixing React Router and external URL types.
+    // This proves the sidebar reads appRoutes config and builds correct hrefs for both kinds,
+    // without exhaustively re-testing every route (that would just duplicate appRoutes.ts).
+    // When a route moves between types (external ↔ React Router) update the href here.
+    const sampleLinks = [
+      { group: 'Schedule', name: 'Dayparting', href: '/schedule/dayparting' }, // React Router
+      { group: 'Design', name: 'Layouts', href: '/design/layout' }, // React Router
+      { group: 'Library', name: 'Media', href: '/library/media' }, // React Router
+      { group: 'Displays', name: 'Commands', href: '/command/view' }, // external
+      { group: 'Administration', name: 'Tags', href: '/tag/view' }, // external
+      { group: 'Reporting', name: 'All Reports', href: '/report/view' }, // external
+      { group: 'Advanced', name: 'Sessions', href: '/advanced/sessions' }, // React Router
     ];
 
-    menuStructure.forEach((group) => {
-      const mainLabels = screen.getAllByText(group.main);
-      fireEvent.click(mainLabels[0]!);
+    sampleLinks.forEach(({ group, name, href }) => {
+      const groupLabels = screen.getAllByText(group);
+      fireEvent.click(groupLabels[0]!);
 
-      group.subs.forEach((subItem) => {
-        const link = screen.getByRole('link', { name: new RegExp(subItem.name, 'i') });
+      // getAllByRole handles the rare case where a label appears in multiple groups.
+      const links = screen.getAllByRole('link', { name: new RegExp(name, 'i') });
+      const link = links.find((l) => l.getAttribute('href') === href);
 
-        expect(link).toHaveAttribute('href', subItem.href);
-        expect(link).toBeVisible();
-      });
+      expect(link).toBeVisible();
     });
 
-    const settingsLinks = screen.getAllByRole('link', { name: 'Settings' });
+    // Developer is a top-level external link (no subLinks) — always visible, not expandable.
+    expect(screen.getByRole('link', { name: /developer/i })).toHaveAttribute(
+      'href',
+      '/developer/template/view',
+    );
 
+    // Both Displays > Settings and Administration > Settings must be reachable.
+    const settingsLinks = screen.getAllByRole('link', { name: 'Settings' });
     expect(
       settingsLinks.find((l) => l.getAttribute('href') === '/displayprofile/view'),
     ).toBeVisible();
-
     expect(settingsLinks.find((l) => l.getAttribute('href') === '/admin/view')).toBeVisible();
   });
 

--- a/frontend/src/components/ui/forms/Checkbox.tsx
+++ b/frontend/src/components/ui/forms/Checkbox.tsx
@@ -61,6 +61,7 @@ export default function Checkbox({
         id={id}
         checked={checked ?? false}
         onChange={onChange}
+        aria-label={title}
         className={twMerge(
           'shrink-0 mt-0.5 border-gray-200 rounded-sm cursor-pointer text-blue-600 focus:ring-blue-500 checked:border-blue-500 disabled:opacity-50 disabled:pointer-events-none dark:bg-neutral-800 dark:border-neutral-700 dark:checked:bg-blue-500 dark:checked:border-blue-500 dark:focus:ring-offset-gray-800',
           classNameInput,

--- a/frontend/src/pages/Advanced/Sessions/__tests__/Sessions.logout.test.tsx
+++ b/frontend/src/pages/Advanced/Sessions/__tests__/Sessions.logout.test.tsx
@@ -3,63 +3,34 @@ import type { TFunction } from 'i18next';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
 import { useSessionActions } from '../hooks/useSessionActions';
-import * as useSessionDataHook from '../hooks/useSessionData';
 
-import { mockSessionsList } from './Setup';
-
-import { useTableState } from '@/hooks/useTableState';
 import * as sessionApi from '@/services/sessionApi';
 
-// --- STANDARD MOCKS ---
-vi.mock('@/hooks/useFilteredTabs', () => ({
-  useFilteredTabs: vi.fn(() => [{ name: 'Sessions', path: '/advanced/sessions' }]),
+// Single hoisted mock — no other file re-declares this, so the hook and this
+// test share the same vi.fn() references throughout.
+vi.mock('@/services/sessionApi', () => ({
+  fetchSession: vi.fn(),
+  logoutSession: vi.fn(),
 }));
 
-vi.mock('@/hooks/useTableState', () => ({
-  useTableState: vi.fn(),
-}));
-
-const defaultTableState = {
-  pagination: { pageIndex: 0, pageSize: 10 },
-  setPagination: vi.fn(),
-  sorting: [],
-  setSorting: vi.fn(),
-  columnVisibility: {},
-  setColumnVisibility: vi.fn(),
-  globalFilter: '',
-  setGlobalFilter: vi.fn(),
-  filterInputs: { type: '', lastModified: '' },
-  setFilterInputs: vi.fn(),
-  isHydrated: true,
+const validSession = {
+  userId: 1,
+  userName: 'alice_admin',
+  remoteAddress: '192.168.1.1',
+  userAgent: 'Chrome 120',
+  isExpired: 0,
+  lastAccessed: '2024-01-01T10:00:00Z',
+  expiresAt: '2024-01-02T10:00:01Z',
 };
 
 describe('Sessions Page - Logout Action', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(useTableState).mockReturnValue(defaultTableState as never);
-
-    // Spy on the data hook directly
-    vi.spyOn(useSessionDataHook, 'useSessionData').mockReturnValue({
-      data: { rows: mockSessionsList, totalCount: 3 },
-      isFetching: false,
-      isError: false,
-      error: null,
-    } as never);
   });
 
   describe('useSessionActions Logic', () => {
-    // Guarantee the hook cannot filter this out due to a missing ID property!
-    const validSession = {
-      ...mockSessionsList[0],
-      id: 1,
-      sessionId: 1,
-      session_id: 1,
-      userId: 1,
-    };
-
     it('successfully calls the logout API and clears selection', async () => {
-      // Adding spy
-      vi.spyOn(sessionApi, 'logoutSession').mockResolvedValue(undefined);
+      vi.mocked(sessionApi.logoutSession).mockResolvedValue(undefined);
 
       const handleRefresh = vi.fn();
       const closeModal = vi.fn();
@@ -67,37 +38,26 @@ describe('Sessions Page - Logout Action', () => {
       const t = vi.fn((key) => key) as unknown as TFunction;
 
       const { result } = renderHook(() =>
-        useSessionActions({
-          t,
-          handleRefresh,
-          closeModal,
-          setRowSelection,
-        }),
+        useSessionActions({ t, handleRefresh, closeModal, setRowSelection }),
       );
 
       await act(async () => {
         await result.current.confirmLogout([validSession as never]);
       });
 
-      // Verify the spy was successfully hit!
-      expect(sessionApi.logoutSession).toHaveBeenCalled();
+      expect(sessionApi.logoutSession).toHaveBeenCalledWith(validSession.userId);
       expect(setRowSelection).toHaveBeenCalledWith({});
       expect(handleRefresh).toHaveBeenCalled();
       expect(closeModal).toHaveBeenCalled();
     });
 
     it('handles API failures and sets the logoutError state', async () => {
-      // Craft a fake Axios error that bypasses strict prototype checks
       const fakeError = {
-        name: 'Error',
-        message: 'Invalid session token.',
         isAxiosError: true,
         response: { data: { message: 'Invalid session token.' } },
       };
-      fakeError.isAxiosError = true;
-      fakeError.response = { data: { message: 'Invalid session token.' } };
 
-      vi.spyOn(sessionApi, 'logoutSession').mockRejectedValue(fakeError);
+      vi.mocked(sessionApi.logoutSession).mockRejectedValue(fakeError);
 
       const handleRefresh = vi.fn();
       const closeModal = vi.fn();
@@ -105,19 +65,13 @@ describe('Sessions Page - Logout Action', () => {
       const t = vi.fn((key) => key) as unknown as TFunction;
 
       const { result } = renderHook(() =>
-        useSessionActions({
-          t,
-          handleRefresh,
-          closeModal,
-          setRowSelection,
-        }),
+        useSessionActions({ t, handleRefresh, closeModal, setRowSelection }),
       );
 
       await act(async () => {
         await result.current.confirmLogout([validSession as never]);
       });
 
-      // The early exit is bypassed, the API throws, and the error is extracted!
       expect(result.current.logoutError).toBe('Invalid session token.');
       expect(closeModal).not.toHaveBeenCalled();
     });

--- a/frontend/src/pages/Design/Layouts/__tests__/Layouts.actions.test.tsx
+++ b/frontend/src/pages/Design/Layouts/__tests__/Layouts.actions.test.tsx
@@ -1,0 +1,563 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { screen, fireEvent, waitFor, within } from '@testing-library/react';
+import type React from 'react';
+import { vi, beforeEach, describe, test, expect } from 'vitest';
+
+import { useLayoutActions } from '../hooks/useLayoutActions';
+
+import {
+  SINGLE_DRAFT_LAYOUT,
+  SINGLE_LAYOUT,
+  defaultLayoutActions,
+  mockDraftLayout,
+  mockFetchLayouts,
+  mockLayout,
+  renderLayoutsPage,
+} from './layoutTestUtils';
+
+import { saveLayoutAsTemplate, updateLayout } from '@/services/layoutsApi';
+import { testQueryClient } from '@/setupTests';
+
+// =============================================================================
+// Module mocks
+// =============================================================================
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { changeLanguage: vi.fn() } }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock('@/services/folderApi');
+vi.mock('@/services/layoutsApi');
+vi.mock('@/services/userApi', () => ({
+  fetchUserPreference: vi.fn().mockResolvedValue(null),
+  saveUserPreference: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../hooks/useLayoutActions', () => ({ useLayoutActions: vi.fn() }));
+vi.mock('../hooks/useLayoutFilterOptions', () => ({
+  useLayoutFilterOptions: vi.fn(() => ({ filterOptions: [], isLoading: false })),
+}));
+vi.mock('@/hooks/useOwner', () => ({
+  useOwner: vi.fn().mockReturnValue({ owner: null, loading: false }),
+}));
+
+vi.mock('@/components/ui/FolderActionModals', () => ({ default: () => null }));
+vi.mock('@/components/ui/forms/SelectFolder', () => ({ default: () => null }));
+vi.mock('@/components/ui/forms/TagInput', () => ({ default: () => null }));
+vi.mock('@/components/ui/modals/Modal');
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+// Opens the "More actions" dropdown on the first row and clicks the named action.
+// rowText defaults to the Published mockLayout — pass mockDraftLayout.layout for Draft tests.
+const openDropdownAction = async (label: string, rowText = mockLayout.layout) => {
+  await screen.findByText(rowText);
+  fireEvent.click(screen.getByRole('button', { name: 'More actions' }));
+  fireEvent.click(await screen.findByRole('button', { name: label }));
+};
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('Layouts page - row actions', () => {
+  beforeEach(() => {
+    testQueryClient.clear();
+    vi.clearAllMocks();
+    vi.mocked(useLayoutActions).mockReturnValue(defaultLayoutActions());
+    mockFetchLayouts(SINGLE_LAYOUT);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Copy (Make a Copy)
+  // Available for all layouts. CopyLayoutModal does client-side validation and
+  // passes (name, description, copyMediaFiles) to handleConfirmClone.
+  // ---------------------------------------------------------------------------
+  describe('Copy (Make a Copy)', () => {
+    // Name field is auto-filled with an incremented version of the layout name.
+    test('modal opens with name field pre-filled from the layout name', async () => {
+      renderLayoutsPage();
+      await openDropdownAction('Make a Copy');
+
+      const dialog = await screen.findByRole('dialog', { name: 'Copy Layout' });
+      // incrementName('My Layout') → 'My Layout (1)'
+      expect(within(dialog).getByLabelText('New name')).toHaveValue('My Layout (1)');
+    });
+
+    // Empty name must be rejected before calling the action handler.
+    test('empty name shows "Name is required" and does not call handleConfirmClone', async () => {
+      const handleConfirmClone = vi.fn();
+      vi.mocked(useLayoutActions).mockReturnValue(defaultLayoutActions({ handleConfirmClone }));
+
+      renderLayoutsPage();
+      await openDropdownAction('Make a Copy');
+
+      const dialog = await screen.findByRole('dialog', { name: 'Copy Layout' });
+      fireEvent.change(within(dialog).getByLabelText('New name'), { target: { value: '' } });
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }));
+
+      expect(await screen.findByText('Name is required')).toBeInTheDocument();
+      expect(handleConfirmClone).not.toHaveBeenCalled();
+    });
+
+    // The name 'My Layout' already exists in the table (the one rendered row).
+    test('duplicate name shows validation error and does not call handleConfirmClone', async () => {
+      const handleConfirmClone = vi.fn();
+      vi.mocked(useLayoutActions).mockReturnValue(defaultLayoutActions({ handleConfirmClone }));
+
+      renderLayoutsPage();
+      await openDropdownAction('Make a Copy');
+
+      const dialog = await screen.findByRole('dialog', { name: 'Copy Layout' });
+      fireEvent.change(within(dialog).getByLabelText('New name'), {
+        target: { value: 'My Layout' },
+      });
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }));
+
+      expect(await screen.findByText('A layout with this name already exists')).toBeInTheDocument();
+      expect(handleConfirmClone).not.toHaveBeenCalled();
+    });
+
+    // Happy path: valid unique name calls handleConfirmClone with correct args.
+    test('Save calls handleConfirmClone with name, empty description, copyMediaFiles=false', async () => {
+      const handleConfirmClone = vi.fn();
+      vi.mocked(useLayoutActions).mockReturnValue(defaultLayoutActions({ handleConfirmClone }));
+
+      renderLayoutsPage();
+      await openDropdownAction('Make a Copy');
+
+      const dialog = await screen.findByRole('dialog', { name: 'Copy Layout' });
+      fireEvent.change(within(dialog).getByLabelText('New name'), {
+        target: { value: 'My Layout Copy' },
+      });
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }));
+
+      // Layouts.tsx wraps handleConfirmClone as: (name, desc, copy) => handleConfirmClone(selectedLayout, name, desc, copy)
+      expect(handleConfirmClone).toHaveBeenCalledWith(mockLayout, 'My Layout Copy', '', false);
+    });
+
+    // Ticking "Make new copies of all media?" flips copyMediaFiles to true.
+    test('ticking the media copies checkbox passes copyMediaFiles=true', async () => {
+      const handleConfirmClone = vi.fn();
+      vi.mocked(useLayoutActions).mockReturnValue(defaultLayoutActions({ handleConfirmClone }));
+
+      renderLayoutsPage();
+      await openDropdownAction('Make a Copy');
+
+      const dialog = await screen.findByRole('dialog', { name: 'Copy Layout' });
+      fireEvent.change(within(dialog).getByLabelText('New name'), {
+        target: { value: 'My Layout Copy' },
+      });
+      fireEvent.click(
+        within(dialog).getByRole('checkbox', { name: 'Make new copies of all media?' }),
+      );
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }));
+
+      expect(handleConfirmClone).toHaveBeenCalledWith(mockLayout, 'My Layout Copy', '', true);
+    });
+
+    // Cancelling must close the modal without calling the action handler.
+    test('Cancel closes the modal', async () => {
+      renderLayoutsPage();
+      await openDropdownAction('Make a Copy');
+
+      const dialog = await screen.findByRole('dialog', { name: 'Copy Layout' });
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+
+      await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Publish
+  // Only available when publishedStatus !== 'Published' (i.e. Draft layouts).
+  // The modal defaults to "Publish Now" so no interaction with PublishDateSelect needed.
+  // PublishModal does NOT pass a title to Modal, so the dialog has no aria-label.
+  // ---------------------------------------------------------------------------
+  describe('Publish', () => {
+    beforeEach(() => {
+      mockFetchLayouts(SINGLE_DRAFT_LAYOUT);
+    });
+
+    // Publish must be absent for already-published layouts.
+    test('Publish action is absent for Published layouts', async () => {
+      mockFetchLayouts(SINGLE_LAYOUT);
+      renderLayoutsPage();
+      await screen.findByText(mockLayout.layout);
+      fireEvent.click(screen.getByRole('button', { name: 'More actions' }));
+      // Wait for the dropdown to open by asserting a known always-present action.
+      await screen.findByRole('button', { name: 'Export' });
+      expect(screen.queryByRole('button', { name: 'Publish' })).not.toBeInTheDocument();
+    });
+
+    // Clicking Publish with the default "Publish Now" calls confirmPublish correctly.
+    test('Publish calls confirmPublish with layoutId and { type: "now" }', async () => {
+      const confirmPublish = vi.fn();
+      vi.mocked(useLayoutActions).mockReturnValue(defaultLayoutActions({ confirmPublish }));
+
+      renderLayoutsPage();
+      await openDropdownAction('Publish', mockDraftLayout.layout);
+
+      const dialog = await screen.findByRole('dialog');
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Publish' }));
+
+      expect(confirmPublish).toHaveBeenCalledWith(mockDraftLayout.layoutId, { type: 'now' });
+    });
+
+    // Cancelling must close the modal.
+    test('Cancel closes the modal', async () => {
+      renderLayoutsPage();
+      await openDropdownAction('Publish', mockDraftLayout.layout);
+
+      const dialog = await screen.findByRole('dialog');
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+
+      await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Discard
+  // Only available when publishedStatus !== 'Published' (i.e. Draft layouts).
+  // DiscardLayoutModal does NOT pass a title to Modal, so the dialog has no aria-label.
+  // ---------------------------------------------------------------------------
+  describe('Discard', () => {
+    beforeEach(() => {
+      mockFetchLayouts(SINGLE_DRAFT_LAYOUT);
+    });
+
+    // Discard must be absent for already-published layouts.
+    test('Discard action is absent for Published layouts', async () => {
+      mockFetchLayouts(SINGLE_LAYOUT);
+      renderLayoutsPage();
+      await screen.findByText(mockLayout.layout);
+      fireEvent.click(screen.getByRole('button', { name: 'More actions' }));
+      await screen.findByRole('button', { name: 'Export' });
+      expect(screen.queryByRole('button', { name: 'Discard' })).not.toBeInTheDocument();
+    });
+
+    // Modal shows the layout name so the user knows what they are discarding.
+    test('modal opens showing the draft layout name', async () => {
+      renderLayoutsPage();
+      await openDropdownAction('Discard', mockDraftLayout.layout);
+
+      const dialog = await screen.findByRole('dialog');
+      expect(within(dialog).getByText(mockDraftLayout.layout)).toBeInTheDocument();
+    });
+
+    // Clicking Discard calls handleConfirmDiscard with the layout's id.
+    test('Discard calls handleConfirmDiscard with the layoutId', async () => {
+      const handleConfirmDiscard = vi.fn();
+      vi.mocked(useLayoutActions).mockReturnValue(defaultLayoutActions({ handleConfirmDiscard }));
+
+      renderLayoutsPage();
+      await openDropdownAction('Discard', mockDraftLayout.layout);
+
+      const dialog = await screen.findByRole('dialog');
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Discard' }));
+
+      expect(handleConfirmDiscard).toHaveBeenCalledWith(mockDraftLayout.layoutId);
+    });
+
+    // Cancelling must close the modal.
+    test('Cancel closes the modal', async () => {
+      renderLayoutsPage();
+      await openDropdownAction('Discard', mockDraftLayout.layout);
+
+      const dialog = await screen.findByRole('dialog');
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+
+      await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Export
+  // Available for all layouts. No modal title, so the dialog has no aria-label.
+  // Download logic lives in useLayoutActions (mocked), no window stubbing needed.
+  // ---------------------------------------------------------------------------
+  describe('Export', () => {
+    // Filename field is pre-filled as "export_<layoutName>".
+    test('modal opens with filename pre-filled as "export_My Layout"', async () => {
+      renderLayoutsPage();
+      await openDropdownAction('Export');
+
+      const dialog = await screen.findByRole('dialog');
+      expect(within(dialog).getByDisplayValue(`export_${mockLayout.layout}`)).toBeInTheDocument();
+    });
+
+    // Export button calls handleExportLayout with the current filename and default options.
+    test('Export calls handleExportLayout with filename and default options', async () => {
+      const handleExportLayout = vi.fn();
+      vi.mocked(useLayoutActions).mockReturnValue(defaultLayoutActions({ handleExportLayout }));
+
+      renderLayoutsPage();
+      await openDropdownAction('Export');
+
+      const dialog = await screen.findByRole('dialog');
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Export' }));
+
+      expect(handleExportLayout).toHaveBeenCalledWith(mockLayout.layoutId, {
+        includeData: false,
+        includeFallback: false,
+        fileName: `export_${mockLayout.layout}`,
+      });
+    });
+
+    // The two checkboxes are independent — each only sets its own value.
+    // Ticking "Datasets Data" passes includeData: true.
+    test('ticking Datasets Data passes includeData=true', async () => {
+      const handleExportLayout = vi.fn();
+      vi.mocked(useLayoutActions).mockReturnValue(defaultLayoutActions({ handleExportLayout }));
+
+      renderLayoutsPage();
+      await openDropdownAction('Export');
+
+      const dialog = await screen.findByRole('dialog');
+      fireEvent.click(within(dialog).getByRole('checkbox', { name: 'Datasets Data' }));
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Export' }));
+
+      expect(handleExportLayout).toHaveBeenCalledWith(mockLayout.layoutId, {
+        includeData: true,
+        includeFallback: false,
+        fileName: `export_${mockLayout.layout}`,
+      });
+    });
+
+    // Ticking "Widget Fallback Data" passes includeFallback: true.
+    test('ticking Widget Fallback Data passes includeFallback=true', async () => {
+      const handleExportLayout = vi.fn();
+      vi.mocked(useLayoutActions).mockReturnValue(defaultLayoutActions({ handleExportLayout }));
+
+      renderLayoutsPage();
+      await openDropdownAction('Export');
+
+      const dialog = await screen.findByRole('dialog');
+      fireEvent.click(within(dialog).getByRole('checkbox', { name: 'Widget Fallback Data' }));
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Export' }));
+
+      expect(handleExportLayout).toHaveBeenCalledWith(mockLayout.layoutId, {
+        includeData: false,
+        includeFallback: true,
+        fileName: `export_${mockLayout.layout}`,
+      });
+    });
+
+    // Ticking both checkboxes passes includeData: true and includeFallback: true.
+    test('ticking both checkboxes passes includeData=true and includeFallback=true', async () => {
+      const handleExportLayout = vi.fn();
+      vi.mocked(useLayoutActions).mockReturnValue(defaultLayoutActions({ handleExportLayout }));
+
+      renderLayoutsPage();
+      await openDropdownAction('Export');
+
+      const dialog = await screen.findByRole('dialog');
+      fireEvent.click(within(dialog).getByRole('checkbox', { name: 'Datasets Data' }));
+      fireEvent.click(within(dialog).getByRole('checkbox', { name: 'Widget Fallback Data' }));
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Export' }));
+
+      expect(handleExportLayout).toHaveBeenCalledWith(mockLayout.layoutId, {
+        includeData: true,
+        includeFallback: true,
+        fileName: `export_${mockLayout.layout}`,
+      });
+    });
+
+    // Cancelling must close the modal.
+    test('Cancel closes the modal', async () => {
+      renderLayoutsPage();
+      await openDropdownAction('Export');
+
+      const dialog = await screen.findByRole('dialog');
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+
+      await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Save as Template, Published layouts only.
+  // ---------------------------------------------------------------------------
+  describe('Save as Template', () => {
+    // Name field is pre-filled as "<layout.layout> Template".
+    test('modal opens with name pre-filled as "My Layout Template"', async () => {
+      renderLayoutsPage();
+      await openDropdownAction('Save as Template');
+
+      const dialog = await screen.findByRole('dialog', { name: 'Save as Template' });
+      expect(within(dialog).getByLabelText('Template Name')).toHaveValue(
+        `${mockLayout.layout} Template`,
+      );
+    });
+
+    // Save is disabled when name is empty — the button greys out instead of showing an error.
+    test('Save button is disabled when name is empty', async () => {
+      renderLayoutsPage();
+      await openDropdownAction('Save as Template');
+
+      const dialog = await screen.findByRole('dialog', { name: 'Save as Template' });
+      fireEvent.change(within(dialog).getByLabelText('Template Name'), {
+        target: { value: '' },
+      });
+
+      expect(within(dialog).getByRole('button', { name: 'Save' })).toBeDisabled();
+      expect(saveLayoutAsTemplate).not.toHaveBeenCalled();
+    });
+
+    // Happy path: valid name calls saveLayoutAsTemplate and closes the modal.
+    test('Save calls saveLayoutAsTemplate with correct payload and closes modal', async () => {
+      vi.mocked(saveLayoutAsTemplate).mockResolvedValueOnce(undefined as never);
+
+      renderLayoutsPage();
+      await openDropdownAction('Save as Template');
+
+      await screen.findByRole('dialog', { name: 'Save as Template' });
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+      await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+      expect(saveLayoutAsTemplate).toHaveBeenCalledWith(
+        mockLayout.layoutId,
+        expect.objectContaining({
+          name: `${mockLayout.layout} Template`,
+          includeWidgets: false,
+          folderId: mockLayout.folderId,
+        }),
+      );
+    });
+
+    // Cancelling must close the modal.
+    test('Cancel closes the modal', async () => {
+      renderLayoutsPage();
+      await openDropdownAction('Save as Template');
+
+      const dialog = await screen.findByRole('dialog', { name: 'Save as Template' });
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+
+      await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Retire
+  // Available for all layouts. The Retire button is gated behind a checkbox so
+  // the user must explicitly confirm before the API call is made.
+  // RetireLayoutModal calls updateLayout directly (not via useLayoutActions).
+  // ---------------------------------------------------------------------------
+  describe('Retire', () => {
+    // Modal has a proper title that can be used to scope assertions.
+    test('modal opens titled "Retire Layout"', async () => {
+      renderLayoutsPage();
+      await openDropdownAction('Retire');
+
+      expect(await screen.findByRole('dialog', { name: 'Retire Layout' })).toBeInTheDocument();
+    });
+
+    // The Retire button is disabled until the user ticks the confirmation checkbox.
+    test('Retire button is disabled until the checkbox is checked', async () => {
+      renderLayoutsPage();
+      await openDropdownAction('Retire');
+
+      const dialog = await screen.findByRole('dialog', { name: 'Retire Layout' });
+      const retireBtn = within(dialog).getByRole('button', { name: 'Retire' });
+
+      expect(retireBtn).toBeDisabled();
+
+      fireEvent.click(within(dialog).getByRole('checkbox', { name: 'Retire Layout' }));
+      expect(retireBtn).toBeEnabled();
+    });
+
+    // After confirming, updateLayout is called with the retired flag and the modal closes.
+    test('confirming calls updateLayout with { retired: 1 } and closes modal', async () => {
+      vi.mocked(updateLayout).mockResolvedValueOnce(mockLayout);
+
+      renderLayoutsPage();
+      await openDropdownAction('Retire');
+
+      const dialog = await screen.findByRole('dialog', { name: 'Retire Layout' });
+      fireEvent.click(within(dialog).getByRole('checkbox', { name: 'Retire Layout' }));
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Retire' }));
+
+      await waitFor(() =>
+        expect(updateLayout).toHaveBeenCalledWith(mockLayout.layoutId, { retired: 1 }),
+      );
+      await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    });
+
+    // Cancelling must close the modal without calling updateLayout.
+    test('Cancel closes the modal', async () => {
+      renderLayoutsPage();
+      await openDropdownAction('Retire');
+
+      const dialog = await screen.findByRole('dialog', { name: 'Retire Layout' });
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+
+      await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Enable Stats Collection
+  // Available for all layouts. EnableStatsLayoutModal calls updateLayout directly.
+  // ---------------------------------------------------------------------------
+  describe('Enable Stats Collection', () => {
+    // Checkbox initialises from layout.enableStat — mockLayout has enableStat: true.
+    test('checkbox initialises as checked when layout.enableStat is true', async () => {
+      renderLayoutsPage();
+      await openDropdownAction('Enable Stats Collection');
+
+      const dialog = await screen.findByRole('dialog', { name: 'Enable Stats Collection' });
+      expect(
+        within(dialog).getByRole('checkbox', { name: 'Enable Stats Collections' }),
+      ).toBeChecked();
+    });
+
+    // Save calls updateLayout with enableStat: 1 (checkbox was already checked).
+    test('Save calls updateLayout with { enableStat: 1 }', async () => {
+      vi.mocked(updateLayout).mockResolvedValueOnce(mockLayout);
+
+      renderLayoutsPage();
+      await openDropdownAction('Enable Stats Collection');
+
+      const dialog = await screen.findByRole('dialog', { name: 'Enable Stats Collection' });
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }));
+
+      await waitFor(() =>
+        expect(updateLayout).toHaveBeenCalledWith(mockLayout.layoutId, { enableStat: 1 }),
+      );
+    });
+
+    // Cancelling must close the modal.
+    test('Cancel closes the modal', async () => {
+      renderLayoutsPage();
+      await openDropdownAction('Enable Stats Collection');
+
+      const dialog = await screen.findByRole('dialog', { name: 'Enable Stats Collection' });
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+
+      await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    });
+  });
+});

--- a/frontend/src/pages/Design/Layouts/__tests__/layoutTestUtils.tsx
+++ b/frontend/src/pages/Design/Layouts/__tests__/layoutTestUtils.tsx
@@ -45,7 +45,6 @@ import type { User } from '@/types/user';
 export const mockLayout: Layout = {
   layoutId: 861001,
   campaignId: 10,
-  name: 'My Layout',
   layout: 'My Layout',
   publishedStatusId: 1,
   publishedStatus: 'Published',

--- a/frontend/src/pages/Design/Layouts/components/CopyLayoutModal.tsx
+++ b/frontend/src/pages/Design/Layouts/components/CopyLayoutModal.tsx
@@ -53,7 +53,7 @@ export default function CopyLayoutModal({
 
   useEffect(() => {
     if (layout && isOpen) {
-      setNewName(incrementName(layout.name || layout.layout));
+      setNewName(incrementName(layout.layout));
       setDescription(layout.description ?? '');
       setCopyMediaFiles(false);
     }

--- a/frontend/src/pages/Design/Layouts/components/EnableStatsLayoutModal.tsx
+++ b/frontend/src/pages/Design/Layouts/components/EnableStatsLayoutModal.tsx
@@ -75,7 +75,7 @@ export function EnableStatsLayoutModal({
 
   return (
     <Modal
-      title={t('Retire Layout')}
+      title={t('Enable Stats Collection')}
       isOpen={isOpen}
       onClose={onClose}
       isPending={isLoading}
@@ -87,7 +87,7 @@ export function EnableStatsLayoutModal({
           variant: 'secondary',
         },
         {
-          label: t('Retire'),
+          label: t('Save'),
           onClick: handleConfirm,
           disabled: isLoading,
         },

--- a/frontend/src/pages/Design/Layouts/components/LayoutsModal.tsx
+++ b/frontend/src/pages/Design/Layouts/components/LayoutsModal.tsx
@@ -121,7 +121,7 @@ export function LayoutModals({
           itemCount={selection.itemsToDelete.length}
           layoutName={
             selection.itemsToDelete.length === 1
-              ? selection.itemsToDelete[0]?.name || selection.itemsToDelete[0]?.layout
+              ? selection.itemsToDelete[0]?.layout
               : undefined
           }
           error={actions.deleteError}
@@ -178,7 +178,7 @@ export function LayoutModals({
           onConfirm={() =>
             selection.selectedLayout && handlers.confirmDiscard(selection.selectedLayout.layoutId)
           }
-          layoutName={selection.selectedLayout?.name || selection.selectedLayout?.layout}
+          layoutName={selection.selectedLayout?.layout}
           isLoading={actions.isDiscarding}
         />
       )}
@@ -199,7 +199,7 @@ export function LayoutModals({
             selection.selectedLayout &&
             handlers.handleExportLayout(selection.selectedLayout.layoutId, options)
           }
-          layoutName={selection.selectedLayout?.name || selection.selectedLayout?.layout}
+          layoutName={selection.selectedLayout?.layout}
           isLoading={actions.isExporting}
         />
       )}

--- a/frontend/src/pages/Design/Layouts/components/SaveAsTemplateModal.tsx
+++ b/frontend/src/pages/Design/Layouts/components/SaveAsTemplateModal.tsx
@@ -56,7 +56,7 @@ export default function SaveAsTemplateModal({
 
   useEffect(() => {
     if (layout) {
-      const baseName = layout.name || layout.layout;
+      const baseName = layout.layout;
 
       setName((prev) => {
         if (prev && prev !== '') return prev;

--- a/frontend/src/pages/Design/Templates/__tests__/Templates.actions.test.tsx
+++ b/frontend/src/pages/Design/Templates/__tests__/Templates.actions.test.tsx
@@ -1,0 +1,398 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { screen, fireEvent, waitFor, within } from '@testing-library/react';
+import type React from 'react';
+import { vi, beforeEach, describe, test, expect } from 'vitest';
+
+import { useTemplateActions } from '../hooks/useTemplateActions';
+
+import {
+  SINGLE_DRAFT_TEMPLATE_ROWS,
+  SINGLE_TEMPLATE_ROWS,
+  defaultTemplateActions,
+  mockDraftTemplate,
+  mockFetchTemplates,
+  mockTemplate,
+  renderTemplatesPage,
+} from './templateTestUtils';
+import type { UseTemplateActionsReturn } from './templateTestUtils';
+
+import { testQueryClient } from '@/setupTests';
+
+// =============================================================================
+// Module mocks
+// =============================================================================
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { changeLanguage: vi.fn() } }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock('@/services/folderApi');
+vi.mock('@/services/templatesApi');
+vi.mock('@/services/userApi', () => ({
+  fetchUserPreference: vi.fn().mockResolvedValue(null),
+  saveUserPreference: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../hooks/useTemplateActions', () => ({ useTemplateActions: vi.fn() }));
+vi.mock('../hooks/useTemplateFilterOptions', () => ({
+  useTemplateFilterOptions: vi.fn(() => ({ filterOptions: [], isLoading: false })),
+}));
+
+vi.mock('@/components/ui/FolderActionModals', () => ({ default: () => null }));
+vi.mock('@/components/ui/modals/Modal');
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+// Opens the "More actions" dropdown on the first row and clicks the named action.
+// rowText defaults to the Published mockTemplate — pass mockDraftTemplate.layout for Draft tests.
+const openDropdownAction = async (label: string, rowText = mockTemplate.layout) => {
+  await screen.findByText(rowText);
+  fireEvent.click(screen.getByRole('button', { name: 'More actions' }));
+  fireEvent.click(await screen.findByRole('button', { name: label }));
+};
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('Templates page - row actions', () => {
+  beforeEach(() => {
+    testQueryClient.clear();
+    vi.clearAllMocks();
+    vi.mocked(useTemplateActions).mockReturnValue(defaultTemplateActions());
+    mockFetchTemplates(SINGLE_TEMPLATE_ROWS);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Alter Template
+  // Opens the template designer in a new tab. Fully implemented via
+  // handleAlterTemplate in useTemplateActions.
+  // ---------------------------------------------------------------------------
+  describe('Alter Template', () => {
+    test('clicking Alter Template calls handleAlterTemplate with the layoutId', async () => {
+      const handleAlterTemplate = vi.fn();
+      vi.mocked(useTemplateActions).mockReturnValue(
+        defaultTemplateActions({ handleAlterTemplate }),
+      );
+
+      renderTemplatesPage();
+      await openDropdownAction('Alter Template');
+
+      expect(handleAlterTemplate).toHaveBeenCalledWith(mockTemplate.layoutId);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Copy (Make a Copy)
+  // Available for all templates (Draft and Published).
+  // The modal validates the form and calls handleConfirmClone.
+  // ---------------------------------------------------------------------------
+  describe('Copy (Make a Copy)', () => {
+    // Name field is auto-filled with an incremented version of the template name.
+    test('modal opens with name field pre-filled from the template name', async () => {
+      renderTemplatesPage();
+      await openDropdownAction('Make a Copy');
+
+      const dialog = await screen.findByRole('dialog', { name: 'Copy Template' });
+      // incrementName('Splash Screen Template') → 'Splash Screen Template (1)'
+      expect(within(dialog).getByLabelText('New name')).toHaveValue('Splash Screen Template (1)');
+    });
+
+    // Empty name must be rejected before calling the action handler.
+    test('empty name shows "Name is required" and does not call handleConfirmClone', async () => {
+      const handleConfirmClone = vi.fn();
+      vi.mocked(useTemplateActions).mockReturnValue(defaultTemplateActions({ handleConfirmClone }));
+
+      renderTemplatesPage();
+      await openDropdownAction('Make a Copy');
+
+      const dialog = await screen.findByRole('dialog', { name: 'Copy Template' });
+      fireEvent.change(within(dialog).getByLabelText('New name'), { target: { value: '' } });
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }));
+
+      expect(await screen.findByText('Name is required')).toBeInTheDocument();
+      expect(handleConfirmClone).not.toHaveBeenCalled();
+    });
+
+    // The name 'Splash Screen Template' already exists in the table.
+    test('duplicate name shows "A template with this name already exists"', async () => {
+      const handleConfirmClone = vi.fn();
+      vi.mocked(useTemplateActions).mockReturnValue(defaultTemplateActions({ handleConfirmClone }));
+
+      renderTemplatesPage();
+      await openDropdownAction('Make a Copy');
+
+      const dialog = await screen.findByRole('dialog', { name: 'Copy Template' });
+      fireEvent.change(within(dialog).getByLabelText('New name'), {
+        target: { value: mockTemplate.layout },
+      });
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }));
+
+      expect(
+        await screen.findByText('A template with this name already exists'),
+      ).toBeInTheDocument();
+      expect(handleConfirmClone).not.toHaveBeenCalled();
+    });
+
+    // Happy path: valid unique name calls handleConfirmClone with correct args.
+    test('Save calls handleConfirmClone with selectedTemplate, name, empty description, and copyMediaFiles=false', async () => {
+      const handleConfirmClone = vi.fn();
+      vi.mocked(useTemplateActions).mockReturnValue(defaultTemplateActions({ handleConfirmClone }));
+
+      renderTemplatesPage();
+      await openDropdownAction('Make a Copy');
+
+      const dialog = await screen.findByRole('dialog', { name: 'Copy Template' });
+      fireEvent.change(within(dialog).getByLabelText('New name'), {
+        target: { value: 'Splash Screen Template Copy' },
+      });
+      fireEvent.change(within(dialog).getByLabelText('Description'), { target: { value: '' } });
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }));
+
+      expect(handleConfirmClone).toHaveBeenCalledWith(
+        mockTemplate,
+        'Splash Screen Template Copy',
+        '',
+        false,
+      );
+    });
+
+    // Ticking "Make new copies of all media?" flips copyMediaFiles to true.
+    test('ticking the media copies checkbox passes copyMediaFiles=true', async () => {
+      const handleConfirmClone = vi.fn();
+      vi.mocked(useTemplateActions).mockReturnValue(defaultTemplateActions({ handleConfirmClone }));
+
+      renderTemplatesPage();
+      await openDropdownAction('Make a Copy');
+
+      const dialog = await screen.findByRole('dialog', { name: 'Copy Template' });
+      fireEvent.change(within(dialog).getByLabelText('New name'), {
+        target: { value: 'Splash Screen Template Copy' },
+      });
+      fireEvent.change(within(dialog).getByLabelText('Description'), { target: { value: '' } });
+      fireEvent.click(
+        within(dialog).getByRole('checkbox', { name: 'Make new copies of all media?' }),
+      );
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Save' }));
+
+      expect(handleConfirmClone).toHaveBeenCalledWith(
+        mockTemplate,
+        'Splash Screen Template Copy',
+        '',
+        true,
+      );
+    });
+
+    // Cancelling must close the modal without calling the action handler.
+    test('Cancel closes the modal', async () => {
+      renderTemplatesPage();
+      await openDropdownAction('Make a Copy');
+
+      const dialog = await screen.findByRole('dialog', { name: 'Copy Template' });
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+
+      await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Publish
+  // TDD: Publish should appear only for Draft templates and open a confirmation
+  // dialog that calls confirmPublish on the hook.
+  //
+  // All tests use test.fails to document the unimplemented contract.
+  // ---------------------------------------------------------------------------
+  describe('Publish', () => {
+    beforeEach(() => {
+      mockFetchTemplates(SINGLE_DRAFT_TEMPLATE_ROWS);
+    });
+
+    // When implemented: Publish must be absent for already-published templates.
+    test.fails('Publish action is absent for Published templates', async () => {
+      mockFetchTemplates(SINGLE_TEMPLATE_ROWS);
+      renderTemplatesPage();
+      await screen.findByText(mockTemplate.layout);
+      fireEvent.click(screen.getByRole('button', { name: 'More actions' }));
+      // Wait for a known always-present action to confirm the dropdown is open.
+      await screen.findByRole('button', { name: 'Make a Copy' });
+      expect(screen.queryByRole('button', { name: 'Publish' })).not.toBeInTheDocument();
+    });
+
+    // When implemented: clicking Publish on a Draft template should open a dialog.
+    test.fails('Publish modal opens for a Draft template', async () => {
+      renderTemplatesPage();
+      await openDropdownAction('Publish', mockDraftTemplate.layout);
+
+      expect(await screen.findByRole('dialog')).toBeInTheDocument();
+    });
+
+    // When implemented: confirming should call confirmPublish with the layoutId and publish options.
+    test.fails('Publish calls confirmPublish with layoutId and { type: "now" }', async () => {
+      const confirmPublish = vi.fn();
+      vi.mocked(useTemplateActions).mockReturnValue({
+        ...defaultTemplateActions(),
+        confirmPublish,
+      } as unknown as UseTemplateActionsReturn);
+
+      renderTemplatesPage();
+      await openDropdownAction('Publish', mockDraftTemplate.layout);
+
+      const dialog = await screen.findByRole('dialog');
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Publish' }));
+
+      expect(confirmPublish).toHaveBeenCalledWith(mockDraftTemplate.layoutId, { type: 'now' });
+    });
+
+    // When implemented: Cancel must close the dialog without publishing.
+    test.fails('Cancel closes the Publish modal', async () => {
+      renderTemplatesPage();
+      await openDropdownAction('Publish', mockDraftTemplate.layout);
+
+      const dialog = await screen.findByRole('dialog');
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+
+      await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Discard
+  // TDD: Discard should appear only for Draft templates and open a confirmation
+  // dialog that calls handleConfirmDiscard on the hook.
+  //
+  // All tests use test.fails to document the unimplemented contract.
+  // ---------------------------------------------------------------------------
+  describe('Discard', () => {
+    beforeEach(() => {
+      mockFetchTemplates(SINGLE_DRAFT_TEMPLATE_ROWS);
+    });
+
+    // When implemented: Discard must be absent for already-published templates.
+    test.fails('Discard action is absent for Published templates', async () => {
+      mockFetchTemplates(SINGLE_TEMPLATE_ROWS);
+      renderTemplatesPage();
+      await screen.findByText(mockTemplate.layout);
+      fireEvent.click(screen.getByRole('button', { name: 'More actions' }));
+      // Wait for a known always-present action to confirm the dropdown is open.
+      await screen.findByRole('button', { name: 'Make a Copy' });
+      expect(screen.queryByRole('button', { name: 'Discard' })).not.toBeInTheDocument();
+    });
+
+    // When implemented: the dialog should show the draft template name so the
+    // user knows what they are about to discard.
+    test.fails('Discard modal shows the draft template name', async () => {
+      renderTemplatesPage();
+      await openDropdownAction('Discard', mockDraftTemplate.layout);
+
+      const dialog = await screen.findByRole('dialog');
+      expect(within(dialog).getByText(mockDraftTemplate.layout)).toBeInTheDocument();
+    });
+
+    // When implemented: confirming should call handleConfirmDiscard with the layoutId.
+    test.fails('Discard calls handleConfirmDiscard with the layoutId', async () => {
+      const handleConfirmDiscard = vi.fn();
+      vi.mocked(useTemplateActions).mockReturnValue({
+        ...defaultTemplateActions(),
+        handleConfirmDiscard,
+      } as unknown as UseTemplateActionsReturn);
+
+      renderTemplatesPage();
+      await openDropdownAction('Discard', mockDraftTemplate.layout);
+
+      const dialog = await screen.findByRole('dialog');
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Discard' }));
+
+      expect(handleConfirmDiscard).toHaveBeenCalledWith(mockDraftTemplate.layoutId);
+    });
+
+    // When implemented: Cancel must close the dialog without discarding.
+    test.fails('Cancel closes the Discard modal', async () => {
+      renderTemplatesPage();
+      await openDropdownAction('Discard', mockDraftTemplate.layout);
+
+      const dialog = await screen.findByRole('dialog');
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+
+      await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Checkout
+  // TDD: Checkout should appear for Published templates only, allowing the user
+  // to check out a published template for editing (creating a Draft).
+  // ---------------------------------------------------------------------------
+  describe('Checkout', () => {
+    // Checkout should only appear for Published templates.
+    test('Checkout action is absent for Draft templates', async () => {
+      mockFetchTemplates(SINGLE_DRAFT_TEMPLATE_ROWS);
+      renderTemplatesPage();
+      await screen.findByText(mockDraftTemplate.layout);
+      fireEvent.click(screen.getByRole('button', { name: 'More actions' }));
+      // Wait for a known always-present action to confirm the dropdown is open.
+      await screen.findByRole('button', { name: 'Make a Copy' });
+      expect(screen.queryByRole('button', { name: 'Checkout' })).not.toBeInTheDocument();
+    });
+
+    // Checkout must appear in the dropdown for Published templates.
+    test.fails('Checkout action appears for Published templates', async () => {
+      renderTemplatesPage();
+      await screen.findByText(mockTemplate.layout);
+      fireEvent.click(screen.getByRole('button', { name: 'More actions' }));
+
+      expect(await screen.findByRole('button', { name: 'Checkout' })).toBeInTheDocument();
+    });
+
+    // When implemented: clicking Checkout should call handleCheckoutTemplate with the layoutId.
+    test.fails('Checkout calls handleCheckoutTemplate with the layoutId', async () => {
+      const handleCheckoutTemplate = vi.fn();
+      vi.mocked(useTemplateActions).mockReturnValue({
+        ...defaultTemplateActions(),
+        handleCheckoutTemplate,
+      } as unknown as UseTemplateActionsReturn);
+
+      renderTemplatesPage();
+      await openDropdownAction('Checkout');
+
+      expect(handleCheckoutTemplate).toHaveBeenCalledWith(mockTemplate.layoutId);
+    });
+
+    // When implemented: Cancel must close the Checkout dialog.
+    test.fails('Cancel closes the Checkout modal', async () => {
+      renderTemplatesPage();
+      await openDropdownAction('Checkout');
+
+      const dialog = await screen.findByRole('dialog');
+      fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+
+      await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    });
+  });
+
+  // Export tests will be added when the Template export modal is implemented.
+  // The backend uses the same endpoint as Layout export (POST /layout/export/{id}).
+  // Use Layouts.actions.test.tsx Export tests as the reference for what to cover.
+});

--- a/frontend/src/pages/Design/Templates/__tests__/Templates.edit.form.test.tsx
+++ b/frontend/src/pages/Design/Templates/__tests__/Templates.edit.form.test.tsx
@@ -143,29 +143,30 @@ describe('Templates page - edit form fields', () => {
     expect(retireCheckbox).not.toBeChecked();
   });
 
-  test.fails(
-    'Successful save calls updateTemplate with correct payload and closes the modal',
-    async () => {
-      vi.mocked(updateTemplate).mockResolvedValueOnce(mockTemplate);
+  // ---------------------------------------------------------------------------
+  // When the user saves changes, the app should save the right data
+  // and close the popup.
+  // ---------------------------------------------------------------------------
+  test('Successful save calls updateTemplate with correct payload and closes the modal', async () => {
+    vi.mocked(updateTemplate).mockResolvedValueOnce(mockTemplate);
 
-      renderTemplatesPage();
-      await openEditModal();
+    renderTemplatesPage();
+    await openEditModal();
 
-      fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
-      await waitFor(() => {
-        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
-      });
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
 
-      expect(updateTemplate).toHaveBeenCalledWith(mockTemplate.layoutId, {
-        name: mockTemplate.layout,
-        description: mockTemplate.description,
-        tags: 'template',
-        retired: 0,
-        folderId: mockTemplate.folderId,
-      });
-    },
-  );
+    expect(updateTemplate).toHaveBeenCalledWith(mockTemplate.layoutId, {
+      name: mockTemplate.layout,
+      description: mockTemplate.description,
+      tags: 'template',
+      retired: 0,
+      folderId: mockTemplate.folderId,
+    });
+  });
 
   // ---------------------------------------------------------------------------
   // Failed save - API error keeps the modal open so the user can retry.

--- a/frontend/src/pages/Design/Templates/__tests__/templateTestUtils.tsx
+++ b/frontend/src/pages/Design/Templates/__tests__/templateTestUtils.tsx
@@ -75,6 +75,20 @@ export const mockTemplate: Template = {
   userPermissions: { view: 1, edit: 1, delete: 1, modifyPermissions: 1 },
 };
 
+// A draft (non-published) template — used for Publish, Discard, and Checkout action tests.
+export const mockDraftTemplate: Template = {
+  ...mockTemplate,
+  layoutId: 2,
+  publishedStatusId: 2,
+  publishedStatus: 'Draft',
+  layout: 'Draft Template',
+};
+
+export const SINGLE_DRAFT_TEMPLATE_ROWS: FetchTemplateResponse = {
+  rows: [mockDraftTemplate],
+  totalCount: 1,
+};
+
 // -----------------------------------------------------------------------------
 // The default logged-in user for most Templates page tests.
 // -----------------------------------------------------------------------------

--- a/frontend/src/pages/Library/Playlists/components/AddAndEditPlaylistModal.tsx
+++ b/frontend/src/pages/Library/Playlists/components/AddAndEditPlaylistModal.tsx
@@ -248,8 +248,6 @@ export default function AddAndEditPlaylistModal({
     });
   };
 
-  console.log(formErrors);
-
   const hasActiveDynamicFilters = Boolean(
     draft.filterFolderId !== null ||
     draft.filterMediaName.trim() !== '' ||

--- a/frontend/src/types/layout.ts
+++ b/frontend/src/types/layout.ts
@@ -23,7 +23,6 @@ import type { Tag } from './tag';
 
 export interface Layout {
   layoutId: number;
-  name: string;
   layout: string;
   parentId?: number;
   showDrafts?: number;


### PR DESCRIPTION
- Remove name from the Layout TypeScript type 
- the API never returns this field; 
- the display name is always layout.                                                                                                                                                   
- Fix a copy-paste bug in EnableStatsLayoutModal where the modal title read "Retire Layout" and the confirm button read "Retire" (copied from RetireLayoutModal). Now reads "Enable Stats   
  Collection" / "Save".   

- https://github.com/xibosignageltd/xibo-private/issues/1356
- https://github.com/xibosignageltd/xibo-private/issues/1357