### PR TITLE
refactor: simplify test suite result reporting

### DIFF
--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -65,23 +65,6 @@ jobs:
         run: |
           docker exec --user www-data -t cms-web /bin/bash -c "cd /var/www/cms; php vendor/bin/phpunit --log-junit results.xml"
 
-      - name: Add workflow result as comment on PR
-        uses: actions/github-script@v6
-        if: always()
-        with:
-          script: |
-            const name = '${{ github.workflow }} (PHPUnit)';
-            const url = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
-            const success = '${{ job.status }}' === 'success';
-            const body = `${name}: ${success ? 'succeeded ✅' : 'failed ❌'}\n${url}`;
-
-            await github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: body
-            })
-
       - name: Set latest commit status as ${{ job.status }}
         uses: myrotvorets/set-commit-status-action@master
         if: always()
@@ -92,6 +75,7 @@ jobs:
 
   vitest:
     name: Run Vitest
+    needs: phpunit
     if: github.event.issue.pull_request && contains(github.event.comment.body, 'TEST:')
     runs-on: ubuntu-latest
 
@@ -170,23 +154,6 @@ jobs:
           name: vitest-coverage-report
           path: frontend/coverage
 
-      - name: Add workflow result as comment on PR
-        uses: actions/github-script@v6
-        if: always()
-        with:
-          script: |
-            const name = '${{ github.workflow }} (Vitest)';
-            const url = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
-            const success = '${{ job.status }}' === 'success';
-            const body = `${name}: ${success ? 'succeeded ✅' : 'failed ❌'}\n${url}`;
-
-            await github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: body
-            })
-
       - name: Set latest commit status as ${{ job.status }}
         uses: myrotvorets/set-commit-status-action@master
         if: always()
@@ -194,3 +161,33 @@ jobs:
           sha: ${{ steps.comment-branch.outputs.head_sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
           status: ${{ job.status }}
+
+  comment:
+    name: Post Result Comment
+    needs: [phpunit, vitest]
+    if: always() && github.event.issue.pull_request && contains(github.event.comment.body, 'TEST:')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add workflow result as comment on PR
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const phpunit = '${{ needs.phpunit.result }}';
+            const vitest = '${{ needs.vitest.result }}';
+            const url = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
+
+            let body;
+            if (phpunit === 'success' && vitest === 'success') {
+              body = `Test Suite: succeeded ✅\n${url}`;
+            } else if (phpunit !== 'success') {
+              body = `Test Suite: failed ❌ (PHPUnit ${phpunit})\n${url}`;
+            } else {
+              body = `Test Suite: failed ❌ (Vitest ${vitest})\n${url}`;
+            }
+
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            })


### PR DESCRIPTION
- PHPUnit fails: `Test Suite: failed ❌ (PHPUnit failure)` Vitest never runs
- PHPUnit passes, Vitest fails: `Test Suite: failed ❌ (Vitest failure)`
- Both pass: `Test Suite: succeeded ✅`               