### PR TITLE
fix: Layout preview: various operations need token refreshing

### DIFF
--- a/lib/Controller/Layout.php
+++ b/lib/Controller/Layout.php
@@ -923,18 +923,6 @@ class Layout extends Base
             rename($layout->getUnmatchedProperty('thumbnail'), $template->getThumbnailUri());
         }
 
-        // Add a new previewJWT for this layout
-        $template->setUnmatchedProperty(
-            'previewJwt',
-            $this->jwtService->generateJwt(
-                'Preview',
-                'layout',
-                $template->layoutId,
-                '/preview/layout/preview/' . $template->layoutId,
-                3600,
-            )->toString()
-        );
-
         // Return
         $this->getState()->hydrate([
             'message' => sprintf(__('Edited %s'), $layout->layout),

--- a/ui/src/layout-editor/layout.js
+++ b/ui/src/layout-editor/layout.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Xibo Signage Ltd
+ * Copyright (C) 2026 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -50,6 +50,7 @@ const Layout = function(id, data) {
   // Layout properties
   this.id = 'layout_' + id;
   this.layoutId = id;
+  this.previewUrl = data.previewUrl;
 
   this.folderId = data.folderId;
 

--- a/ui/src/layout-editor/main.js
+++ b/ui/src/layout-editor/main.js
@@ -809,6 +809,10 @@ lD.reloadData = function(
         // get Layout folder id
         lD.folderId = lD.layout.folderId;
 
+        // Update the previewJWT for the new layout
+        const previewUrl = new URL(lD.layout.previewUrl);
+        window.previewJwt = previewUrl.searchParams.get('jwt');
+
         // Select the same object
         const selectObjectId = (lD.selectedObject.type === 'element') ?
           lD.selectedObject.elementId :
@@ -2794,9 +2798,6 @@ lD.dropItemAdd = function(droppable, draggable, dropPosition) {
             if (response.success && response.id) {
               // Deselect previous object
               lD.selectObject();
-
-              // Update the previewJWT for the new layout
-              window.previewJwt = response.data.previewJwt;
 
               lD.reloadData(response.data,
                 {


### PR DESCRIPTION
Apply template was handled in xibosignage/xibo#3861, but that only fixed 1 place. Roll back that change and apply it in `lD.reloadData`, which covers all cases.

fixes xibosignage/xibo#3856