### PR TITLE
fix: XMDS issue with links output by anything which accesses from /xmds.php

### DIFF
--- a/lib/Helper/LinkSigner.php
+++ b/lib/Helper/LinkSigner.php
@@ -53,13 +53,7 @@ class LinkSigner
         bool $isRequestFromPwa = false,
     ): string {
         // Start with the base url, which should correctly account for running with a CMS_ALIAS
-        $xmdsRoot = (new HttpsDetect())->getBaseUrl();
-
-        // PWA requests resources via `/pwa/getResource` and `/pwa/getData`, but the link should be served from `/xmds.php`
-        if ($isRequestFromPwa) {
-            $xmdsRoot = str_replace('/pwa/getResource', '/xmds.php', $xmdsRoot);
-            $xmdsRoot = str_replace('/pwa/getData', '/xmds.php', $xmdsRoot);
-        }
+        $xmdsRoot = (new HttpsDetect())->getBaseUrl() . '/xmds.php';
 
         // Build the rest of the URL
         $saveAsPath = $xmdsRoot

--- a/lib/Xmds/Wsdl.php
+++ b/lib/Xmds/Wsdl.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2025 Xibo Signage Ltd
+ * Copyright (C) 2026 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -68,6 +68,6 @@ class Wsdl
      */
     public static function getRoot(): string
     {
-        return (new HttpsDetect())->getBaseUrl();
+        return (new HttpsDetect())->getBaseUrl() . '/xmds.php';
     }
 }


### PR DESCRIPTION
Issue introduced here: 42b2e2ef13b972716f3fd60e72d5f3d1be4e408b

Signed links are only generated and accessed from `xmds.php`.