### PR TITLE
User: revert regression and use sanitiser default to correctly ignore missing libraryQuota via the API.

### DIFF
--- a/lib/Controller/User.php
+++ b/lib/Controller/User.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2025 Xibo Signage Ltd
+ * Copyright (C) 2026 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -830,7 +830,7 @@ class User extends Base
         $user->userName = $sanitizedParams->getString('userName');
         $user->email = $sanitizedParams->getString('email');
         $user->homePageId = $sanitizedParams->getString('homePageId');
-        $user->libraryQuota = $sanitizedParams->getInt('libraryQuota');
+        $user->libraryQuota = $sanitizedParams->getInt('libraryQuota', ['default' => $user->libraryQuota]);
         $user->retired = $sanitizedParams->getCheckbox('retired');
 
         // Are user home folders enabled? Don't change unless they are.

--- a/lib/Entity/User.php
+++ b/lib/Entity/User.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2025 Xibo Signage Ltd
+ * Copyright (C) 2026 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -743,8 +743,9 @@ class User implements \JsonSerializable, UserEntityInterface
         if (!v::alnum('_.-')->length(1, 50)->validate($this->userName) && !v::email()->validate($this->userName))
             throw new InvalidArgumentException(__('User name must be between 1 and 50 characters.'), 'userName');
 
-        if (!empty($this->libraryQuota) && !v::intType()->validate($this->libraryQuota))
+        if (!v::intType()->validate($this->libraryQuota)) {
             throw new InvalidArgumentException(__('Library Quota must be a whole number.'), 'libraryQuota');
+        }
 
         if (!empty($this->email) && !v::email()->validate($this->email))
             throw new InvalidArgumentException(__('Please enter a valid email address or leave it empty.'), 'email');
@@ -967,6 +968,7 @@ class User implements \JsonSerializable, UserEntityInterface
         // This is essentially a dirty edit (i.e. we don't touch the group assignments)
         $group = $this->userGroupFactory->getById($this->groupId);
         $group->group = $this->userName;
+        $group->libraryQuota = $this->libraryQuota;
         $group->isSystemNotification = $this->isSystemNotification;
         $group->isDisplayNotification = $this->isDisplayNotification;
         $group->isCustomNotification = $this->isCustomNotification;
@@ -975,13 +977,6 @@ class User implements \JsonSerializable, UserEntityInterface
         $group->isLibraryNotification = $this->isLibraryNotification;
         $group->isReportNotification = $this->isReportNotification;
         $group->isScheduleNotification = $this->isScheduleNotification;
-
-        // Do not update libraryQuota unless explicitly provided.
-        // This preserves the current value instead of resetting it to null or 0.
-        if (!empty($this->libraryQuota)) {
-            $group->libraryQuota = $this->libraryQuota;
-        }
-
         $group->save(['linkUsers' => false]);
     }
 


### PR DESCRIPTION
fixes xibosignageltd/xibo-private#1282

For posterity this PR reverts the change made previously to make libraryQuota not required for the API, which fixes this issue. It then reimplements the fix for the API issue, so that the API does not change behaviour (not providing a value keeps the same value)

This makes this field work differently to others, so that if you clear its value and leave it empty, it will not change the existing value - makes sense for the API, weird for the form.

A better original fix would be to make the parameter required in the API and on the form. Doing so now would be a breaking change for the original issue OP, so cannot be done in a patch.