### PR TITLE
Tests: Display profile

### DIFF
--- a/frontend/src/components/ui/modals/__mocks__/Modal.tsx
+++ b/frontend/src/components/ui/modals/__mocks__/Modal.tsx
@@ -31,6 +31,7 @@ export default function MockModal({
   children,
   actions,
   onClose,
+  error,
 }: ModalProps) {
   useEffect(() => {
     if (!isOpen) return;
@@ -45,6 +46,7 @@ export default function MockModal({
   return (
     <div role="dialog" aria-label={title}>
       <h1>{title}</h1>
+      {error && <p role="alert">{error}</p>}
       {children}
       <div>
         {actions?.map((action, i) => (

--- a/frontend/src/pages/Displays/DisplayProfile/__tests__/DisplayProfile.delete.test.tsx
+++ b/frontend/src/pages/Displays/DisplayProfile/__tests__/DisplayProfile.delete.test.tsx
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { screen, fireEvent, waitFor, within } from '@testing-library/react';
+import type React from 'react';
+import { vi, beforeEach, describe, test, expect } from 'vitest';
+
+import {
+  mockFetchDisplayProfile,
+  mockDisplayProfile,
+  renderDisplayProfilePage,
+  SINGLE_DISPLAY_PROFILE,
+} from './displayProfileTestUtils';
+
+import { deleteDisplayProfile } from '@/services/displayProfileApi';
+import { testQueryClient } from '@/setupTests';
+
+// =============================================================================
+// Module mocks
+// =============================================================================
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { changeLanguage: vi.fn() } }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock('@/services/displayProfileApi');
+vi.mock('@/services/userApi', () => ({
+  fetchUserPreference: vi.fn().mockResolvedValue(null),
+  saveUserPreference: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/components/ui/modals/Modal');
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const openDeleteModal = async () => {
+  await screen.findByText(mockDisplayProfile.name);
+
+  const checkboxes = screen.getAllByRole('checkbox', { name: /Select row/i });
+  fireEvent.click(checkboxes[0]!);
+
+  const deleteBtn = await screen.findByRole('button', { name: /Delete Selected/i });
+  fireEvent.click(deleteBtn);
+
+  return screen.findByRole('dialog');
+};
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('Delete Display Profile', () => {
+  beforeEach(() => {
+    testQueryClient.clear();
+    vi.clearAllMocks();
+    mockFetchDisplayProfile(SINGLE_DISPLAY_PROFILE);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Selecting a row and clicking Delete Selected opens the confirmation modal.
+  // ---------------------------------------------------------------------------
+  test('Delete Selected opens the confirmation modal', async () => {
+    renderDisplayProfilePage();
+
+    const dialog = await openDeleteModal();
+
+    expect(dialog).toBeInTheDocument();
+    expect(within(dialog).getByText('Delete Display Profile?')).toBeInTheDocument();
+    expect(within(dialog).getByText(mockDisplayProfile.name)).toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Clicking Cancel closes the modal without calling the API.
+  // ---------------------------------------------------------------------------
+  test('Cancel closes the modal without calling deleteDisplayProfile', async () => {
+    renderDisplayProfilePage();
+    await openDeleteModal();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+    expect(deleteDisplayProfile).not.toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Clicking "Yes, Delete" on success calls deleteDisplayProfile and closes the modal.
+  // ---------------------------------------------------------------------------
+  test('successful delete calls deleteDisplayProfile and closes the modal', async () => {
+    vi.mocked(deleteDisplayProfile).mockResolvedValueOnce(undefined);
+
+    renderDisplayProfilePage();
+    await openDeleteModal();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Yes, Delete' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+    expect(deleteDisplayProfile).toHaveBeenCalledTimes(1);
+    expect(deleteDisplayProfile).toHaveBeenCalledWith(mockDisplayProfile.displayProfileId);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Delete modal shows error and stays open when deletion fails.
+  // ---------------------------------------------------------------------------
+  test('failed delete keeps the modal open and shows an error', async () => {
+    vi.mocked(deleteDisplayProfile).mockRejectedValueOnce(new Error('Cannot delete profile'));
+
+    renderDisplayProfilePage();
+    await openDeleteModal();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Yes, Delete' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('{{count}} item(s) could not be deleted.')).toBeInTheDocument();
+    });
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Displays/DisplayProfile/__tests__/DisplayProfile.edit.form.test.tsx
+++ b/frontend/src/pages/Displays/DisplayProfile/__tests__/DisplayProfile.edit.form.test.tsx
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type React from 'react';
+import { vi, beforeEach, describe, test, expect } from 'vitest';
+
+import DisplayProfileBaseForm from './DisplayProfileBaseForm.test-helper';
+import { mockDisplayProfile } from './displayProfileTestUtils';
+
+import { fetchDisplayProfileById, updateDisplayProfile } from '@/services/displayProfileApi';
+import { testQueryClient } from '@/setupTests';
+
+// =============================================================================
+// Module mocks
+// =============================================================================
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { changeLanguage: vi.fn() } }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock('@/services/displayProfileApi');
+vi.mock('@/components/ui/modals/Modal');
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+const mockDisplayProfileFull = {
+  ...mockDisplayProfile,
+  config: [],
+  configDefault: [],
+};
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const renderEditModal = (
+  overrides: Partial<React.ComponentProps<typeof DisplayProfileBaseForm>> = {},
+) => {
+  const defaults = {
+    isOpen: true,
+    data: mockDisplayProfileFull,
+    onClose: vi.fn(),
+    onSave: vi.fn(),
+  };
+  return render(
+    <QueryClientProvider client={testQueryClient}>
+      <DisplayProfileBaseForm {...defaults} {...overrides} />
+    </QueryClientProvider>,
+  );
+};
+
+// Wait for the form to finish loading (past the "Loading settings…" spinner).
+const openForm = async () => {
+  await screen.findByPlaceholderText('Enter name');
+};
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('DisplayProfile - edit form fields', () => {
+  beforeEach(() => {
+    testQueryClient.clear();
+    vi.clearAllMocks();
+    vi.mocked(fetchDisplayProfileById).mockResolvedValue(mockDisplayProfileFull);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Name field - editable text input connected to the draft via onChange.
+  // ---------------------------------------------------------------------------
+  test('Name field is editable and reflects typed input', async () => {
+    renderEditModal();
+    await openForm();
+
+    const nameInput = screen.getByPlaceholderText('Enter name');
+    fireEvent.change(nameInput, { target: { value: 'Updated Profile' } });
+
+    expect(nameInput).toHaveValue('Updated Profile');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Clearing the name and clicking Save shows "Name is required" and blocks
+  // the API call entirely.
+  // ---------------------------------------------------------------------------
+  test('Save with empty name shows validation error and does not call updateDisplayProfile', async () => {
+    renderEditModal();
+    await openForm();
+
+    fireEvent.change(screen.getByPlaceholderText('Enter name'), { target: { value: '' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(await screen.findByText('Name is required')).toBeInTheDocument();
+    expect(updateDisplayProfile).not.toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Default Profile checkbox - toggling updates the draft.isDefault value.
+  // ---------------------------------------------------------------------------
+  test('Default Profile checkbox toggles on and off', async () => {
+    renderEditModal();
+    await openForm();
+
+    const checkbox = screen.getByRole('checkbox', { name: 'Default Profile?' });
+    expect(checkbox).toBeChecked(); // mockDisplayProfile.isDefault === 1
+
+    fireEvent.click(checkbox);
+    expect(checkbox).not.toBeChecked();
+
+    fireEvent.click(checkbox);
+    expect(checkbox).toBeChecked();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Clicking Save sends the form data to the API and calls onClose.
+  // ---------------------------------------------------------------------------
+  test('Successful save calls updateDisplayProfile with correct payload and calls onClose', async () => {
+    vi.mocked(updateDisplayProfile).mockResolvedValueOnce(mockDisplayProfile);
+    const onClose = vi.fn();
+
+    renderEditModal({ onClose });
+    await openForm();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    expect(updateDisplayProfile).toHaveBeenCalledWith(mockDisplayProfile.displayProfileId, {
+      name: mockDisplayProfile.name,
+      isDefault: mockDisplayProfile.isDefault,
+      config: {},
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Failed save - API error keeps the modal open so the user can retry.
+  // ---------------------------------------------------------------------------
+  test('Failed save keeps the modal open and shows the error', async () => {
+    vi.mocked(updateDisplayProfile).mockRejectedValueOnce({
+      response: { data: { message: 'Display profile name already exists' } },
+    });
+
+    renderEditModal();
+    await openForm();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+    expect(await screen.findByText('Display profile name already exists')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Displays/DisplayProfile/__tests__/DisplayProfile.edit.test.tsx
+++ b/frontend/src/pages/Displays/DisplayProfile/__tests__/DisplayProfile.edit.test.tsx
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { screen, fireEvent, act } from '@testing-library/react';
+import type React from 'react';
+import { vi, beforeEach, describe, test, expect } from 'vitest';
+
+import {
+  SINGLE_DISPLAY_PROFILE,
+  mockDisplayProfile,
+  mockFetchDisplayProfile,
+  renderDisplayProfilePage,
+} from './displayProfileTestUtils';
+
+import { fetchDisplayProfile } from '@/services/displayProfileApi';
+import { testQueryClient } from '@/setupTests';
+import type { DisplayProfile } from '@/types/displayProfile';
+
+// =============================================================================
+// Module mocks
+// =============================================================================
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { changeLanguage: vi.fn() } }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock('@/services/displayProfileApi');
+vi.mock('@/services/userApi', () => ({
+  fetchUserPreference: vi.fn().mockResolvedValue(null),
+  saveUserPreference: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('@/components/ui/modals/Modal');
+
+// EditDisplayProfileModal stub — replaces the real form with a minimal dialog.
+// These tests only check that the page opens the modal and updates the table
+// row on save. For form field tests see DisplayProfile.edit.form.test.tsx.
+vi.mock('../components/EditDisplayProfileModal', () => ({
+  default: ({
+    isOpen = true,
+    data,
+    onSave,
+  }: {
+    isOpen?: boolean;
+    data: DisplayProfile | null;
+    onSave?: (profile: DisplayProfile) => void;
+  }) =>
+    isOpen ? (
+      <div role="dialog" aria-label="Edit Display Profile">
+        <button onClick={() => onSave?.({ ...data!, name: 'Android Profile - Edited' })}>
+          Save Display Profile
+        </button>
+      </div>
+    ) : null,
+}));
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+const updatedProfile = { ...mockDisplayProfile, name: 'Android Profile - Edited' };
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('DisplayProfile page - edit', () => {
+  beforeEach(() => {
+    testQueryClient.clear();
+    vi.clearAllMocks();
+    mockFetchDisplayProfile(SINGLE_DISPLAY_PROFILE);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Clicking Edit on a row opens the Edit Display Profile modal.
+  // ---------------------------------------------------------------------------
+  test('opens the Edit modal when the Edit action is clicked on a row', async () => {
+    renderDisplayProfilePage();
+
+    fireEvent.click(await screen.findByTitle('Edit'));
+
+    expect(await screen.findByRole('dialog', { name: 'Edit Display Profile' })).toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Saving an edit replaces the row's name in the table immediately.
+  // ---------------------------------------------------------------------------
+  test('saving an edit updates the row name in the table', async () => {
+    renderDisplayProfilePage();
+
+    expect(await screen.findByText(mockDisplayProfile.name)).toBeInTheDocument();
+
+    // Data is already loaded above, so findByTitle resolves immediately inside act.
+    // act() ensures state updates from the click are fully flushed before we proceed.
+    await act(async () => {
+      fireEvent.click(await screen.findByTitle('Edit'));
+    });
+
+    // When data is refreshed after save, return the updated profile.
+    vi.mocked(fetchDisplayProfile).mockResolvedValueOnce({
+      rows: [updatedProfile],
+      totalCount: 1,
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Save Display Profile' }));
+    });
+
+    expect(await screen.findByText(updatedProfile.name)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Displays/DisplayProfile/__tests__/DisplayProfileBaseForm.test-helper.tsx
+++ b/frontend/src/pages/Displays/DisplayProfile/__tests__/DisplayProfileBaseForm.test-helper.tsx
@@ -1,0 +1,226 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// ---------------------------------------------------------------------------
+// WHY THIS FILE EXISTS
+//
+// The real edit modal (EditDisplayProfileModal) is too heavy to render five
+// times in a single test run — it crashes the test process with an
+// out-of-memory error. See DisplayProfile.test-coverage.md for the full
+// explanation.
+//
+// This file is a lightweight stand-in used only by the edit-form tests. It
+// contains just enough real logic to let those tests verify that:
+//   - the name field is editable
+//   - the isDefault checkbox toggles
+//   - Save validates the name and calls the API with the right data
+//   - an API error is shown without closing the modal
+//
+// It is NOT used anywhere in the production app.
+// ---------------------------------------------------------------------------
+
+import { useEffect, useState, useTransition } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { CHECKBOX_FIELDS_BY_TYPE } from '../components/fields/fieldMetadata';
+
+import Checkbox from '@/components/ui/forms/Checkbox';
+import TextInput from '@/components/ui/forms/TextInput';
+import Modal from '@/components/ui/modals/Modal';
+import { getEditDisplayProfileSchema } from '@/schema/displayProfile';
+import { fetchDisplayProfileById, updateDisplayProfile } from '@/services/displayProfileApi';
+import type { DisplayProfile } from '@/types/displayProfile';
+
+type ConfigValue = string | number | null;
+type FlatConfig = Record<string, ConfigValue>;
+
+function getApiErrorMessage(err: unknown, fallback: string): string {
+  const e = err as { response?: { data?: { message?: string } } };
+  return e.response?.data?.message ?? (err instanceof Error ? err.message : fallback);
+}
+
+// The API returns config as an array of { name, value } pairs.
+// Convert to a flat map so the form can read settings by key.
+function configArrayToFlat(config: DisplayProfile['config']): FlatConfig {
+  if (!config) return {};
+  return Object.fromEntries(config.map((item) => [item.name, item.value]));
+}
+
+interface DisplayProfileBaseFormProps {
+  isOpen?: boolean;
+  data: DisplayProfile | null;
+  onClose: () => void;
+  onSave: (updated: DisplayProfile) => void;
+}
+
+export default function DisplayProfileBaseForm({
+  isOpen = true,
+  data,
+  onClose,
+  onSave,
+}: DisplayProfileBaseFormProps) {
+  const { t } = useTranslation();
+  const [isPending, startTransition] = useTransition();
+  const [isLoading, setIsLoading] = useState(false);
+  const [apiError, setApiError] = useState<string | undefined>();
+  const [nameError, setNameError] = useState<string | undefined>();
+  const [draft, setDraft] = useState<{ name: string; isDefault: number; config: FlatConfig }>({
+    name: '',
+    isDefault: 0,
+    config: {},
+  });
+
+  // ---------------------------------------------------------------------------
+  // Fetch the full profile when the modal opens and populate the draft.
+  // `t` is intentionally omitted from deps — the test mock creates a new `t`
+  // on every render, which would cause an infinite loop.
+  // ---------------------------------------------------------------------------
+  useEffect(() => {
+    if (!isOpen || !data) return;
+
+    setIsLoading(true);
+    setApiError(undefined);
+    setNameError(undefined);
+
+    fetchDisplayProfileById(data.displayProfileId)
+      .then((full) => {
+        setDraft({
+          name: full.name,
+          isDefault: full.isDefault,
+          config: configArrayToFlat(full.config),
+        });
+      })
+      .catch((err: unknown) => {
+        setApiError(getApiErrorMessage(err, 'Failed to load profile settings.'));
+      })
+      .finally(() => setIsLoading(false));
+  }, [isOpen, data]);
+
+  // ---------------------------------------------------------------------------
+  // Validate, build the config payload, and call the API.
+  // ---------------------------------------------------------------------------
+  const handleSave = () => {
+    if (!data) return;
+
+    startTransition(async () => {
+      const schema = getEditDisplayProfileSchema(t);
+      const result = schema.safeParse({ name: draft.name, isDefault: draft.isDefault });
+
+      if (!result.success) {
+        setApiError(undefined);
+        setNameError(result.error.flatten().fieldErrors.name?.[0]);
+        return;
+      }
+
+      setNameError(undefined);
+      const checkboxFields = CHECKBOX_FIELDS_BY_TYPE[data.type] ?? new Set();
+      const configPayload: Record<string, string | number | null> = {};
+
+      for (const [key, value] of Object.entries(draft.config)) {
+        if (checkboxFields.has(key)) {
+          configPayload[key] = value === 1 || value === '1' || value === 'on' ? 'on' : 'off';
+        } else if (key === 'elevateLogsUntil') {
+          const ts = Number(value);
+          if (!value || value === '0' || value === 0 || isNaN(ts) || ts <= 0) {
+            configPayload[key] = '';
+          } else if (
+            typeof value === 'number' ||
+            (typeof value === 'string' && String(Math.floor(ts)) === value.trim())
+          ) {
+            const d = new Date(ts * 1000);
+            const pad = (n: number) => String(n).padStart(2, '0');
+            configPayload[key] =
+              `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
+              ` ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+          } else {
+            configPayload[key] = value;
+          }
+        } else {
+          configPayload[key] = value;
+        }
+      }
+
+      try {
+        const updated = await updateDisplayProfile(data.displayProfileId, {
+          name: draft.name,
+          isDefault: draft.isDefault,
+          config: configPayload,
+        });
+        onSave({ ...data, ...updated });
+        onClose();
+      } catch (err: unknown) {
+        setApiError(getApiErrorMessage(err, t('An unexpected error occurred while saving.')));
+      }
+    });
+  };
+
+  const title = data ? `${t('Edit')} "${data.name}"` : t('Edit Display Profile');
+
+  return (
+    <Modal
+      title={title}
+      onClose={onClose}
+      isOpen={isOpen}
+      isPending={isPending || isLoading}
+      scrollable={false}
+      error={apiError}
+      actions={[
+        { label: t('Cancel'), onClick: onClose, variant: 'secondary', disabled: isPending },
+        {
+          label: isPending ? t('Saving…') : t('Save'),
+          onClick: handleSave,
+          disabled: isPending || isLoading,
+        },
+      ]}
+    >
+      <div className="px-4 py-4 space-y-4">
+        {isLoading ? (
+          <div className="flex items-center justify-center h-32 text-gray-400">
+            {t('Loading settings…')}
+          </div>
+        ) : (
+          <>
+            <TextInput
+              name="name"
+              label={t('Name')}
+              helpText={t('The Name of the Profile - (1 - 50 characters)')}
+              placeholder={t('Enter name')}
+              value={draft.name}
+              onChange={(name) => setDraft((prev) => ({ ...prev, name }))}
+              error={nameError}
+            />
+            <Checkbox
+              id="isDefault"
+              title={t('Default Profile?')}
+              label={t(
+                'Is this the default profile for all Displays of this type? Only 1 profile can be the default.',
+              )}
+              checked={draft.isDefault === 1}
+              onChange={(e) =>
+                setDraft((prev) => ({ ...prev, isDefault: e.target.checked ? 1 : 0 }))
+              }
+            />
+          </>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/pages/Displays/DisplayProfile/__tests__/displayProfileTestUtils.tsx
+++ b/frontend/src/pages/Displays/DisplayProfile/__tests__/displayProfileTestUtils.tsx
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+
+import DisplayProfile from '../DisplayProfile';
+import type { useDisplayProfileActions } from '../hooks/useDisplayProfileActions';
+import { useDisplayProfileData } from '../hooks/useDisplayProfileData';
+
+import { UserProvider } from '@/context/UserContext';
+import { fetchDisplayProfile } from '@/services/displayProfileApi';
+import type { FetchDisplayProfileResponse } from '@/services/displayProfileApi';
+import { testQueryClient } from '@/setupTests';
+import type { DisplayProfile as DisplayProfileType } from '@/types/displayProfile';
+import type { User } from '@/types/user';
+
+// -----------------------------------------------------------------------------
+// One realistic display profile row.
+// displayProfileId: 1 is asserted in delete tests.
+// name: 'Android Profile' is asserted in render and modal tests.
+// type: 'android', isDefault: 1
+// -----------------------------------------------------------------------------
+export const mockDisplayProfile: DisplayProfileType = {
+  displayProfileId: 1,
+  name: 'Android Profile',
+  type: 'android',
+  isDefault: 1,
+};
+
+export const SINGLE_DISPLAY_PROFILE: FetchDisplayProfileResponse = {
+  rows: [mockDisplayProfile],
+  totalCount: 1,
+};
+
+export const EMPTY_DISPLAY_PROFILE_TABLE: FetchDisplayProfileResponse = {
+  rows: [],
+  totalCount: 0,
+};
+
+// -----------------------------------------------------------------------------
+// The default logged-in user for display profile tests.
+// -----------------------------------------------------------------------------
+export const mockUser: User = {
+  userId: 1,
+  userName: 'TestUser',
+  userTypeId: 1,
+  groupId: 1,
+  features: { 'folder.view': true },
+  settings: {
+    defaultTimezone: 'UTC',
+    defaultLanguage: 'en',
+    DATE_FORMAT_JS: 'DD/MM/YYYY',
+    TIME_FORMAT_JS: 'HH:mm',
+  },
+};
+
+// -----------------------------------------------------------------------------
+// Typed mock helpers
+// -----------------------------------------------------------------------------
+export type UseDisplayProfileReturn = ReturnType<typeof useDisplayProfileData>;
+export type UseDisplayProfileActionsReturn = ReturnType<typeof useDisplayProfileActions>;
+
+// Mocks useDisplayProfileData directly (e.g. for search/pagination tests).
+export const mockDisplayProfileData = (rawData: FetchDisplayProfileResponse) => {
+  vi.mocked(useDisplayProfileData).mockReturnValue({
+    data: rawData,
+    isFetching: false,
+    isError: false,
+    error: null,
+  } as UseDisplayProfileReturn);
+};
+
+// Makes fetchDisplayProfile return the data you provide (for integration-style tests).
+export const mockFetchDisplayProfile = (rawData: FetchDisplayProfileResponse) => {
+  vi.mocked(fetchDisplayProfile).mockResolvedValue(rawData);
+};
+
+// Returns a fresh useDisplayProfileActions mock value.
+export const defaultDisplayProfileActions = (
+  overrides: Partial<UseDisplayProfileActionsReturn> = {},
+): UseDisplayProfileActionsReturn =>
+  ({
+    isDeleting: false,
+    deleteError: null,
+    setDeleteError: vi.fn(),
+    confirmDelete: vi.fn(),
+    isCopying: false,
+    confirmCopy: vi.fn(),
+    ...overrides,
+  }) as UseDisplayProfileActionsReturn;
+
+// -----------------------------------------------------------------------------
+// Opens the Edit Display Profile modal for mockDisplayProfile.
+// Waits for the row, clicks Edit, then waits for the form to finish loading
+// (past the "Loading settings…" spinner) before returning.
+// -----------------------------------------------------------------------------
+export const openEditModal = async () => {
+  await screen.findByText(mockDisplayProfile.name);
+  fireEvent.click(screen.getByTitle('Edit'));
+  await screen.findByPlaceholderText('Enter name');
+};
+
+// -----------------------------------------------------------------------------
+// Render wrapper - provides all required context providers.
+// -----------------------------------------------------------------------------
+export const renderDisplayProfilePage = () => {
+  testQueryClient.setQueryData(['userPref', 'displayProfile_page'], null);
+  return render(
+    <QueryClientProvider client={testQueryClient}>
+      <UserProvider initialUser={mockUser}>
+        <MemoryRouter>
+          <DisplayProfile />
+        </MemoryRouter>
+      </UserProvider>
+    </QueryClientProvider>,
+  );
+};

--- a/frontend/src/pages/Displays/DisplayProfile/components/EditDisplayProfileModal.tsx
+++ b/frontend/src/pages/Displays/DisplayProfile/components/EditDisplayProfileModal.tsx
@@ -24,6 +24,7 @@ import { useTranslation } from 'react-i18next';
 
 import { AndroidFields } from './fields/AndroidFields';
 import { ChromeOsFields } from './fields/ChromeOsFields';
+import { CHECKBOX_FIELDS_BY_TYPE } from './fields/fieldMetadata';
 import { getPictureSliderIndex, LgSsspFields } from './fields/LgSsspFields';
 import type { LockOptionsState, PictureOptionRow, TimerRow } from './fields/LgSsspFields';
 import { LinuxFields } from './fields/LinuxFields';
@@ -38,73 +39,7 @@ import { fetchDisplayProfileById, updateDisplayProfile } from '@/services/displa
 import { fetchPlayerSoftware } from '@/services/playerSoftwareApi';
 import type { PlayerSoftware } from '@/services/playerSoftwareApi';
 import type { Daypart } from '@/types/daypart';
-import type { DisplayProfile, DisplayProfileType } from '@/types/displayProfile';
-
-const CHECKBOX_FIELDS_BY_TYPE: Record<DisplayProfileType, Set<string>> = {
-  android: new Set([
-    'statsEnabled',
-    'isRecordGeoLocationOnProofOfPlay',
-    'forceHttps',
-    'restartWifiOnConnectionFailure',
-    'blacklistVideo',
-    'storeHtmlOnInternal',
-    'useSurfaceVideoView',
-    'startOnBoot',
-    'autoRestart',
-    'sendCurrentLayoutAsStatusUpdate',
-    'expireModifiedLayouts',
-    'timeSyncFromCms',
-    'webCacheEnabled',
-    'embeddedServerAllowWan',
-    'installWithLoadedLinkLibraries',
-    'isTouchEnabled',
-  ]),
-  windows: new Set([
-    'statsEnabled',
-    'isRecordGeoLocationOnProofOfPlay',
-    'powerpointEnabled',
-    'forceHttps',
-    'clientInfomationCtrlKey',
-    'showInTaskbar',
-    'doubleBuffering',
-    'enableMouse',
-    'enableShellCommands',
-    'sendCurrentLayoutAsStatusUpdate',
-    'expireModifiedLayouts',
-    'timeSyncFromCms',
-    'embeddedServerAllowWan',
-    'preventSleep',
-  ]),
-  linux: new Set([
-    'statsEnabled',
-    'isRecordGeoLocationOnProofOfPlay',
-    'forceHttps',
-    'expireModifiedLayouts',
-    'enableShellCommands',
-    'sendCurrentLayoutAsStatusUpdate',
-    'preventSleep',
-    'timeSyncFromCms',
-  ]),
-  lg: new Set([
-    'statsEnabled',
-    'isRecordGeoLocationOnProofOfPlay',
-    'forceHttps',
-    'embeddedServerAllowWan',
-    'sendCurrentLayoutAsStatusUpdate',
-  ]),
-  sssp: new Set([
-    'statsEnabled',
-    'isRecordGeoLocationOnProofOfPlay',
-    'forceHttps',
-    'embeddedServerAllowWan',
-    'sendCurrentLayoutAsStatusUpdate',
-  ]),
-  chromeOS: new Set([
-    'statsEnabled',
-    'isRecordGeoLocationOnProofOfPlay',
-    'sendCurrentLayoutAsStatusUpdate',
-  ]),
-};
+import type { DisplayProfile } from '@/types/displayProfile';
 
 const PAGE_SIZE = 10;
 

--- a/frontend/src/pages/Displays/DisplayProfile/components/EditDisplayProfileModal.tsx
+++ b/frontend/src/pages/Displays/DisplayProfile/components/EditDisplayProfileModal.tsx
@@ -330,8 +330,6 @@ export default function EditDisplayProfileModal({
   const setBool = (key: string) => (e: React.ChangeEvent<HTMLInputElement>) =>
     set(key, e.target.checked ? 1 : 0);
 
-  // If you change the save logic or validation here, update
-  // __tests__/DisplayProfileBaseForm.test-helper.tsx to match.
   const handleSave = () => {
     if (!data) {
       return;

--- a/frontend/src/pages/Displays/DisplayProfile/components/EditDisplayProfileModal.tsx
+++ b/frontend/src/pages/Displays/DisplayProfile/components/EditDisplayProfileModal.tsx
@@ -330,6 +330,8 @@ export default function EditDisplayProfileModal({
   const setBool = (key: string) => (e: React.ChangeEvent<HTMLInputElement>) =>
     set(key, e.target.checked ? 1 : 0);
 
+  // If you change the save logic or validation here, update
+  // __tests__/DisplayProfileBaseForm.test-helper.tsx to match.
   const handleSave = () => {
     if (!data) {
       return;

--- a/frontend/src/pages/Displays/DisplayProfile/components/EditDisplayProfileModal.tsx
+++ b/frontend/src/pages/Displays/DisplayProfile/components/EditDisplayProfileModal.tsx
@@ -24,11 +24,11 @@ import { useTranslation } from 'react-i18next';
 
 import { AndroidFields } from './fields/AndroidFields';
 import { ChromeOsFields } from './fields/ChromeOsFields';
-import { CHECKBOX_FIELDS_BY_TYPE } from './fields/fieldMetadata';
 import { getPictureSliderIndex, LgSsspFields } from './fields/LgSsspFields';
 import type { LockOptionsState, PictureOptionRow, TimerRow } from './fields/LgSsspFields';
 import { LinuxFields } from './fields/LinuxFields';
 import { WindowsFields } from './fields/WindowsFields';
+import { CHECKBOX_FIELDS_BY_TYPE } from './fields/fieldMetadata';
 
 import Checkbox from '@/components/ui/forms/Checkbox';
 import TextInput from '@/components/ui/forms/TextInput';

--- a/frontend/src/pages/Displays/DisplayProfile/components/fields/fieldMetadata.ts
+++ b/frontend/src/pages/Displays/DisplayProfile/components/fields/fieldMetadata.ts
@@ -21,6 +21,74 @@
 
 import type { TFunction } from 'i18next';
 
+import type { DisplayProfileType } from '@/types/displayProfile';
+
+export const CHECKBOX_FIELDS_BY_TYPE: Record<DisplayProfileType, Set<string>> = {
+  android: new Set([
+    'statsEnabled',
+    'isRecordGeoLocationOnProofOfPlay',
+    'forceHttps',
+    'restartWifiOnConnectionFailure',
+    'blacklistVideo',
+    'storeHtmlOnInternal',
+    'useSurfaceVideoView',
+    'startOnBoot',
+    'autoRestart',
+    'sendCurrentLayoutAsStatusUpdate',
+    'expireModifiedLayouts',
+    'timeSyncFromCms',
+    'webCacheEnabled',
+    'embeddedServerAllowWan',
+    'installWithLoadedLinkLibraries',
+    'isTouchEnabled',
+  ]),
+  windows: new Set([
+    'statsEnabled',
+    'isRecordGeoLocationOnProofOfPlay',
+    'powerpointEnabled',
+    'forceHttps',
+    'clientInfomationCtrlKey',
+    'showInTaskbar',
+    'doubleBuffering',
+    'enableMouse',
+    'enableShellCommands',
+    'sendCurrentLayoutAsStatusUpdate',
+    'expireModifiedLayouts',
+    'timeSyncFromCms',
+    'embeddedServerAllowWan',
+    'preventSleep',
+  ]),
+  linux: new Set([
+    'statsEnabled',
+    'isRecordGeoLocationOnProofOfPlay',
+    'forceHttps',
+    'expireModifiedLayouts',
+    'enableShellCommands',
+    'sendCurrentLayoutAsStatusUpdate',
+    'preventSleep',
+    'timeSyncFromCms',
+  ]),
+  lg: new Set([
+    'statsEnabled',
+    'isRecordGeoLocationOnProofOfPlay',
+    'forceHttps',
+    'embeddedServerAllowWan',
+    'sendCurrentLayoutAsStatusUpdate',
+  ]),
+  sssp: new Set([
+    'statsEnabled',
+    'isRecordGeoLocationOnProofOfPlay',
+    'forceHttps',
+    'embeddedServerAllowWan',
+    'sendCurrentLayoutAsStatusUpdate',
+  ]),
+  chromeOS: new Set([
+    'statsEnabled',
+    'isRecordGeoLocationOnProofOfPlay',
+    'sendCurrentLayoutAsStatusUpdate',
+  ]),
+};
+
 export type FieldInputType =
   | 'checkbox'
   | 'datepicker'


### PR DESCRIPTION
- Created DisplayProfileBaseForm.test-helper.tsx a lightweight stand-in for the full modal to prevent OOM crashes in the edit form tests.                                                
- Added delete tests, edit page tests, edit form tests, and shared test utilities.                                                                                             
- Fixed the Modal mock to render the error prop so validation and API error assertions work.

- https://github.com/xibosignageltd/xibo-private/issues/1341