### PR TITLE
Media: support downloading module files again if they are partially downloaded

### DIFF
--- a/lib/Entity/Media.php
+++ b/lib/Entity/Media.php
@@ -490,6 +490,8 @@ class Media implements \JsonSerializable
                 || $this->valid == 0
                 || ($expires > 0 && $expires < Carbon::now()->format('U'))
                 || ($this->mediaType === 'module' && (
+                    // Save is required if the file doesn't exist, and also if it exists but isn't the size
+                    // we have recorded for it in the database
                     !file_exists($this->downloadSink(false))
                     || ($this->fileSize > 0 && filesize($this->downloadSink(false)) !== $this->fileSize)
                 ));

--- a/lib/Entity/Media.php
+++ b/lib/Entity/Media.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2025 Xibo Signage Ltd
+ * Copyright (C) 2026 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -489,7 +489,10 @@ class Media implements \JsonSerializable
             $this->isSaveRequired = $this->isSaveRequired
                 || $this->valid == 0
                 || ($expires > 0 && $expires < Carbon::now()->format('U'))
-                || ($this->mediaType === 'module' && !file_exists($this->downloadSink(false)));
+                || ($this->mediaType === 'module' && (
+                    !file_exists($this->downloadSink(false))
+                    || ($this->fileSize > 0 && filesize($this->downloadSink(false)) !== $this->fileSize)
+                ));
 
             if ($options['audit']) {
                 $this->audit($this->mediaId, 'Updated', $this->getChangedProperties());

--- a/lib/Factory/MediaFactory.php
+++ b/lib/Factory/MediaFactory.php
@@ -163,7 +163,7 @@ class MediaFactory extends BaseFactory
      * @throws \Xibo\Support\Exception\GeneralException
      * @throws \Xibo\Support\Exception\InvalidArgumentException
      */
-    public function queueDownload($name, $uri, $expiry, $requestOptions = [])
+    public function queueDownload($name, $uri, $expiry, $requestOptions = []): Media
     {
         // Determine the save name
         if (!isset($requestOptions['fileType'])) {
@@ -243,12 +243,15 @@ class MediaFactory extends BaseFactory
 
     /**
      * Process the queue of downloads
-     * @param null|callable $success success callable
-     * @param null|callable $failure failure callable
-     * @param null|callable $rejected rejected callable
+     * @param callable|null $success success callable
+     * @param callable|null $failure failure callable
+     * @param callable|null $rejected rejected callable
      */
-    public function processDownloads($success = null, $failure = null, $rejected = null)
-    {
+    public function processDownloads(
+        ?callable $success = null,
+        ?callable $failure = null,
+        ?callable $rejected = null
+    ): void {
         if (count($this->remoteDownloadQueue) > 0) {
             $this->getLog()->debug('Processing Queue of ' . count($this->remoteDownloadQueue) . ' downloads.');
 
@@ -271,15 +274,32 @@ class MediaFactory extends BaseFactory
                                 $this->getLog()->debug('processDownloads: successful, headers = '
                                     . var_export($response->getHeaders(), true));
 
-                                // Get the content length
+                                // Get the content length to reject downloads bigger than we can accept
+                                // (before downloading anything other than headers)
+                                // Only reject if Content-Length is present AND exceeds the limit.
+                                // Servers using chunked transfer encoding omit Content-Length entirely;
+                                // treating an absent header as "too large" wrongly rejects valid images.
                                 $contentLength = $response->getHeaderLine('Content-Length');
-                                if (empty($contentLength)
-                                    || intval($contentLength) > ByteFormatter::toBytes(Environment::getMaxUploadSize())
+                                if (!empty($contentLength)
+                                    && intval($contentLength) > ByteFormatter::toBytes(Environment::getMaxUploadSize())
                                 ) {
                                     throw new \Exception(__('File too large'));
                                 }
                             }
-                        }
+                        },
+                        'progress' => function (
+                            int $downloadTotal,
+                            int $downloadedBytes,
+                            int $uploadTotal,
+                            int $uploadedBytes
+                        ) {
+                            // Abort the transfer mid-stream if the download grows beyond the
+                            // max upload size. This handles servers that omit Content-Length
+                            // (e.g. chunked transfer encoding) where on_headers cannot reject early.
+                            if ($downloadedBytes > ByteFormatter::toBytes(Environment::getMaxUploadSize())) {
+                                throw new \Exception(__('File too large'));
+                            }
+                        },
                     ]);
 
                     yield function () use ($client, $url, $requestOptions) {
@@ -349,7 +369,8 @@ class MediaFactory extends BaseFactory
 
         // Handle the downloads that did not require downloading
         if (count($this->remoteDownloadNotRequiredQueue) > 0) {
-            $this->getLog()->debug('Processing Queue of ' . count($this->remoteDownloadNotRequiredQueue) . ' items which do not need downloading.');
+            $this->getLog()->debug('Processing Queue of ' . count($this->remoteDownloadNotRequiredQueue)
+                . ' items which do not need downloading.');
 
             foreach ($this->remoteDownloadNotRequiredQueue as $item) {
                 // If a success callback has been provided, call it


### PR DESCRIPTION
This particularly affects the Ticker widget with MRSS.

As additional fix not all file download servers will output Content-Length headers, implement progress callback as an additional check. 

fixes xibosignageltd/xibo-private#1355