### PR TITLE
Frontend: Menuboards page

### DIFF
--- a/frontend/src/components/ui/__tests__/DatePicker.test.tsx
+++ b/frontend/src/components/ui/__tests__/DatePicker.test.tsx
@@ -28,6 +28,7 @@ vi.mock('@/context/UserContext', () => ({
 }));
 
 import DatePicker from '../DatePicker';
+
 import { useUserContext } from '@/context/UserContext';
 
 const mockUseUserContext = useUserContext as ReturnType<typeof vi.fn>;

--- a/frontend/src/components/ui/forms/BandwidthInput.tsx
+++ b/frontend/src/components/ui/forms/BandwidthInput.tsx
@@ -69,6 +69,7 @@ interface BandwidthInputProps {
   onChange: (kb: number | null) => void;
   label?: string;
   helpText?: string;
+  optional?: boolean;
 }
 
 export default function BandwidthInput({
@@ -76,6 +77,7 @@ export default function BandwidthInput({
   onChange,
   label,
   helpText,
+  optional = false,
 }: BandwidthInputProps) {
   const { t } = useTranslation();
   const [unit, setUnit] = useState<BandwidthUnit>(() => detectUnit(valueKb));
@@ -95,7 +97,10 @@ export default function BandwidthInput({
 
   return (
     <div className="flex flex-col gap-1">
-      <label className="text-sm font-semibold text-gray-500">{label ?? t('Bandwidth limit')}</label>
+      <label className="flex items-center justify-between text-sm font-semibold text-gray-500">
+        <span>{label ?? t('Bandwidth limit')}</span>
+        {optional && <span className="text-xs font-normal text-gray-500">{t('Optional')}</span>}
+      </label>
       <div className="flex gap-2">
         <div className="flex-1">
           <NumberInput name="bandwidthLimit" value={displayValue} onChange={handleValueChange} />

--- a/frontend/src/components/ui/forms/CommandDropdown.tsx
+++ b/frontend/src/components/ui/forms/CommandDropdown.tsx
@@ -36,6 +36,7 @@ interface CommandDropdownProps {
   label?: string;
   helpText?: string;
   error?: string;
+  optional?: boolean;
 }
 
 export default function CommandDropdown({
@@ -45,6 +46,7 @@ export default function CommandDropdown({
   label,
   helpText,
   error,
+  optional = false,
 }: CommandDropdownProps) {
   const { t } = useTranslation();
 
@@ -115,6 +117,7 @@ export default function CommandDropdown({
       searchPlaceholder={t('Search commands...')}
       onSearch={(v) => setSearchTerm(v)}
       error={error}
+      optional={optional}
     />
   );
 }

--- a/frontend/src/components/ui/forms/DatePickerInput.tsx
+++ b/frontend/src/components/ui/forms/DatePickerInput.tsx
@@ -47,6 +47,7 @@ interface DatePickerInputProps {
   disablePastDates?: boolean;
   disableFutureDates?: boolean;
   showTimePicker?: boolean;
+  optional?: boolean;
 }
 
 export default function DatePickerInput({
@@ -58,6 +59,7 @@ export default function DatePickerInput({
   disablePastDates = false,
   disableFutureDates = false,
   showTimePicker = true,
+  optional = false,
 }: DatePickerInputProps) {
   const { t } = useTranslation();
   const { user } = useUserContext();
@@ -85,7 +87,10 @@ export default function DatePickerInput({
 
   return (
     <div className="flex flex-col gap-1.5 relative">
-      <label className="text-sm font-semibold text-gray-500">{label}</label>
+      <label className="flex items-center justify-between text-sm font-semibold text-gray-500">
+        <span>{label}</span>
+        {optional && <span className="text-xs font-normal text-gray-500">{t('Optional')}</span>}
+      </label>
 
       <div
         ref={refs.setReference}

--- a/frontend/src/components/ui/forms/DurationInput.tsx
+++ b/frontend/src/components/ui/forms/DurationInput.tsx
@@ -27,6 +27,7 @@ interface DurationInputProps {
   value: number;
   onChange: (seconds: number) => void;
   error?: string;
+  optional?: boolean;
 }
 
 function formatSeconds(seconds: number): string {
@@ -45,7 +46,7 @@ function parseTimeToSeconds(value: string): number {
   return h * 3600 + m * 60 + s;
 }
 
-export default function DurationInput({ value, onChange, error }: DurationInputProps) {
+export default function DurationInput({ value, onChange, error, optional = false }: DurationInputProps) {
   const { t } = useTranslation();
   const [displayValue, setDisplayValue] = useState(formatSeconds(value));
   const STEP = 1;
@@ -70,7 +71,10 @@ export default function DurationInput({ value, onChange, error }: DurationInputP
 
   return (
     <div className="flex flex-col justify-end relative">
-      <label className="text-sm font-semibold text-gray-500">{t('Duration')}</label>
+      <label className="flex items-center justify-between text-sm font-semibold text-gray-500">
+        <span>{t('Duration')}</span>
+        {optional && <span className="text-xs font-normal text-gray-500">{t('Optional')}</span>}
+      </label>
 
       <div className="relative flex">
         <input

--- a/frontend/src/components/ui/forms/DurationInput.tsx
+++ b/frontend/src/components/ui/forms/DurationInput.tsx
@@ -46,7 +46,12 @@ function parseTimeToSeconds(value: string): number {
   return h * 3600 + m * 60 + s;
 }
 
-export default function DurationInput({ value, onChange, error, optional = false }: DurationInputProps) {
+export default function DurationInput({
+  value,
+  onChange,
+  error,
+  optional = false,
+}: DurationInputProps) {
   const { t } = useTranslation();
   const [displayValue, setDisplayValue] = useState(formatSeconds(value));
   const STEP = 1;

--- a/frontend/src/components/ui/forms/ExpiryDateSelect.tsx
+++ b/frontend/src/components/ui/forms/ExpiryDateSelect.tsx
@@ -48,7 +48,12 @@ interface ExpiryDateSelectProps {
   optional?: boolean;
 }
 
-export default function ExpiryDateSelect({ value, options, onSelect, optional = false }: ExpiryDateSelectProps) {
+export default function ExpiryDateSelect({
+  value,
+  options,
+  onSelect,
+  optional = false,
+}: ExpiryDateSelectProps) {
   const { t } = useTranslation();
   const { user } = useUserContext();
   const timeZone = user?.settings?.defaultTimezone;

--- a/frontend/src/components/ui/forms/ExpiryDateSelect.tsx
+++ b/frontend/src/components/ui/forms/ExpiryDateSelect.tsx
@@ -45,9 +45,10 @@ interface ExpiryDateSelectProps {
   value?: ExpiryValue;
   options: string[];
   onSelect: (value: ExpiryValue) => void;
+  optional?: boolean;
 }
 
-export default function ExpiryDateSelect({ value, options, onSelect }: ExpiryDateSelectProps) {
+export default function ExpiryDateSelect({ value, options, onSelect, optional = false }: ExpiryDateSelectProps) {
   const { t } = useTranslation();
   const { user } = useUserContext();
   const timeZone = user?.settings?.defaultTimezone;
@@ -85,7 +86,10 @@ export default function ExpiryDateSelect({ value, options, onSelect }: ExpiryDat
 
   return (
     <div className="relative overflow-visible">
-      <label className="text-sm font-semibold text-gray-500">{t('Expiry Date')}</label>
+      <label className="flex items-center justify-between text-sm font-semibold text-gray-500">
+        <span>{t('Expiry Date')}</span>
+        {optional && <span className="text-xs font-normal text-gray-500">{t('Optional')}</span>}
+      </label>
 
       <div
         ref={refs.setReference}

--- a/frontend/src/components/ui/forms/MediaInput.tsx
+++ b/frontend/src/components/ui/forms/MediaInput.tsx
@@ -19,6 +19,18 @@
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import {
+  useFloating,
+  autoUpdate,
+  offset,
+  flip,
+  shift,
+  size,
+  useClick,
+  useDismiss,
+  useInteractions,
+  FloatingPortal,
+} from '@floating-ui/react';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { Search, X, ChevronDown, Loader2, Check } from 'lucide-react';
 import { useState, useRef, useEffect } from 'react';
@@ -32,6 +44,8 @@ interface MediaInputProps {
   onChange: (value: string) => void;
   helpText?: string;
   isMulti?: boolean;
+  optional?: boolean;
+  mediaType?: string;
 }
 
 export default function MediaInput({
@@ -40,18 +54,45 @@ export default function MediaInput({
   onChange,
   helpText,
   isMulti = false,
+  optional = false,
+  mediaType = 'image',
 }: MediaInputProps) {
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
-
   const [nameCache, setNameCache] = useState<Record<string, string>>({});
-
-  const containerRef = useRef<HTMLDivElement>(null);
   const observerTarget = useRef<HTMLDivElement>(null);
 
   const selectedIds = value ? String(value).split(',').filter(Boolean) : [];
+
+  const { refs, floatingStyles, context } = useFloating({
+    open: isOpen,
+    onOpenChange: (open) => {
+      setIsOpen(open);
+      if (!open) {
+        setSearchTerm('');
+      }
+    },
+    placement: 'bottom-start',
+    whileElementsMounted: autoUpdate,
+    middleware: [
+      offset(4),
+      flip(),
+      shift(),
+      size({
+        apply({ rects, elements }) {
+          Object.assign(elements.floating.style, {
+            width: `${rects.reference.width}px`,
+          });
+        },
+      }),
+    ],
+  });
+
+  const click = useClick(context);
+  const dismiss = useDismiss(context);
+  const { getReferenceProps, getFloatingProps } = useInteractions([click, dismiss]);
 
   useEffect(() => {
     const handler = setTimeout(() => {
@@ -60,24 +101,14 @@ export default function MediaInput({
     return () => clearTimeout(handler);
   }, [searchTerm]);
 
-  useEffect(() => {
-    function handleClickOutside(event: MouseEvent) {
-      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
-        setIsOpen(false);
-      }
-    }
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
-
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } = useInfiniteQuery({
-    queryKey: ['libraryMedia', debouncedSearch],
+    queryKey: ['libraryMedia', debouncedSearch, mediaType],
     queryFn: async ({ pageParam = 0, signal }) => {
       return fetchMedia({
         start: pageParam,
         length: 20,
         keyword: debouncedSearch || undefined,
-        type: 'image',
+        type: mediaType || undefined,
         signal,
       });
     },
@@ -148,12 +179,16 @@ export default function MediaInput({
   };
 
   return (
-    <div className="flex flex-col gap-1.5 relative" ref={containerRef}>
-      <label className="text-sm font-semibold text-gray-500">{label}</label>
+    <div className="flex flex-col gap-1.5">
+      <label className="flex items-center justify-between text-sm font-semibold text-gray-500">
+        <span>{label}</span>
+        {optional && <span className="text-xs font-normal text-gray-500">{t('Optional')}</span>}
+      </label>
 
       <div
-        onClick={() => setIsOpen(!isOpen)}
-        className={`flex flex-wrap items-center gap-1.5 py-1.5 px-2 bg-white border rounded-lg min-h-11.25 transition-colors ${
+        ref={refs.setReference}
+        {...getReferenceProps()}
+        className={`flex flex-wrap items-center gap-1.5 py-1.5 px-2 bg-white border rounded-lg min-h-11.25 transition-colors cursor-pointer ${
           isOpen
             ? 'border-xibo-blue-500 ring-1 ring-xibo-blue-500'
             : 'border-gray-200 hover:border-gray-300'
@@ -193,72 +228,82 @@ export default function MediaInput({
 
       {helpText && <p className="text-xs text-gray-500">{helpText}</p>}
 
-      {/* Dropdown Popover */}
-      {isOpen && (
-        <div className="absolute z-50 top-full left-0 mt-0.5 w-full bg-white border border-gray-200 rounded-lg shadow-lg flex flex-col overflow-hidden">
-          <div className="px-3 py-2 text-sm bg-gray-100 text-gray-500 font-semibold uppercase">
-            {t('Select Media')}
-          </div>
-          <div className="p-2">
-            <div className="relative flex-1 flex">
-              <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
-                <Search className="w-4 h-4 text-gray-500" />
+      <FloatingPortal>
+        {isOpen && (
+          <div
+            ref={refs.setFloating}
+            style={floatingStyles}
+            {...getFloatingProps()}
+            className="z-9999 bg-white border border-gray-200 rounded-lg shadow-lg flex flex-col overflow-hidden"
+          >
+            <div className="px-3 py-2 text-sm bg-gray-100 text-gray-500 font-semibold uppercase">
+              {t('Select Media')}
+            </div>
+            <div className="p-2">
+              <div className="relative flex-1 flex">
+                <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
+                  <Search className="w-4 h-4 text-gray-500" />
+                </div>
+                <input
+                  type="text"
+                  placeholder={t('Search')}
+                  value={searchTerm}
+                  onChange={(e) => setSearchTerm(e.target.value)}
+                  className="py-2 px-3 pl-10 block h-11.25 rounded-lg w-full border-gray-200 disabled:opacity-50 disabled:pointer-events-none disabled:bg-gray-200"
+                  autoFocus
+                />
               </div>
-              <input
-                type="text"
-                placeholder={t('Search')}
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-                className="py-2 px-3 pl-10 block h-11.25 rounded-lg w-full border-gray-200 disabled:opacity-50 disabled:pointer-events-none disabled:bg-gray-200"
-                autoFocus
-              />
+            </div>
+
+            <div className="max-h-60 overflow-y-auto p-2">
+              {isLoading && mediaItems.length === 0 ? (
+                <div className="flex justify-center items-center py-4">
+                  <Loader2 className="h-5 w-5 text-gray-400 animate-spin" />
+                </div>
+              ) : mediaItems.length === 0 ? (
+                <div className="py-4 text-center text-sm text-gray-500">{t('No media found.')}</div>
+              ) : (
+                <ul className="flex flex-col gap-0.5">
+                  {mediaItems.map((media) => {
+                    const idString = String(media.mediaId);
+                    const isSelected = selectedIds.includes(idString);
+
+                    return (
+                      <li key={media.mediaId}>
+                        <button
+                          type="button"
+                          onClick={() => handleSelect(idString)}
+                          className={`w-full text-left px-3 py-2 text-sm font-semibold text-gray-800 rounded-md cursor-pointer flex items-center justify-between transition-colors ${
+                            isSelected
+                              ? 'bg-xibo-blue-50 text-xibo-blue-700 font-medium'
+                              : 'text-gray-700 hover:bg-gray-50'
+                          }`}
+                        >
+                          <div className="truncate pr-2">
+                            <span className="truncate">{media.name}</span>
+                          </div>
+                          {isSelected && (
+                            <Check size={16} className="text-xibo-blue-600 shrink-0" />
+                          )}
+                        </button>
+                      </li>
+                    );
+                  })}
+
+                  <div
+                    ref={observerTarget}
+                    className="h-4 w-full flex justify-center items-center mt-2"
+                  >
+                    {isFetchingNextPage && (
+                      <Loader2 className="h-4 w-4 text-gray-400 animate-spin" />
+                    )}
+                  </div>
+                </ul>
+              )}
             </div>
           </div>
-
-          <div className="max-h-60 overflow-y-auto p-2">
-            {isLoading && mediaItems.length === 0 ? (
-              <div className="flex justify-center items-center py-4">
-                <Loader2 className="h-5 w-5 text-gray-400 animate-spin" />
-              </div>
-            ) : mediaItems.length === 0 ? (
-              <div className="py-4 text-center text-sm text-gray-500">{t('No media found.')}</div>
-            ) : (
-              <ul className="flex flex-col gap-0.5">
-                {mediaItems.map((media) => {
-                  const idString = String(media.mediaId);
-                  const isSelected = selectedIds.includes(idString);
-
-                  return (
-                    <li key={media.mediaId}>
-                      <button
-                        type="button"
-                        onClick={() => handleSelect(idString)}
-                        className={`w-full text-left px-3 py-2 text-sm font-semibold text-gray-800 rounded-md cursor-pointer flex items-center justify-between transition-colors ${
-                          isSelected
-                            ? 'bg-xibo-blue-50 text-xibo-blue-700 font-medium'
-                            : 'text-gray-700 hover:bg-gray-50'
-                        }`}
-                      >
-                        <div className="truncate pr-2">
-                          <span className="truncate">{media.name}</span>
-                        </div>
-                        {isSelected && <Check size={16} className="text-xibo-blue-600 shrink-0" />}
-                      </button>
-                    </li>
-                  );
-                })}
-
-                <div
-                  ref={observerTarget}
-                  className="h-4 w-full flex justify-center items-center mt-2"
-                >
-                  {isFetchingNextPage && <Loader2 className="h-4 w-4 text-gray-400 animate-spin" />}
-                </div>
-              </ul>
-            )}
-          </div>
-        </div>
-      )}
+        )}
+      </FloatingPortal>
     </div>
   );
 }

--- a/frontend/src/components/ui/forms/MultiSelectDropdown.tsx
+++ b/frontend/src/components/ui/forms/MultiSelectDropdown.tsx
@@ -57,6 +57,7 @@ interface MultiSelectDropdownProps {
   className?: string;
   showTags?: boolean;
   onDropdownClose?: () => void;
+  optional?: boolean;
 }
 
 export default function MultiSelectDropdown({
@@ -73,6 +74,7 @@ export default function MultiSelectDropdown({
   className,
   showTags = false,
   onDropdownClose,
+  optional = false,
 }: MultiSelectDropdownProps) {
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
@@ -178,7 +180,10 @@ export default function MultiSelectDropdown({
 
   return (
     <div className={twMerge('flex flex-col gap-1 relative w-full', className)}>
-      <label className="text-sm font-semibold text-gray-500 leading-5">{t(label)}</label>
+      <label className="flex items-center justify-between text-sm font-semibold text-gray-500 leading-5">
+        <span>{t(label)}</span>
+        {optional && <span className="text-xs font-normal text-gray-500">{t('Optional')}</span>}
+      </label>
 
       <div
         ref={refs.setReference}

--- a/frontend/src/components/ui/forms/NumberInput.tsx
+++ b/frontend/src/components/ui/forms/NumberInput.tsx
@@ -34,6 +34,7 @@ interface NumberInputProps {
   className?: string;
   disabled?: boolean;
   min?: number;
+  optional?: boolean;
 }
 
 export default function NumberInput({
@@ -47,6 +48,7 @@ export default function NumberInput({
   error,
   disabled = false,
   min = 0,
+  optional = false,
 }: NumberInputProps) {
   const { t } = useTranslation();
   const generatedId = useId();
@@ -54,8 +56,9 @@ export default function NumberInput({
   return (
     <div className="flex flex-col gap-1 w-full">
       {label && (
-        <label htmlFor={generatedId} className="text-sm font-semibold text-gray-500 leading-4.5">
-          {!label ? t('Text') : label}
+        <label htmlFor={generatedId} className="flex items-center justify-between text-sm font-semibold text-gray-500 leading-4.5">
+          <span>{label}</span>
+          {optional && <span className="text-xs font-normal text-gray-500">{t('Optional')}</span>}
         </label>
       )}
       <input

--- a/frontend/src/components/ui/forms/NumberInput.tsx
+++ b/frontend/src/components/ui/forms/NumberInput.tsx
@@ -56,7 +56,10 @@ export default function NumberInput({
   return (
     <div className="flex flex-col gap-1 w-full">
       {label && (
-        <label htmlFor={generatedId} className="flex items-center justify-between text-sm font-semibold text-gray-500 leading-4.5">
+        <label
+          htmlFor={generatedId}
+          className="flex items-center justify-between text-sm font-semibold text-gray-500 leading-4.5"
+        >
           <span>{label}</span>
           {optional && <span className="text-xs font-normal text-gray-500">{t('Optional')}</span>}
         </label>

--- a/frontend/src/components/ui/forms/PublishDateSelect.tsx
+++ b/frontend/src/components/ui/forms/PublishDateSelect.tsx
@@ -45,9 +45,10 @@ export type PublishValue = { type: 'now' } | { type: 'scheduled'; date: Date };
 interface PublishDateSelectProps {
   value?: PublishValue;
   onSelect: (value: PublishValue) => void;
+  optional?: boolean;
 }
 
-export default function PublishDateSelect({ value, onSelect }: PublishDateSelectProps) {
+export default function PublishDateSelect({ value, onSelect, optional = false }: PublishDateSelectProps) {
   const { t } = useTranslation();
   const { user } = useUserContext();
   const timeZone = user?.settings?.defaultTimezone;
@@ -85,7 +86,10 @@ export default function PublishDateSelect({ value, onSelect }: PublishDateSelect
 
   return (
     <div className="relative overflow-visible">
-      <label className="text-sm font-semibold text-gray-500">{t('Expiry Date')}</label>
+      <label className="flex items-center justify-between text-sm font-semibold text-gray-500">
+        <span>{t('Publish Date')}</span>
+        {optional && <span className="text-xs font-normal text-gray-500">{t('Optional')}</span>}
+      </label>
 
       <div
         ref={refs.setReference}

--- a/frontend/src/components/ui/forms/PublishDateSelect.tsx
+++ b/frontend/src/components/ui/forms/PublishDateSelect.tsx
@@ -48,7 +48,11 @@ interface PublishDateSelectProps {
   optional?: boolean;
 }
 
-export default function PublishDateSelect({ value, onSelect, optional = false }: PublishDateSelectProps) {
+export default function PublishDateSelect({
+  value,
+  onSelect,
+  optional = false,
+}: PublishDateSelectProps) {
   const { t } = useTranslation();
   const { user } = useUserContext();
   const timeZone = user?.settings?.defaultTimezone;

--- a/frontend/src/components/ui/forms/SelectDropdown.tsx
+++ b/frontend/src/components/ui/forms/SelectDropdown.tsx
@@ -64,6 +64,7 @@ interface SelectDropdownProps {
   hasMore?: boolean;
   isLoadingMore?: boolean;
   clearable?: boolean;
+  optional?: boolean;
 }
 
 export default function SelectDropdown({
@@ -87,6 +88,7 @@ export default function SelectDropdown({
   hasMore,
   isLoadingMore,
   clearable,
+  optional = false,
 }: SelectDropdownProps) {
   const { t } = useTranslation();
 
@@ -155,7 +157,10 @@ export default function SelectDropdown({
   return (
     <div className={twMerge('relative overflow-visible', className)}>
       {label && (
-        <label className="text-sm font-semibold text-gray-500 leading-5">{label && t(label)}</label>
+        <label className="flex items-center justify-between text-sm font-semibold text-gray-500 leading-5">
+          <span>{t(label)}</span>
+          {optional && <span className="text-xs font-normal text-gray-500">{t('Optional')}</span>}
+        </label>
       )}
 
       <div

--- a/frontend/src/components/ui/forms/SelectFolder.tsx
+++ b/frontend/src/components/ui/forms/SelectFolder.tsx
@@ -48,6 +48,7 @@ interface SelectFolderProps {
   placeholder?: string;
   onSelect: (folder: { id: number; text: string } | null) => void;
   onAction?: (action: FolderAction, folder: Folder) => void;
+  optional?: boolean;
 }
 
 export default function SelectFolder({
@@ -56,6 +57,7 @@ export default function SelectFolder({
   placeholder,
   onSelect,
   onAction,
+  optional = false,
 }: SelectFolderProps) {
   const { t } = useTranslation();
   const { user } = useUserContext();
@@ -201,8 +203,9 @@ export default function SelectFolder({
 
   return (
     <div className="relative">
-      <label className="block text-sm font-semibold text-gray-500 mb-1">
-        {t('Select folder location')}
+      <label className="flex items-center justify-between text-sm font-semibold text-gray-500 mb-1">
+        <span>{t('Select folder location')}</span>
+        {optional && <span className="text-xs font-normal text-gray-500">{t('Optional')}</span>}
       </label>
 
       <div

--- a/frontend/src/components/ui/forms/Slider.tsx
+++ b/frontend/src/components/ui/forms/Slider.tsx
@@ -20,6 +20,7 @@
  */
 
 import { useId } from 'react';
+import { useTranslation } from 'react-i18next';
 
 interface SliderProps {
   min: number;
@@ -32,6 +33,7 @@ interface SliderProps {
   rightLabel?: string;
   displayValue?: string;
   disabled?: boolean;
+  optional?: boolean;
 }
 
 export default function Slider({
@@ -45,14 +47,17 @@ export default function Slider({
   rightLabel,
   displayValue,
   disabled = false,
+  optional = false,
 }: SliderProps) {
   const id = useId();
+  const { t } = useTranslation();
 
   return (
     <div className="flex flex-col gap-1 w-full">
       {label && (
-        <label htmlFor={id} className="text-sm font-semibold text-gray-500 leading-4.5">
-          {label}
+        <label htmlFor={id} className="flex items-center justify-between text-sm font-semibold text-gray-500 leading-4.5">
+          <span>{label}</span>
+          {optional && <span className="text-xs font-normal text-gray-500">{t('Optional')}</span>}
         </label>
       )}
       <input

--- a/frontend/src/components/ui/forms/Slider.tsx
+++ b/frontend/src/components/ui/forms/Slider.tsx
@@ -55,7 +55,10 @@ export default function Slider({
   return (
     <div className="flex flex-col gap-1 w-full">
       {label && (
-        <label htmlFor={id} className="flex items-center justify-between text-sm font-semibold text-gray-500 leading-4.5">
+        <label
+          htmlFor={id}
+          className="flex items-center justify-between text-sm font-semibold text-gray-500 leading-4.5"
+        >
           <span>{label}</span>
           {optional && <span className="text-xs font-normal text-gray-500">{t('Optional')}</span>}
         </label>

--- a/frontend/src/components/ui/forms/Switch.tsx
+++ b/frontend/src/components/ui/forms/Switch.tsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useEffect, useId, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface SwitchProps {
+  label?: string;
+  checked: boolean;
+  helpText?: string;
+  optional?: boolean;
+  disabled?: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+export default function Switch({
+  label,
+  checked,
+  helpText,
+  optional = false,
+  disabled = false,
+  onChange,
+}: SwitchProps) {
+  const { t } = useTranslation();
+  const id = useId();
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => { setMounted(true); }, []);
+
+  return (
+    <div className="flex flex-col gap-1 w-full">
+      {label && (
+        <label
+          htmlFor={id}
+          className="flex items-center justify-between text-sm font-semibold text-gray-500 leading-4.5"
+        >
+          <span>{label}</span>
+          {optional && <span className="text-xs font-normal text-gray-500">{t('Optional')}</span>}
+        </label>
+      )}
+      <div className="flex items-center gap-3">
+        <span className={`text-sm font-medium ${checked ? 'text-gray-400' : 'text-gray-700'}`}>
+          {t('Off')}
+        </span>
+        <button
+          id={id}
+          type="button"
+          role="switch"
+          aria-checked={checked}
+          disabled={disabled}
+          onClick={() => onChange(!checked)}
+          className={`relative inline-flex h-9.5 w-15.5 border p-0.5 shrink-0 cursor-pointer items-center rounded-full transition-colors duration-200 ease-in-out focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ${
+            checked ? 'bg-blue-100 border-blue-300' : 'bg-gray-100 border-gray-300'
+          }`}
+        >
+          <span
+            className={`inline-flex h-8 w-8 transform items-center justify-center rounded-full shadow-sm ${mounted ? 'transition-all duration-200 ease-in-out' : ''} ${
+              checked
+                ? 'translate-x-6 bg-xibo-blue-600'
+                : 'translate-x-0 bg-gray-200 border-xibo-blue-200 border'
+            }`}
+          >
+            {checked ? (
+              <svg
+                className="h-3.5 w-3.5 text-white"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={3}
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+              </svg>
+            ) : (
+              <svg
+                className="h-3.5 w-3.5 text-xibo-blue-500"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                strokeWidth={3}
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            )}
+          </span>
+        </button>
+        <span className={`text-sm font-medium ${checked ? 'text-blue-600' : 'text-gray-400'}`}>
+          {t('On')}
+        </span>
+      </div>
+      {helpText && <p className="text-xs text-gray-400 mt-1">{helpText}</p>}
+    </div>
+  );
+}

--- a/frontend/src/components/ui/forms/Switch.tsx
+++ b/frontend/src/components/ui/forms/Switch.tsx
@@ -42,7 +42,9 @@ export default function Switch({
   const { t } = useTranslation();
   const id = useId();
   const [mounted, setMounted] = useState(false);
-  useEffect(() => { setMounted(true); }, []);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   return (
     <div className="flex flex-col gap-1 w-full">

--- a/frontend/src/components/ui/forms/TagInput.tsx
+++ b/frontend/src/components/ui/forms/TagInput.tsx
@@ -37,6 +37,7 @@ interface TagInputProps {
   prefix?: React.ReactNode;
   suffix?: React.ReactNode;
   error?: string;
+  optional?: boolean;
 }
 
 function TagInput({
@@ -50,6 +51,7 @@ function TagInput({
   prefix,
   suffix,
   error,
+  optional = false,
 }: TagInputProps) {
   const { t } = useTranslation();
   const [input, setInput] = useState('');
@@ -96,8 +98,9 @@ function TagInput({
 
   return (
     <div className={twMerge('flex flex-col gap-1 relative w-full', className)}>
-      <label className="text-sm font-semibold text-gray-500 leading-5">
-        {!label ? t('Tags') : label}
+      <label className="flex items-center justify-between text-sm font-semibold text-gray-500 leading-5">
+        <span>{!label ? t('Tags') : label}</span>
+        {optional && <span className="text-xs font-normal text-gray-500">{t('Optional')}</span>}
       </label>
 
       <div

--- a/frontend/src/components/ui/forms/TextInput.tsx
+++ b/frontend/src/components/ui/forms/TextInput.tsx
@@ -40,6 +40,7 @@ interface TextInputProps {
   multiline?: boolean;
   rows?: number;
   type?: React.HTMLInputTypeAttribute;
+  optional?: boolean;
 }
 
 export default function TextInput({
@@ -59,6 +60,7 @@ export default function TextInput({
   multiline = false,
   rows,
   type,
+  optional = false,
 }: TextInputProps) {
   const { t } = useTranslation();
   const generatedId = useId();
@@ -68,9 +70,13 @@ export default function TextInput({
       {label && (
         <label
           htmlFor={generatedId}
-          className={twMerge('text-sm font-semibold text-gray-500 leading-4.5', labelClassName)}
+          className={twMerge(
+            'flex items-center justify-between text-sm font-semibold text-gray-500 leading-4.5',
+            labelClassName,
+          )}
         >
-          {label}
+          <span>{label}</span>
+          {optional && <span className="text-xs font-normal text-gray-500">{t('Optional')}</span>}
         </label>
       )}
       <div

--- a/frontend/src/components/ui/forms/TimePickerInput.tsx
+++ b/frontend/src/components/ui/forms/TimePickerInput.tsx
@@ -47,6 +47,7 @@ interface TimePickerInputProps {
   error?: string;
   className?: string;
   timeFormat?: TimeFormat;
+  optional?: boolean;
 }
 
 function pad(n: number): string {
@@ -171,6 +172,7 @@ export default function TimePickerInput({
   error,
   className,
   timeFormat = 'HH:mm:ss',
+  optional = false,
 }: TimePickerInputProps) {
   const { t } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
@@ -189,7 +191,10 @@ export default function TimePickerInput({
 
   return (
     <div className={twMerge('flex flex-col gap-1.5 relative', className)}>
-      <label className="text-sm font-semibold text-gray-500">{label}</label>
+      <label className="flex items-center justify-between text-sm font-semibold text-gray-500">
+        <span>{label}</span>
+        {optional && <span className="text-xs font-normal text-gray-500">{t('Optional')}</span>}
+      </label>
 
       <div
         ref={refs.setReference}

--- a/frontend/src/components/ui/forms/TimezoneSelect.tsx
+++ b/frontend/src/components/ui/forms/TimezoneSelect.tsx
@@ -83,6 +83,7 @@ interface TimezoneSelectProps {
   onChange: (value: string) => void;
   helpText?: string;
   placeholder?: string;
+  optional?: boolean;
 }
 
 export default function TimezoneSelect({
@@ -91,6 +92,7 @@ export default function TimezoneSelect({
   onChange,
   helpText,
   placeholder = ' ',
+  optional = false,
 }: TimezoneSelectProps) {
   const { t } = useTranslation();
 
@@ -104,6 +106,7 @@ export default function TimezoneSelect({
       helpText={helpText}
       searchable
       searchPlaceholder={t('Search timezones…')}
+      optional={optional}
     />
   );
 }

--- a/frontend/src/components/ui/table/DataTable.tsx
+++ b/frontend/src/components/ui/table/DataTable.tsx
@@ -75,6 +75,7 @@ interface DataTableProps<TData, TValue> {
   columnVisibility?: VisibilityState;
   onColumnVisibilityChange?: OnChangeFn<VisibilityState>;
   noResultsCustom?: React.ReactNode;
+  tableLabel?: string;
 }
 
 const getCommonPinningStyles = <TData, TValue>(column: Column<TData, TValue>): CSSProperties => {
@@ -125,6 +126,7 @@ export function DataTable<TData, TValue>({
   columnVisibility,
   onColumnVisibilityChange,
   noResultsCustom,
+  tableLabel,
 }: DataTableProps<TData, TValue>) {
   const { t } = useTranslation();
 
@@ -245,9 +247,9 @@ export function DataTable<TData, TValue>({
       {!hideToolbar && (
         <div className="flex justify-between data-table-header flex-none mt-5">
           <div className="flex items-center gap-3">
-            {viewMode && (
+            {(viewMode || tableLabel) && (
               <div className="text-gray-500 font-sans text-sm font-semibold leading-normal tracking-tight uppercase">
-                {t('Table View')}
+                {tableLabel ? tableLabel : t('Table View')}
               </div>
             )}
             {selectedCount > 0 && bulkActions.length > 0 && (

--- a/frontend/src/config/appRoutes.ts
+++ b/frontend/src/config/appRoutes.ts
@@ -208,7 +208,28 @@ export const APP_ROUTES: AppRoute[] = [
       {
         path: 'menu-boards',
         labelKey: 'Menu Boards',
-        externalURL: '/menuboard/view',
+        lazy: () =>
+          import('@/pages/Library/MenuBoard/MenuBoards').then((m) => ({ Component: m.default })),
+        feature: 'menuBoard.view',
+      },
+      {
+        path: 'menu-boards/:menuId/categories',
+        labelKey: 'Menu Board Categories',
+        hideFromMenu: true,
+        lazy: () =>
+          import('@/pages/Library/MenuBoard/subPages/Categories/MenuBoardCategories').then((m) => ({
+            Component: m.default,
+          })),
+        feature: 'menuBoard.view',
+      },
+      {
+        path: 'menu-boards/:menuId/categories/:categoryId/products',
+        labelKey: 'Menu Board Products',
+        hideFromMenu: true,
+        lazy: () =>
+          import('@/pages/Library/MenuBoard/subPages/Products/MenuBoardProducts').then((m) => ({
+            Component: m.default,
+          })),
         feature: 'menuBoard.view',
       },
     ],

--- a/frontend/src/pages/Design/Layouts/components/LayoutPreviewer.tsx
+++ b/frontend/src/pages/Design/Layouts/components/LayoutPreviewer.tsx
@@ -19,15 +19,15 @@
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {FolderInput, Info, UserPlus2, X} from 'lucide-react';
-import {useState} from 'react';
-import {useTranslation} from 'react-i18next';
+import { FolderInput, Info, UserPlus2, X } from 'lucide-react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 
-import {LayoutInfoPanel} from './LayoutInfoPannel';
+import { LayoutInfoPanel } from './LayoutInfoPannel';
 
-import {useKeydown} from '@/hooks/useKeydown';
-import {useOwner} from '@/hooks/useOwner';
-import type {Layout} from '@/types/layout';
+import { useKeydown } from '@/hooks/useKeydown';
+import { useOwner } from '@/hooks/useOwner';
+import type { Layout } from '@/types/layout';
 
 interface LayoutPreviewerProps {
   layoutId: number | null;
@@ -101,7 +101,8 @@ export default function LayoutPreviewer({
       {/* Preview */}
       <div className="flex flex-1 min-h-0">
         <div className="flex-1 w-full p-4 flex justify-center items-center overflow-hidden min-h-0">
-          <iframe sandbox="allow-scripts"
+          <iframe
+            sandbox="allow-scripts"
             src={layoutData?.previewUrl ?? `/layout/preview/${layoutId}`}
             title={`Layout ${layoutId}`}
             className="w-full h-full min-h-125 rounded shadow-md border-0"

--- a/frontend/src/pages/Displays/DisplayGroup/__tests__/mocks/displayGroupApi.ts
+++ b/frontend/src/pages/Displays/DisplayGroup/__tests__/mocks/displayGroupApi.ts
@@ -21,9 +21,10 @@
 
 import { vi } from 'vitest';
 
+import { useDisplayGroupData } from '../../hooks/useDisplayGroupData';
+
 import { fetchDisplayGroups } from '@/services/displayGroupApi';
 import type { FetchDisplayGroupsResponse } from '@/services/displayGroupApi';
-import { useDisplayGroupData } from '../../hooks/useDisplayGroupData';
 
 export type UseDisplayGroupReturn = ReturnType<typeof useDisplayGroupData>;
 

--- a/frontend/src/pages/Displays/DisplayGroup/components/AddAndEditDisplayGroupModal.tsx
+++ b/frontend/src/pages/Displays/DisplayGroup/components/AddAndEditDisplayGroupModal.tsx
@@ -315,7 +315,7 @@ export default function AddAndEditDisplayGroupModal({
     >
       {/* Tab bar */}
       <div className="flex flex-col h-full overflow-y-hidden overflow-x-visible px-6">
-        <nav className="flex overflow-x-auto border-b border-gray-200" aria-label="Tabs">
+        <nav className="flex overflow-x-auto" aria-label="Tabs">
           {(['general', 'reference'] as const).map((tab) => (
             <button
               key={tab}

--- a/frontend/src/pages/Displays/DisplayGroup/components/ManageMembersModal.tsx
+++ b/frontend/src/pages/Displays/DisplayGroup/components/ManageMembersModal.tsx
@@ -315,7 +315,7 @@ export default function ManageMembersModal({
     >
       {/* Tab bar */}
       <div className="flex flex-col h-full overflow-y-hidden overflow-x-visible px-6">
-        <nav className="flex overflow-x-auto border-b border-gray-200" aria-label="Tabs">
+        <nav className="flex overflow-x-auto" aria-label="Tabs">
           {tabs.map((tab) => (
             <button
               key={tab.key}

--- a/frontend/src/pages/Displays/DisplayProfile/components/fields/LgSsspFields.tsx
+++ b/frontend/src/pages/Displays/DisplayProfile/components/fields/LgSsspFields.tsx
@@ -19,20 +19,20 @@
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import type {TFunction} from 'i18next';
-import {Minus, Plus} from 'lucide-react';
+import type { TFunction } from 'i18next';
+import { Minus, Plus } from 'lucide-react';
 import React from 'react';
 
-import {DynamicSettingField} from './DynamicSettingField';
-import {getFieldMetaForType} from './fieldMetadata';
+import { DynamicSettingField } from './DynamicSettingField';
+import { getFieldMetaForType } from './fieldMetadata';
 
 import Button from '@/components/ui/Button';
 import Checkbox from '@/components/ui/forms/Checkbox';
 import SelectDropdown from '@/components/ui/forms/SelectDropdown';
 import Slider from '@/components/ui/forms/Slider';
 import TimePickerInput from '@/components/ui/forms/TimePickerInput';
-import type {PlayerSoftware} from '@/services/playerSoftwareApi';
-import type {Daypart} from '@/types/daypart';
+import type { PlayerSoftware } from '@/services/playerSoftwareApi';
+import type { Daypart } from '@/types/daypart';
 
 export interface TimerRow {
   id: number;

--- a/frontend/src/pages/Displays/DisplayProfile/components/fields/fieldMetadata.ts
+++ b/frontend/src/pages/Displays/DisplayProfile/components/fields/fieldMetadata.ts
@@ -19,9 +19,9 @@
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import type {TFunction} from 'i18next';
+import type { TFunction } from 'i18next';
 
-import type {DisplayProfileType} from '@/types/displayProfile';
+import type { DisplayProfileType } from '@/types/displayProfile';
 
 export const CHECKBOX_FIELDS_BY_TYPE: Record<DisplayProfileType, Set<string>> = {
   android: new Set([

--- a/frontend/src/pages/Displays/Displays/components/EditDisplayModal.tsx
+++ b/frontend/src/pages/Displays/Displays/components/EditDisplayModal.tsx
@@ -42,6 +42,7 @@ import NumberInput from '@/components/ui/forms/NumberInput';
 import SelectDropdown from '@/components/ui/forms/SelectDropdown';
 import type { SelectOption } from '@/components/ui/forms/SelectDropdown';
 import SelectFolder from '@/components/ui/forms/SelectFolder';
+import Switch from '@/components/ui/forms/Switch';
 import TagInput from '@/components/ui/forms/TagInput';
 import TextInput from '@/components/ui/forms/TextInput';
 import TimezoneSelect from '@/components/ui/forms/TimezoneSelect';
@@ -865,10 +866,7 @@ export default function EditDisplayModal({
       ]}
     >
       <div className="flex flex-col h-full overflow-y-hidden overflow-x-visible px-4">
-        <nav
-          className="flex px-4 overflow-x-auto shrink-0 border-b border-gray-200"
-          aria-label="Tabs"
-        >
+        <nav className="flex px-4 overflow-x-auto shrink-0" aria-label="Tabs">
           <button type="button" className={tab('general')} onClick={() => setActiveTab('general')}>
             {t('General')}
           </button>
@@ -955,16 +953,6 @@ export default function EditDisplayModal({
                 onChange={(tags) => set('tags', tags)}
               />
               <SelectDropdown
-                label={t('Authorise display?')}
-                helpText={t('Use one of the available slots for this display?')}
-                value={String(draft.licensed)}
-                options={[
-                  { value: '0', label: t('No') },
-                  { value: '1', label: t('Yes') },
-                ]}
-                onSelect={(v) => set('licensed', Number(v))}
-              />
-              <SelectDropdown
                 label={t('Default Layout')}
                 helpText={t(
                   'Set the Default Layout to use when no other content is scheduled to this Display. This will override the global Default Layout as set in CMS Administrator Settings. If left blank a global Default Layout will be automatically set for this Display.',
@@ -980,6 +968,12 @@ export default function EditDisplayModal({
                 searchable
                 searchPlaceholder={t('Search layouts...')}
                 onSearch={(v) => setLayoutSearch(v)}
+              />
+              <Switch
+                label={t('Authorise display?')}
+                helpText={t('Use one of the available slots for this display?')}
+                checked={draft.licensed === 1}
+                onChange={(v) => set('licensed', v ? 1 : 0)}
               />
             </>
           )}

--- a/frontend/src/pages/Library/Dataset/subPages/Columns/DatasetColumns.tsx
+++ b/frontend/src/pages/Library/Dataset/subPages/Columns/DatasetColumns.tsx
@@ -58,7 +58,7 @@ export default function DatasetColumns() {
     debouncedFilter,
     setGlobalFilter,
     isHydrated,
-  } = useTableState<Record<string, string>>(`dataset_columns_${datasetId}`, {
+  } = useTableState<Record<string, string>>('dataset_columns', {
     pagination: { pageIndex: 0, pageSize: 10 },
     sorting: [],
     columnVisibility: {

--- a/frontend/src/pages/Library/Dataset/subPages/Data/DatasetData.tsx
+++ b/frontend/src/pages/Library/Dataset/subPages/Data/DatasetData.tsx
@@ -67,7 +67,7 @@ export default function DatasetData() {
     filterInputs,
     setFilterInputs,
     isHydrated,
-  } = useTableState<Record<string, string>>(`dataset_data_${datasetId}`, {
+  } = useTableState<Record<string, string>>('dataset_data', {
     pagination: { pageIndex: 0, pageSize: 10 },
     sorting: [],
     columnVisibility: {},

--- a/frontend/src/pages/Library/Dataset/subPages/Rss/DatasetRss.tsx
+++ b/frontend/src/pages/Library/Dataset/subPages/Rss/DatasetRss.tsx
@@ -58,7 +58,7 @@ export default function DatasetRss() {
     debouncedFilter,
     setGlobalFilter,
     isHydrated,
-  } = useTableState<Record<string, string>>(`dataset_rss_${datasetId}`, {
+  } = useTableState<Record<string, string>>('dataset_rss', {
     pagination: { pageIndex: 0, pageSize: 10 },
     sorting: [],
     columnVisibility: {

--- a/frontend/src/pages/Library/Dataset/subPages/Rss/components/AddAndEditDatasetRssModal.tsx
+++ b/frontend/src/pages/Library/Dataset/subPages/Rss/components/AddAndEditDatasetRssModal.tsx
@@ -295,7 +295,7 @@ export function AddAndEditDatasetRssModal({
     >
       <div className="flex flex-col h-full overflow-y-hidden overflow-x-visible px-4">
         <nav
-          className="flex px-4 overflow-x-auto shrink-0 border-b border-gray-200"
+          className="flex px-4 overflow-x-auto shrink-0"
           aria-label="Tabs"
         >
           <button

--- a/frontend/src/pages/Library/Dataset/subPages/Rss/components/AddAndEditDatasetRssModal.tsx
+++ b/frontend/src/pages/Library/Dataset/subPages/Rss/components/AddAndEditDatasetRssModal.tsx
@@ -294,10 +294,7 @@ export function AddAndEditDatasetRssModal({
       ]}
     >
       <div className="flex flex-col h-full overflow-y-hidden overflow-x-visible px-4">
-        <nav
-          className="flex px-4 overflow-x-auto shrink-0"
-          aria-label="Tabs"
-        >
+        <nav className="flex px-4 overflow-x-auto shrink-0" aria-label="Tabs">
           <button
             type="button"
             className={getTabClass('general')}

--- a/frontend/src/pages/Library/Media/components/MediaPreviewer.tsx
+++ b/frontend/src/pages/Library/Media/components/MediaPreviewer.tsx
@@ -36,7 +36,7 @@ interface MediaPreviewerProps {
   fileName?: string | undefined;
   onMove?: () => void;
   onShare?: (id: number) => void;
-  onDownload: () => void;
+  onDownload?: () => void;
   onClose: () => void;
   mediaData?: Media | null;
   folderName?: string;
@@ -58,6 +58,7 @@ export default function MediaPreviewer({
   const [showInfoPanel, setShowInfoPanel] = useState(false);
   const activeUrlRef = useRef<string | null>(null);
   const [url, setUrl] = useState<string | null>(null);
+  const [resolvedType, setResolvedType] = useState<string | undefined>(mediaType ?? undefined);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -76,6 +77,7 @@ export default function MediaPreviewer({
   useEffect(() => {
     if (!mediaId) {
       revokeUrl();
+      setResolvedType(undefined);
       setShowInfoPanel(false);
       return;
     }
@@ -90,13 +92,28 @@ export default function MediaPreviewer({
       try {
         const rawBlob = await fetchMediaBlob(mediaId);
 
-        if (!isMounted) return;
+        if (!isMounted) {
+          return;
+        }
+
+        const detected =
+          mediaType ??
+          (rawBlob.type.startsWith('video/')
+            ? 'video'
+            : rawBlob.type.startsWith('audio/')
+              ? 'audio'
+              : rawBlob.type === 'application/pdf'
+                ? 'pdf'
+                : rawBlob.type.startsWith('image/')
+                  ? 'image'
+                  : undefined);
+        setResolvedType(detected);
 
         let mimeType = rawBlob.type;
 
-        if (mediaType === 'pdf') {
+        if (detected === 'pdf') {
           mimeType = 'application/pdf';
-        } else if (mediaType === 'video') {
+        } else if (detected === 'video') {
           mimeType = 'video/mp4';
         }
         const finalBlob = new Blob([rawBlob], { type: mimeType });
@@ -159,20 +176,24 @@ export default function MediaPreviewer({
               <UserPlus2 className="p-1" />
             </button>
           )}
-          <button
-            onClick={onDownload}
-            className="flex justify-center items-center cursor-pointer rounded-lg hover:bg-white/10"
-            title={t('Download')}
-          >
-            <Download className="p-1" />
-          </button>
-          <button
-            onClick={() => setShowInfoPanel((prev) => !prev)}
-            className="flex justify-center items-center cursor-pointer rounded-lg hover:bg-white/10"
-            title={t('Details')}
-          >
-            <Info className="p-1" />
-          </button>
+          {onDownload && (
+            <button
+              onClick={onDownload}
+              className="flex justify-center items-center cursor-pointer rounded-lg hover:bg-white/10"
+              title={t('Download')}
+            >
+              <Download className="p-1" />
+            </button>
+          )}
+          {mediaData && (
+            <button
+              onClick={() => setShowInfoPanel((prev) => !prev)}
+              className="flex justify-center items-center cursor-pointer rounded-lg hover:bg-white/10"
+              title={t('Details')}
+            >
+              <Info className="p-1" />
+            </button>
+          )}
         </div>
       </div>
 
@@ -187,19 +208,19 @@ export default function MediaPreviewer({
             <div className="text-red-500 bg-red-50 p-4 rounded">{error}</div>
           ) : url ? (
             <>
-              {mediaType === 'video' ? (
+              {resolvedType === 'video' ? (
                 <video src={url} controls className="max-h-full max-w-full shadow-md" autoPlay />
-              ) : mediaType === 'image' ? (
+              ) : resolvedType === 'image' ? (
                 <img
                   src={url}
                   alt={fileName}
                   className="max-w-full max-h-full object-contain shadow-md"
                 />
-              ) : mediaType === 'audio' ? (
+              ) : resolvedType === 'audio' ? (
                 <div className="flex items-center align-middle justify-center w-2/3 max-w-xl h-full flex-col gap-4">
                   <audio src={url} controls autoPlay className="w-full" />
                 </div>
-              ) : mediaType === 'pdf' ? (
+              ) : resolvedType === 'pdf' ? (
                 <iframe
                   src={url}
                   title={fileName}

--- a/frontend/src/pages/Library/MenuBoard/MenuBoardConfig.tsx
+++ b/frontend/src/pages/Library/MenuBoard/MenuBoardConfig.tsx
@@ -1,0 +1,257 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type { ColumnDef } from '@tanstack/react-table';
+import type { TFunction } from 'i18next';
+import { CopyCheck, Edit, FolderInput, Trash2, UserPlus2 } from 'lucide-react';
+import { type ComponentProps } from 'react';
+
+import type { FilterConfigItem } from '@/components/ui/FilterInputs';
+import type { DataTableBulkAction } from '@/components/ui/table/DataTableBulkActions';
+import { TextCell, ActionsCell } from '@/components/ui/table/cells';
+import { getCommonFormOptions } from '@/config/commonForms';
+import type { MenuBoard } from '@/types/menuBoard';
+import type { ActionItem, BaseModalType } from '@/types/table';
+import { formatDateTime } from '@/utils/date';
+
+export interface MenuBoardFilterInput {
+  menuId: string;
+  code: string;
+  userId: string;
+  lastModified: string;
+}
+
+export type ModalType = BaseModalType | null;
+
+export const INITIAL_FILTER_STATE: MenuBoardFilterInput = {
+  menuId: '',
+  userId: '',
+  code: '',
+  lastModified: '',
+};
+
+export const getBaseFilterKeys = (t: TFunction): FilterConfigItem<MenuBoardFilterInput>[] => [
+  {
+    label: t('Menu Board ID'),
+    placeholder: t('Enter ID'),
+    name: 'menuId',
+    type: 'number',
+  },
+  {
+    label: t('Code'),
+    placeholder: t('Enter Code'),
+    name: 'code',
+    type: 'text',
+  },
+  {
+    label: t('Owner'),
+    name: 'userId',
+    className: '',
+    shouldTranslateOptions: false,
+    showAllOption: false,
+    options: [{ label: t('Select Owner'), value: null }],
+  },
+  {
+    label: t('Last Modified'),
+    name: 'lastModified',
+    className: '',
+    shouldTranslateOptions: true,
+    showAllOption: false,
+    allowCustomRange: true,
+    options: getCommonFormOptions(t).lastModifiedFilter,
+  },
+];
+
+export interface MenuBoardActionsProps {
+  t: TFunction;
+  onDelete: (id: number) => void;
+  openAddEditModal: (row: MenuBoard) => void;
+  openShareModal?: (id: number) => void;
+  openMoveModal?: (row: MenuBoard) => void;
+  copyMenuBoard?: (id: number) => void;
+  onNavigate: (path: string) => void;
+}
+
+export const getMenuBoardItemActions = ({
+  t,
+  onDelete,
+  openAddEditModal,
+  openShareModal,
+  openMoveModal,
+  copyMenuBoard,
+  onNavigate,
+}: MenuBoardActionsProps): ((menuBoard: MenuBoard) => ActionItem[]) => {
+  return (menuBoard: MenuBoard) => [
+    // Quick Actions
+    {
+      label: t('Edit'),
+      icon: Edit,
+      onClick: () => openAddEditModal(menuBoard),
+      isQuickAction: true,
+      variant: 'primary' as const,
+    },
+
+    // Dropdown Menu Actions
+    {
+      label: t('Edit'),
+      icon: Edit,
+      onClick: () => openAddEditModal(menuBoard),
+    },
+    {
+      label: t('Make a Copy'),
+      icon: CopyCheck,
+      onClick: () => copyMenuBoard && copyMenuBoard(menuBoard.menuId),
+    },
+    {
+      label: t('Move'),
+      icon: FolderInput,
+      onClick: () => openMoveModal && openMoveModal(menuBoard),
+    },
+    {
+      label: t('Share'),
+      icon: UserPlus2,
+      onClick: () => openShareModal && openShareModal(menuBoard.menuId),
+    },
+    { isSeparator: true },
+    {
+      label: t('View Categories'),
+      isNavigation: true,
+      onClick: () => {
+        onNavigate(`/library/menu-boards/${menuBoard.menuId}/categories`);
+      },
+    },
+    { isSeparator: true },
+    {
+      label: t('Delete'),
+      icon: Trash2,
+      onClick: () => onDelete(menuBoard.menuId),
+      variant: 'danger' as const,
+    },
+  ];
+};
+
+export const getMenuBoardColumns = (props: MenuBoardActionsProps): ColumnDef<MenuBoard>[] => {
+  const { t } = props;
+  const getActions = getMenuBoardItemActions(props);
+  return [
+    {
+      accessorKey: 'menuId',
+      header: t('ID'),
+      size: 60,
+      cell: (info) => <TextCell>{info.getValue<number>()}</TextCell>,
+    },
+    {
+      accessorKey: 'name',
+      header: t('Name'),
+      size: 150,
+      enableHiding: false,
+      cell: (info) => <TextCell weight="bold">{info.getValue<string>()}</TextCell>,
+    },
+    {
+      accessorKey: 'description',
+      header: t('Description'),
+      size: 150,
+      cell: (info) => <TextCell>{info.getValue<string>()}</TextCell>,
+    },
+    {
+      accessorKey: 'code',
+      header: t('Code'),
+      size: 100,
+      cell: (info) => <TextCell>{info.getValue<string>()}</TextCell>,
+    },
+    {
+      accessorKey: 'owner',
+      header: t('Owner'),
+      size: 150,
+      cell: (info) => <TextCell>{info.getValue<string>()}</TextCell>,
+    },
+    {
+      accessorKey: 'groupsWithPermissions',
+      enableSorting: false,
+      header: t('Sharing'),
+      size: 120,
+      cell: (info) => {
+        const groups = info.getValue() as string;
+        return <TextCell className="italic text-gray-500">{groups || t('Private')}</TextCell>;
+      },
+    },
+    {
+      accessorKey: 'modifiedDt',
+      header: t('Modified'),
+      size: 160,
+      cell: (info) => {
+        const ts = info.getValue<number>();
+        return <TextCell>{ts ? formatDateTime(new Date(ts * 1000)) : ''}</TextCell>;
+      },
+    },
+    {
+      id: 'tableActions',
+      header: '',
+      size: 120,
+      minSize: 120,
+      maxSize: 120,
+      enableHiding: false,
+      enableResizing: false,
+      cell: ({ row }) => (
+        <ActionsCell
+          row={row}
+          actions={getActions(row.original) as ComponentProps<typeof ActionsCell>['actions']}
+        />
+      ),
+    },
+  ];
+};
+
+interface GetBulkActionsProps {
+  t: TFunction;
+  onDelete: () => void;
+  onMove?: () => void;
+  onShare: () => void;
+}
+
+export const getBulkActions = ({
+  t,
+  onDelete,
+  onMove,
+  onShare,
+}: GetBulkActionsProps): DataTableBulkAction<MenuBoard>[] => {
+  return [
+    ...(onMove
+      ? [
+          {
+            label: t('Move'),
+            icon: FolderInput,
+            onClick: onMove,
+          },
+        ]
+      : []),
+    {
+      label: t('Share'),
+      icon: UserPlus2,
+      onClick: onShare,
+    },
+    {
+      label: t('Delete Selected'),
+      icon: Trash2,
+      onClick: onDelete,
+    },
+  ];
+};

--- a/frontend/src/pages/Library/MenuBoard/MenuBoards.tsx
+++ b/frontend/src/pages/Library/MenuBoard/MenuBoards.tsx
@@ -358,9 +358,7 @@ export default function MenuBoards() {
         <div className="min-h-0 flex flex-col">
           {!isHydrated ? (
             <div className="flex-1 flex items-center justify-center bg-gray-50 animate-pulse rounded-lg border border-gray-200">
-              <span className="text-gray-400 font-medium">
-                {t('Loading your preferences...')}
-              </span>
+              <span className="text-gray-400 font-medium">{t('Loading your preferences...')}</span>
             </div>
           ) : (
             <DataTable

--- a/frontend/src/pages/Library/MenuBoard/MenuBoards.tsx
+++ b/frontend/src/pages/Library/MenuBoard/MenuBoards.tsx
@@ -1,0 +1,419 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import type { RowSelectionState } from '@tanstack/react-table';
+import { Filter, FilterX, Plus, Search } from 'lucide-react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+
+import type { ModalType } from './MenuBoardConfig';
+import {
+  getBulkActions,
+  getMenuBoardColumns,
+  INITIAL_FILTER_STATE,
+  type MenuBoardFilterInput,
+} from './MenuBoardConfig';
+import { MenuBoardModals } from './components/MenuBoardModals';
+import { useMenuBoardActions } from './hooks/useMenuBoardActions';
+import { useMenuBoardData } from './hooks/useMenuBoardData';
+import { useMenuBoardFilterOptions } from './hooks/useMenuBoardFilterOptions';
+
+import Button from '@/components/ui/Button';
+import FilterInputs from '@/components/ui/FilterInputs';
+import FolderBreadcrumb from '@/components/ui/FolderBreadCrumb';
+import FolderSidebar from '@/components/ui/FolderSidebar';
+import TabNav from '@/components/ui/TabNav';
+import { DataTable } from '@/components/ui/table/DataTable';
+import { useUserContext } from '@/context/UserContext';
+import { useFilteredTabs } from '@/hooks/useFilteredTabs';
+import { useFolderActions } from '@/hooks/useFolderActions';
+import { usePermissions } from '@/hooks/usePermissions';
+import { useTableState } from '@/hooks/useTableState';
+import { fetchContextButtons } from '@/services/folderApi';
+import type { MenuBoard } from '@/types/menuBoard';
+
+export default function MenuBoards() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { user } = useUserContext();
+  const queryClient = useQueryClient();
+  const canViewFolders = usePermissions()?.canViewFolders;
+  const homeFolderId = user?.homeFolderId ?? 1;
+
+  const {
+    pagination,
+    setPagination,
+    sorting,
+    setSorting,
+    columnVisibility,
+    setColumnVisibility,
+    globalFilter,
+    debouncedFilter,
+    setGlobalFilter,
+    filterInputs,
+    setFilterInputs,
+    folderId: selectedFolderId,
+    setFolderId: setSelectedFolderId,
+    isHydrated,
+  } = useTableState<MenuBoardFilterInput>('menuBoard_page', {
+    pagination: { pageIndex: 0, pageSize: 10 },
+    sorting: [],
+    columnVisibility: {
+      menuId: true,
+      name: true,
+      description: true,
+      code: true,
+      owner: true,
+      groupsWithPermissions: true,
+      modifiedDt: true,
+    },
+    viewMode: 'table',
+    globalFilter: '',
+    filterInputs: INITIAL_FILTER_STATE,
+    folderId: canViewFolders ? homeFolderId : null,
+  });
+
+  const [folderRefreshTrigger, setFolderRefreshTrigger] = useState(0);
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const [selectionCache, setSelectionCache] = useState<Record<string, MenuBoard>>({});
+  const [openFilter, setOpenFilter] = useState(false);
+  const [showFolderSidebar, setShowFolderSidebar] = useState(false);
+  const [activeModal, setActiveModal] = useState<ModalType>(null);
+
+  const [itemsToDelete, setItemsToDelete] = useState<MenuBoard[]>([]);
+  const [itemsToMove, setItemsToMove] = useState<MenuBoard[]>([]);
+  const [shareEntityIds, setShareEntityIds] = useState<number | number[] | null>(null);
+  const [selectedMenuBoardId, setSelectedMenuBoardId] = useState<number | null>(null);
+
+  const openModal = (name: ModalType) => setActiveModal(name);
+  const closeModal = () => setActiveModal(null);
+
+  const {
+    data: queryData,
+    isFetching,
+    isError,
+    error: queryError,
+  } = useMenuBoardData({
+    pagination,
+    sorting,
+    filter: debouncedFilter,
+    advancedFilters: filterInputs,
+    folderId: selectedFolderId,
+    enabled: isHydrated,
+  });
+
+  const { data: folderPerms } = useQuery({
+    queryKey: ['folderPermissions', selectedFolderId],
+    queryFn: () => fetchContextButtons(selectedFolderId as number),
+    enabled: selectedFolderId !== null,
+    staleTime: 1000 * 60 * 5,
+  });
+
+  const data = queryData?.rows;
+  const pageCount = Math.ceil((queryData?.totalCount || 0) / pagination.pageSize);
+  const error = isError && queryError instanceof Error ? queryError.message : '';
+  const menuBoardList = data ?? [];
+  const canAddToFolder = folderPerms?.create || false;
+
+  const folderActions = useFolderActions({
+    onSuccess: (targetFolder) => {
+      setFolderRefreshTrigger((prev) => prev + 1);
+      if (targetFolder) {
+        handleFolderChange({ id: targetFolder.id, text: targetFolder.text });
+      } else {
+        handleRefresh();
+      }
+    },
+  });
+
+  const getRowId = (row: MenuBoard) => row.menuId.toString();
+
+  const handleRowSelectionChange = (
+    updaterOrValue: RowSelectionState | ((old: RowSelectionState) => RowSelectionState),
+  ) => {
+    const newSelection =
+      typeof updaterOrValue === 'function' ? updaterOrValue(rowSelection) : updaterOrValue;
+
+    setRowSelection(newSelection);
+
+    setSelectionCache((prev) => {
+      const next = { ...prev };
+      menuBoardList.forEach((item) => {
+        const id = getRowId(item);
+        if (newSelection[id]) {
+          next[id] = item;
+        }
+      });
+      return next;
+    });
+  };
+
+  const selectedMenuBoard = menuBoardList.find((m) => m.menuId === selectedMenuBoardId) ?? null;
+  const existingNames = menuBoardList.map((m) => m.name);
+
+  const handleRefresh = () => {
+    queryClient.invalidateQueries({ queryKey: ['menuBoard'] });
+  };
+
+  const handleFolderChange = (folder: { id: number | null; text: string | '' }) => {
+    setSelectedFolderId(folder.id);
+    setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+    setRowSelection({});
+  };
+
+  const {
+    isDeleting,
+    deleteError,
+    setDeleteError,
+    isCloning,
+    confirmDelete,
+    handleConfirmClone,
+    handleConfirmMove,
+  } = useMenuBoardActions({
+    t,
+    handleRefresh,
+    closeModal,
+    setRowSelection,
+    setItemsToMove,
+  });
+
+  const handleDelete = (id: number) => {
+    const menuBoard = menuBoardList.find((m) => m.menuId === id);
+    if (!menuBoard) {
+      return;
+    }
+    setItemsToDelete([menuBoard]);
+    setDeleteError(null);
+    openModal('delete');
+  };
+
+  const openAddEditModal = (menuBoard: MenuBoard | null) => {
+    setSelectedMenuBoardId(menuBoard ? menuBoard.menuId : null);
+    openModal('edit');
+  };
+
+  const openCopyModal = (menuBoardId: number) => {
+    setSelectedMenuBoardId(menuBoardId);
+    openModal('copy');
+  };
+
+  const handleResetFilters = () => {
+    setFilterInputs(INITIAL_FILTER_STATE);
+    setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+  };
+
+  const columns = getMenuBoardColumns({
+    t,
+    onDelete: handleDelete,
+    openAddEditModal,
+    openMoveModal: (menuBoard) => {
+      setItemsToMove([menuBoard]);
+      openModal('move');
+    },
+    openShareModal: (menuBoardId) => {
+      setShareEntityIds(menuBoardId);
+      openModal('share');
+    },
+    copyMenuBoard: openCopyModal,
+    onNavigate: (path) => {
+      navigate(path);
+    },
+  });
+
+  const getAllSelectedItems = (): MenuBoard[] =>
+    Object.keys(rowSelection)
+      .map((id) => selectionCache[id])
+      .filter((item): item is MenuBoard => !!item);
+
+  const bulkActions = getBulkActions({
+    t,
+    onDelete: () => {
+      const allItems = getAllSelectedItems();
+      setItemsToDelete(allItems);
+      setDeleteError(null);
+      openModal('delete');
+    },
+    onMove: canViewFolders
+      ? () => {
+          const allItems = getAllSelectedItems();
+          setItemsToMove(allItems);
+          openModal('move');
+        }
+      : undefined,
+    onShare: () => {
+      const allItems = getAllSelectedItems();
+      const ids = allItems.map((i) => i.menuId);
+      setShareEntityIds(ids);
+      openModal('share');
+    },
+  });
+
+  const { filterOptions } = useMenuBoardFilterOptions(t);
+  const libraryTabs = useFilteredTabs('library');
+
+  return (
+    <section className="flex h-full w-full min-h-0 relative outline-none overflow-hidden">
+      <FolderSidebar
+        isOpen={showFolderSidebar}
+        selectedFolderId={selectedFolderId}
+        onSelect={handleFolderChange}
+        onClose={() => setShowFolderSidebar(false)}
+        onAction={folderActions.openAction}
+        refreshTrigger={folderRefreshTrigger}
+      />
+      <div className="flex-1 flex flex-col min-h-0 min-w-0 px-5 pb-5">
+        <div className="flex flex-row justify-between py-4 items-center gap-4">
+          <TabNav activeTab="Menu Boards" navigation={libraryTabs} />
+          <div className="flex items-center gap-2 md:mb-0">
+            <Button
+              variant="primary"
+              className="font-semibold"
+              disabled={!canAddToFolder || !isHydrated}
+              onClick={() => openAddEditModal(null)}
+              leftIcon={Plus}
+            >
+              {t('Add Menu Board')}
+            </Button>
+          </div>
+        </div>
+
+        <div className="flex flex-col lg:flex-row justify-between items-center gap-4">
+          <div className="w-full lg:flex-1 md:min-w-0">
+            <FolderBreadcrumb
+              currentFolderId={selectedFolderId}
+              onNavigate={handleFolderChange}
+              isSidebarOpen={showFolderSidebar}
+              onToggleSidebar={() => setShowFolderSidebar(!showFolderSidebar)}
+              onAction={folderActions.openAction}
+              refreshTrigger={folderRefreshTrigger}
+            />
+          </div>
+
+          <div className="flex items-center gap-2 w-full xl:w-115 lg:w-75 shrink-0">
+            <div className="relative flex-1 flex">
+              <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
+                <Search className="w-4 h-4 text-gray-400" />
+              </div>
+              <input
+                name="search"
+                value={globalFilter}
+                disabled={!isHydrated}
+                onChange={(e) => {
+                  setGlobalFilter(e.target.value);
+                  setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+                }}
+                placeholder={t('Search menu boards...')}
+                className="py-2 px-3 pl-10 block h-11.25 bg-gray-100 rounded-lg w-full border-gray-200 disabled:opacity-50 disabled:pointer-events-none disabled:bg-gray-200"
+              />
+            </div>
+            <Button
+              leftIcon={!openFilter ? Filter : FilterX}
+              variant="secondary"
+              disabled={!isHydrated}
+              onClick={() => setOpenFilter((prev) => !prev)}
+              removeTextOnMobile
+            >
+              {t('Filters')}
+            </Button>
+          </div>
+        </div>
+
+        <FilterInputs
+          onChange={(name, value) => {
+            setFilterInputs((prev) => ({ ...prev, [name]: value }));
+            setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+          }}
+          isOpen={openFilter}
+          values={filterInputs}
+          options={filterOptions}
+          onReset={handleResetFilters}
+        />
+
+        {error && (
+          <div className="bg-red-50 border border-red-200 text-red-800 p-4" role="alert">
+            {error}
+          </div>
+        )}
+
+        <div className="min-h-0 flex flex-col">
+          {!isHydrated ? (
+            <div className="flex-1 flex items-center justify-center bg-gray-50 animate-pulse rounded-lg border border-gray-200">
+              <span className="text-gray-400 font-medium">
+                {t('Loading your preferences...')}
+              </span>
+            </div>
+          ) : (
+            <DataTable
+              columns={columns}
+              data={menuBoardList}
+              pageCount={pageCount}
+              pagination={pagination}
+              onPaginationChange={setPagination}
+              sorting={sorting}
+              onSortingChange={setSorting}
+              globalFilter={globalFilter}
+              onGlobalFilterChange={setGlobalFilter}
+              loading={isFetching}
+              rowSelection={rowSelection}
+              onRowSelectionChange={handleRowSelectionChange}
+              onRefresh={handleRefresh}
+              columnPinning={{ left: ['tableSelection'], right: ['tableActions'] }}
+              columnVisibility={columnVisibility}
+              onColumnVisibilityChange={setColumnVisibility}
+              bulkActions={bulkActions}
+              viewMode={null}
+              getRowId={getRowId}
+            />
+          )}
+        </div>
+      </div>
+
+      <MenuBoardModals
+        actions={{
+          activeModal,
+          closeModal,
+          handleRefresh,
+          deleteError,
+          isDeleting,
+          isCloning,
+        }}
+        selection={{
+          selectedMenuBoard,
+          selectedMenuBoardId,
+          itemsToDelete,
+          itemsToMove,
+          existingNames,
+          shareEntityIds,
+          setShareEntityIds,
+        }}
+        handlers={{
+          confirmDelete: () => confirmDelete(itemsToDelete),
+          handleConfirmClone: (name, description, code) =>
+            handleConfirmClone(selectedMenuBoard, name, description, code),
+          handleConfirmMove: (folderId) => handleConfirmMove(itemsToMove, folderId),
+        }}
+        folderActions={folderActions}
+      />
+    </section>
+  );
+}

--- a/frontend/src/pages/Library/MenuBoard/components/AddAndEditMenuBoardModal.tsx
+++ b/frontend/src/pages/Library/MenuBoard/components/AddAndEditMenuBoardModal.tsx
@@ -1,0 +1,206 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useEffect, useState, useTransition } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import SelectFolder from '@/components/ui/forms/SelectFolder';
+import TextInput from '@/components/ui/forms/TextInput';
+import Modal from '@/components/ui/modals/Modal';
+import { usePermissions } from '@/hooks/usePermissions';
+import { getMenuBoardSchema } from '@/schema/menuBoard';
+import { createMenuBoard, updateMenuBoard } from '@/services/menuBoardApi';
+import type { MenuBoard } from '@/types/menuBoard';
+
+interface AddAndEditMenuBoardModalProps {
+  type: 'add' | 'edit';
+  isOpen?: boolean;
+  data?: MenuBoard | null;
+  onClose: () => void;
+  onSave: () => void;
+}
+
+interface MenuBoardDraft {
+  name: string;
+  description: string;
+  code: string;
+  folderId: number | null;
+}
+
+type MenuBoardFormErrors = {
+  name?: string;
+  description?: string;
+  code?: string;
+};
+
+const DEFAULT_DRAFT: MenuBoardDraft = {
+  name: '',
+  description: '',
+  code: '',
+  folderId: null,
+};
+
+const createDraftFromData = (data?: MenuBoard | null): MenuBoardDraft => {
+  if (!data) {
+    return { ...DEFAULT_DRAFT };
+  }
+  return {
+    name: data.name ?? '',
+    description: data.description ?? '',
+    code: data.code ?? '',
+    folderId: data.folderId ?? null,
+  };
+};
+
+export default function AddAndEditMenuBoardModal({
+  type,
+  isOpen = true,
+  onClose,
+  data,
+  onSave,
+}: AddAndEditMenuBoardModalProps) {
+  const { t } = useTranslation();
+  const [isPending, startTransition] = useTransition();
+  const [apiError, setApiError] = useState<string | undefined>();
+  const [formErrors, setFormErrors] = useState<MenuBoardFormErrors>({});
+  const canViewFolders = usePermissions()?.canViewFolders;
+
+  const [draft, setDraft] = useState<MenuBoardDraft>(() => createDraftFromData(data));
+
+  useEffect(() => {
+    if (isOpen) {
+      setDraft(createDraftFromData(data));
+      setApiError(undefined);
+      setFormErrors({});
+    }
+  }, [data, isOpen]);
+
+  const updateDraft = <K extends keyof MenuBoardDraft>(field: K, value: MenuBoardDraft[K]) => {
+    setDraft((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const clearError = (field: keyof MenuBoardFormErrors) => {
+    setFormErrors((prev) => ({ ...prev, [field]: undefined }));
+  };
+
+  const handleSave = () => {
+    const schema = getMenuBoardSchema(t);
+    const result = schema.safeParse(draft);
+
+    if (!result.success) {
+      const fieldErrors = result.error.flatten().fieldErrors;
+      setFormErrors({
+        name: fieldErrors.name?.[0],
+        description: fieldErrors.description?.[0],
+        code: fieldErrors.code?.[0],
+      });
+      return;
+    }
+
+    setFormErrors({});
+    setApiError(undefined);
+
+    startTransition(async () => {
+      try {
+        if (type === 'edit') {
+          if (!data) {
+            return;
+          }
+          await updateMenuBoard(data.menuId, draft);
+        } else {
+          await createMenuBoard(draft);
+        }
+        onSave();
+        onClose();
+      } catch (err: unknown) {
+        const axiosError = err as { response?: { data?: { message?: string } } };
+        setApiError(axiosError.response?.data?.message ?? t('An unexpected error occurred.'));
+      }
+    });
+  };
+
+  return (
+    <Modal
+      title={type === 'add' ? t('Add Menu Board') : t('Edit Menu Board')}
+      onClose={onClose}
+      isOpen={isOpen}
+      isPending={isPending}
+      error={apiError}
+      actions={[
+        { label: t('Cancel'), onClick: onClose, variant: 'secondary', disabled: isPending },
+        { label: isPending ? t('Saving…') : t('Save'), onClick: handleSave, disabled: isPending },
+      ]}
+    >
+      <div className="px-8 pb-8 space-y-4 pt-4">
+        {canViewFolders && (
+          <div className="relative z-20">
+            <SelectFolder
+              selectedId={draft.folderId}
+              onSelect={(f) => updateDraft('folderId', f?.id ?? null)}
+            />
+          </div>
+        )}
+
+        <TextInput
+          name="name"
+          label={t('Name')}
+          placeholder={t('Enter Name')}
+          helpText={t('The Name for this Menu Board.')}
+          value={draft.name}
+          error={formErrors.name}
+          onChange={(val) => {
+            updateDraft('name', val);
+            clearError('name');
+          }}
+        />
+
+        <TextInput
+          name="code"
+          label={t('Code')}
+          placeholder={t('Enter Code')}
+          helpText={t('The Code identifier for this Menu Board.')}
+          value={draft.code}
+          error={formErrors.code}
+          optional
+          onChange={(val) => {
+            updateDraft('code', val);
+            clearError('code');
+          }}
+        />
+
+        <TextInput
+          name="description"
+          label={t('Description')}
+          placeholder={t('Enter a short description')}
+          helpText={t('Up to 250 characters.')}
+          value={draft.description}
+          error={formErrors.description}
+          optional
+          multiline
+          onChange={(val) => {
+            updateDraft('description', val);
+            clearError('description');
+          }}
+        />
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/pages/Library/MenuBoard/components/CopyMenuBoardModal.tsx
+++ b/frontend/src/pages/Library/MenuBoard/components/CopyMenuBoardModal.tsx
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import TextInput from '@/components/ui/forms/TextInput';
+import Modal from '@/components/ui/modals/Modal';
+import type { MenuBoard } from '@/types/menuBoard';
+import { incrementName } from '@/utils/stringUtils';
+
+interface CopyMenuBoardModalProps {
+  isOpen?: boolean;
+  onClose: () => void;
+  onConfirm: (newName: string, newDescription: string, newCode: string) => void;
+  menuBoard: MenuBoard | null;
+  isLoading?: boolean;
+  existingNames: string[];
+}
+
+export default function CopyMenuBoardModal({
+  isOpen = true,
+  onClose,
+  onConfirm,
+  menuBoard,
+  isLoading,
+  existingNames,
+}: CopyMenuBoardModalProps) {
+  const { t } = useTranslation();
+  const [newName, setNewName] = useState('');
+  const [newDescription, setNewDescription] = useState('');
+  const [newCode, setNewCode] = useState('');
+  const [error, setError] = useState<string | undefined>();
+
+  useEffect(() => {
+    if (isOpen) {
+      if (menuBoard) {
+        setNewName(incrementName(menuBoard.name));
+        setNewDescription(menuBoard.description ?? '');
+        setNewCode(menuBoard.code ?? '');
+      } else {
+        setNewName('');
+        setNewDescription('');
+        setNewCode('');
+      }
+    }
+    setError(undefined);
+  }, [menuBoard, isOpen]);
+
+  const handleSave = () => {
+    const trimmed = newName.trim();
+
+    if (!trimmed) {
+      setError(t('Name is required'));
+      return;
+    }
+
+    if (existingNames.some((n) => n.toLowerCase() === trimmed.toLowerCase())) {
+      setError(t('A menu board with this name already exists'));
+      return;
+    }
+
+    setError(undefined);
+    onConfirm(trimmed, newDescription, newCode);
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      title={t('Copy Menu Board')}
+      onClose={onClose}
+      size="sm"
+      actions={[
+        {
+          label: t('Cancel'),
+          onClick: onClose,
+          variant: 'secondary',
+          disabled: isLoading,
+        },
+        {
+          label: isLoading ? t('Saving…') : t('Save'),
+          onClick: handleSave,
+          disabled: isLoading,
+        },
+      ]}
+    >
+      <div className="px-8 pb-8 space-y-4 pt-4">
+        <TextInput
+          name="newName"
+          value={newName}
+          label={t('Name')}
+          helpText={t('The Name for this Menu Board.')}
+          error={error}
+          onChange={(val) => {
+            setNewName(val);
+            if (error) {
+              setError(undefined);
+            }
+          }}
+        />
+
+        <TextInput
+          name="newCode"
+          value={newCode}
+          label={t('Code')}
+          helpText={t('The Code identifier for this Menu Board.')}
+          optional
+          onChange={(val) => {
+            setNewCode(val);
+          }}
+        />
+
+        <TextInput
+          name="newDescription"
+          value={newDescription}
+          label={t('Description')}
+          helpText={t('Up to 250 characters.')}
+          optional
+          multiline
+          onChange={(val) => {
+            setNewDescription(val);
+          }}
+        />
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/pages/Library/MenuBoard/components/DeleteMenuBoardModal.tsx
+++ b/frontend/src/pages/Library/MenuBoard/components/DeleteMenuBoardModal.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Trash2Icon } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import Modal from '@/components/ui/modals/Modal';
+
+interface DeleteMenuBoardModalProps {
+  isOpen?: boolean;
+  onClose: () => void;
+  onDelete: () => void;
+  itemCount: number;
+  menuBoardName?: string;
+  error?: string | null;
+  isLoading?: boolean;
+}
+
+export default function DeleteMenuBoardModal({
+  isOpen = true,
+  onClose,
+  onDelete,
+  menuBoardName,
+  isLoading,
+  itemCount,
+  error,
+}: DeleteMenuBoardModalProps) {
+  const { t } = useTranslation();
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      isPending={isLoading}
+      onClose={onClose}
+      actions={[
+        {
+          label: t('Cancel'),
+          onClick: onClose,
+          variant: 'secondary',
+        },
+        {
+          label: isLoading ? t('Deleting…') : t('Yes, Delete'),
+          onClick: onDelete,
+          disabled: isLoading,
+        },
+      ]}
+      size="md"
+    >
+      <div className="flex flex-col p-5 gap-3">
+        <div>
+          <div className="flex justify-center mb-4">
+            <div className="bg-red-100 w-15.5 h-15.5 text-red-800 border-red-50 border-[7px] rounded-full p-3">
+              <Trash2Icon size={26} />
+            </div>
+          </div>
+          <h2 className="text-center text-lg font-semibold mb-2 text-red-800">
+            {itemCount === 1 ? t('Delete Menu Board?') : t('Delete Menu Boards?')}
+          </h2>
+        </div>
+        <p className="text-center text-gray-500">
+          {itemCount === 1 ? (
+            <>
+              {t('Are you sure you want to delete ')}"<strong>{menuBoardName}</strong>"?
+            </>
+          ) : (
+            <>
+              {t('Are you sure you want to delete ')}
+              <strong>{itemCount}</strong> {t('menu boards')}?
+            </>
+          )}
+        </p>
+
+        {error && (
+          <div className="mt-2 text-center">
+            <p className="text-sm font-medium text-red-600">{error}</p>
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/pages/Library/MenuBoard/components/MenuBoardModals.tsx
+++ b/frontend/src/pages/Library/MenuBoard/components/MenuBoardModals.tsx
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useTranslation } from 'react-i18next';
+
+import AddAndEditMenuBoardModal from './AddAndEditMenuBoardModal';
+import CopyMenuBoardModal from './CopyMenuBoardModal';
+import DeleteMenuBoardModal from './DeleteMenuBoardModal';
+
+import FolderActionModals from '@/components/ui/FolderActionModals';
+import MoveModal from '@/components/ui/modals/MoveModal';
+import ShareModal from '@/components/ui/modals/ShareModal';
+import type { useFolderActions } from '@/hooks/useFolderActions';
+import type { MenuBoard } from '@/types/menuBoard';
+
+interface MenuBoardModalsProps {
+  actions: {
+    activeModal: string | null;
+    closeModal: () => void;
+    handleRefresh: () => void;
+    deleteError: string | null;
+    isDeleting: boolean;
+    isCloning: boolean;
+  };
+  selection: {
+    selectedMenuBoard: MenuBoard | null;
+    selectedMenuBoardId: number | null;
+    itemsToDelete: MenuBoard[];
+    itemsToMove: MenuBoard[];
+    existingNames: string[];
+    shareEntityIds: number | number[] | null;
+    setShareEntityIds: React.Dispatch<React.SetStateAction<number | number[] | null>>;
+  };
+  handlers: {
+    confirmDelete: () => void;
+    handleConfirmClone: (name: string, description: string, code: string) => void;
+    handleConfirmMove: (folderId: number) => void;
+  };
+  folderActions: ReturnType<typeof useFolderActions>;
+}
+
+export function MenuBoardModals({
+  actions,
+  selection,
+  handlers,
+  folderActions,
+}: MenuBoardModalsProps) {
+  const { t } = useTranslation();
+  const isModalOpen = (name: string) => actions.activeModal === name;
+
+  return (
+    <>
+      {isModalOpen('edit') && (
+        <AddAndEditMenuBoardModal
+          type={selection.selectedMenuBoardId ? 'edit' : 'add'}
+          onClose={actions.closeModal}
+          data={selection.selectedMenuBoard}
+          onSave={() => {
+            actions.handleRefresh();
+          }}
+        />
+      )}
+
+      {isModalOpen('share') && (
+        <ShareModal
+          title={t('Share Menu Board')}
+          onClose={() => {
+            actions.closeModal();
+            selection.setShareEntityIds(null);
+            actions.handleRefresh();
+          }}
+          entityType="MenuBoard"
+          entityId={selection.shareEntityIds ?? selection.selectedMenuBoard?.menuId ?? null}
+        />
+      )}
+
+      <FolderActionModals folderActions={folderActions} />
+
+      {isModalOpen('delete') && (
+        <DeleteMenuBoardModal
+          onClose={actions.closeModal}
+          onDelete={handlers.confirmDelete}
+          itemCount={selection.itemsToDelete.length}
+          menuBoardName={
+            selection.itemsToDelete.length === 1 ? selection.itemsToDelete[0]?.name : undefined
+          }
+          error={actions.deleteError}
+          isLoading={actions.isDeleting}
+        />
+      )}
+
+      {isModalOpen('copy') && (
+        <CopyMenuBoardModal
+          onClose={actions.closeModal}
+          onConfirm={(name, description, code) =>
+            handlers.handleConfirmClone(name, description, code)
+          }
+          menuBoard={selection.selectedMenuBoard}
+          isLoading={actions.isCloning}
+          existingNames={selection.existingNames}
+        />
+      )}
+
+      {isModalOpen('move') && (
+        <MoveModal
+          onClose={actions.closeModal}
+          onConfirm={handlers.handleConfirmMove}
+          items={selection.itemsToMove}
+          entityLabel={t('Menu Board')}
+        />
+      )}
+    </>
+  );
+}

--- a/frontend/src/pages/Library/MenuBoard/hooks/useMenuBoardActions.ts
+++ b/frontend/src/pages/Library/MenuBoard/hooks/useMenuBoardActions.ts
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type { RowSelectionState } from '@tanstack/react-table';
+import { isAxiosError } from 'axios';
+import type { TFunction } from 'i18next';
+import type { Dispatch, SetStateAction } from 'react';
+import { useState } from 'react';
+
+import { notify } from '@/components/ui/Notification';
+import { selectFolder } from '@/services/folderApi';
+import { copyMenuBoard, deleteMenuBoard } from '@/services/menuBoardApi';
+import type { MenuBoard } from '@/types/menuBoard';
+
+interface UseMenuBoardActionsProps {
+  t: TFunction;
+  handleRefresh: () => void;
+  closeModal: () => void;
+  setRowSelection: Dispatch<SetStateAction<RowSelectionState>>;
+  setItemsToMove: (items: MenuBoard[]) => void;
+}
+
+export function useMenuBoardActions({
+  t,
+  handleRefresh,
+  closeModal,
+  setRowSelection,
+  setItemsToMove,
+}: UseMenuBoardActionsProps) {
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [isCloning, setIsCloning] = useState(false);
+
+  const confirmDelete = async (itemsToDelete: MenuBoard[]) => {
+    if (itemsToDelete.length === 0 || isDeleting) {
+      return;
+    }
+
+    try {
+      setIsDeleting(true);
+      const results = await Promise.allSettled(
+        itemsToDelete.map((item) => deleteMenuBoard(item.menuId)),
+      );
+
+      const failed = results.filter((r) => r.status === 'rejected');
+
+      if (failed.length > 0) {
+        const firstRejected = failed[0] as PromiseRejectedResult;
+        const reason = firstRejected.reason;
+        const message =
+          isAxiosError(reason) && reason.response?.data?.message
+            ? reason.response.data.message
+            : t('{{count}} item(s) could not be deleted.', { count: failed.length });
+        setDeleteError(message);
+        setRowSelection({});
+        handleRefresh();
+        return;
+      }
+
+      setRowSelection({});
+      handleRefresh();
+      closeModal();
+    } catch (error) {
+      console.error(error);
+      const message =
+        isAxiosError(error) && error.response?.data?.message
+          ? error.response.data.message
+          : t('Some selected items could not be deleted.');
+      setDeleteError(message);
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const handleConfirmClone = async (
+    selectedMenuBoard: MenuBoard | null,
+    name: string,
+    description: string,
+    code: string,
+  ) => {
+    if (!selectedMenuBoard) {
+      return;
+    }
+
+    try {
+      setIsCloning(true);
+      await copyMenuBoard({ menuBoardId: selectedMenuBoard.menuId, name, description, code });
+      notify.success(t('Menu Board copied successfully'));
+      handleRefresh();
+      closeModal();
+    } catch (error) {
+      console.error('Copy menu board failed', error);
+      notify.error(t('Failed to copy Menu Board'));
+    } finally {
+      setIsCloning(false);
+    }
+  };
+
+  const handleConfirmMove = async (itemsToMove: MenuBoard[], newFolderId: number) => {
+    if (!itemsToMove || itemsToMove.length === 0) {
+      return;
+    }
+
+    const movePromises = itemsToMove.map((item) =>
+      selectFolder({
+        folderId: newFolderId,
+        targetId: item.menuId,
+        targetType: 'menuboard',
+      }),
+    );
+
+    try {
+      const results = await Promise.all(movePromises);
+      const failures = results.filter((res) => !res.success);
+
+      if (failures.length === 0) {
+        notify.info(t('{{count}} items moved successfully!', { count: itemsToMove.length }));
+      } else if (failures.length === itemsToMove.length) {
+        notify.error(t('Failed to move items.'));
+      } else {
+        notify.warning(
+          t('Moved {{success}} items, but {{fail}} failed.', {
+            success: itemsToMove.length - failures.length,
+            fail: failures.length,
+          }),
+        );
+      }
+
+      setItemsToMove([]);
+      setRowSelection({});
+      handleRefresh();
+      closeModal();
+    } catch (error) {
+      console.error(error);
+      notify.error(t('An unexpected error occurred while moving items.'));
+    }
+  };
+
+  return {
+    isDeleting,
+    deleteError,
+    setDeleteError,
+    isCloning,
+    confirmDelete,
+    handleConfirmClone,
+    handleConfirmMove,
+  };
+}

--- a/frontend/src/pages/Library/MenuBoard/hooks/useMenuBoardData.ts
+++ b/frontend/src/pages/Library/MenuBoard/hooks/useMenuBoardData.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import type { PaginationState, SortingState } from '@tanstack/react-table';
+import type { AxiosError } from 'axios';
+
+import type { MenuBoardFilterInput } from '../MenuBoardConfig';
+
+import type { FetchMenuBoardRequest } from '@/services/menuBoardApi';
+import { fetchMenuBoard } from '@/services/menuBoardApi';
+import { resolveLastModified } from '@/utils/date';
+
+export const MenuBoardQueryKeys = {
+  all: ['menuBoard'] as const,
+  list: (params: Record<string, unknown>) => [...MenuBoardQueryKeys.all, 'list', params] as const,
+};
+
+interface UseMenuBoardDataParams {
+  pagination: PaginationState;
+  sorting: SortingState;
+  filter: string;
+  folderId: number | null;
+  advancedFilters: MenuBoardFilterInput;
+  enabled?: boolean;
+}
+
+export const useMenuBoardData = ({
+  pagination,
+  sorting,
+  filter,
+  folderId,
+  advancedFilters,
+  enabled = true,
+}: UseMenuBoardDataParams) => {
+  const queryParams = {
+    pageIndex: pagination.pageIndex,
+    pageSize: pagination.pageSize,
+    sorting,
+    filter,
+    folderId,
+    ...advancedFilters,
+  };
+
+  return useQuery({
+    queryKey: MenuBoardQueryKeys.list(queryParams),
+
+    queryFn: async ({ signal }) => {
+      const startOffset = pagination.pageIndex * pagination.pageSize;
+
+      const sortBy = sorting?.[0]?.id;
+      const sortDir = sorting?.[0]?.desc ? 'desc' : 'asc';
+
+      const { menuId, userId, code, lastModified } = advancedFilters;
+
+      const request: FetchMenuBoardRequest = {
+        start: startOffset,
+        length: pagination.pageSize,
+        keyword: filter,
+        sortBy,
+        sortDir: sorting.length ? sortDir : undefined,
+        signal,
+        menuId: menuId ? Number(menuId) : undefined,
+        userId: userId ? Number(userId) : undefined,
+        code: code || undefined,
+        ...resolveLastModified(lastModified),
+      };
+
+      if (typeof folderId === 'number') {
+        request.folderId = folderId;
+      }
+
+      return fetchMenuBoard(request);
+    },
+
+    enabled,
+
+    placeholderData: keepPreviousData,
+    staleTime: 1000 * 60,
+
+    throwOnError: (error: AxiosError) => {
+      return error.response?.status ? error.response.status >= 500 : false;
+    },
+  });
+};

--- a/frontend/src/pages/Library/MenuBoard/hooks/useMenuBoardFilterOptions.ts
+++ b/frontend/src/pages/Library/MenuBoard/hooks/useMenuBoardFilterOptions.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type { TFunction } from 'i18next';
+import { useEffect, useState } from 'react';
+
+import { getBaseFilterKeys } from '../MenuBoardConfig';
+
+import type { FilterOption } from '@/components/ui/SelectFilter';
+import { fetchUsers } from '@/services/userApi';
+
+export function useMenuBoardFilterOptions(t: TFunction) {
+  const [filterOptions, setFilterOptions] = useState(() => getBaseFilterKeys(t));
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let ignore = false;
+
+    async function loadDynamicOptions() {
+      try {
+        const usersRes = await fetchUsers({ start: 0, length: 1000 });
+
+        if (ignore) {
+          return;
+        }
+
+        const userOptions: FilterOption[] = usersRes.rows.map((user) => ({
+          label: user.userName,
+          value: user.userId.toString(),
+        }));
+
+        const mergedOptions = getBaseFilterKeys(t).map((item) => {
+          if (item.name === 'userId') {
+            return {
+              ...item,
+              options: [...(item.options ?? []), ...userOptions],
+            };
+          }
+          return item;
+        });
+
+        setFilterOptions(mergedOptions);
+      } catch (error) {
+        console.error('Failed to load filter options', error);
+      } finally {
+        if (!ignore) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    loadDynamicOptions();
+
+    return () => {
+      ignore = true;
+    };
+  }, [t]);
+
+  return { filterOptions, isLoading };
+}

--- a/frontend/src/pages/Library/MenuBoard/subPages/Categories/MenuBoardCategories.tsx
+++ b/frontend/src/pages/Library/MenuBoard/subPages/Categories/MenuBoardCategories.tsx
@@ -1,0 +1,427 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import type { RowSelectionState } from '@tanstack/react-table';
+import { isAxiosError } from 'axios';
+import { ChevronRight, Filter, FilterX, Plus, Search } from 'lucide-react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import {
+  getCategoryBulkActions,
+  getCategoryColumnDefinitions,
+  INITIAL_CATEGORY_FILTER_STATE,
+  getCategoryFilterKeys,
+  type MenuBoardCategoryFilterInput,
+} from './MenuBoardCategoriesConfig';
+import { MenuBoardCategoryModals } from './components/MenuBoardCategoryModals';
+import {
+  MenuBoardCategoryQueryKeys,
+  useMenuBoardCategoriesData,
+} from './hooks/useMenuBoardCategoriesData';
+
+import Button from '@/components/ui/Button';
+import FilterInputs from '@/components/ui/FilterInputs';
+import { notify } from '@/components/ui/Notification';
+import TabNav from '@/components/ui/TabNav';
+import { DataTable } from '@/components/ui/table/DataTable';
+import { useFilteredTabs } from '@/hooks/useFilteredTabs';
+import { useTableState } from '@/hooks/useTableState';
+import MediaPreviewer from '@/pages/Library/Media/components/MediaPreviewer';
+import {
+  getMenuBoardById,
+  copyMenuBoardCategory,
+  deleteMenuBoardCategory,
+} from '@/services/menuBoardApi';
+import type { MenuBoardCategory } from '@/types/menuBoardCategory';
+
+type CategoryModalType = 'edit' | 'copy' | 'delete' | null;
+
+export default function MenuBoardCategories() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { menuId } = useParams<{ menuId: string }>();
+
+  const {
+    pagination,
+    setPagination,
+    sorting,
+    setSorting,
+    columnVisibility,
+    setColumnVisibility,
+    globalFilter,
+    debouncedFilter,
+    setGlobalFilter,
+    filterInputs,
+    setFilterInputs,
+    isHydrated,
+  } = useTableState<MenuBoardCategoryFilterInput>('menuBoardCategories', {
+    pagination: { pageIndex: 0, pageSize: 10 },
+    sorting: [],
+    columnVisibility: {
+      menuCategoryId: true,
+      name: true,
+      thumbnail: true,
+      description: true,
+      code: true,
+    },
+    viewMode: 'table',
+    globalFilter: '',
+    filterInputs: INITIAL_CATEGORY_FILTER_STATE,
+    folderId: null,
+  });
+
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const [selectionCache, setSelectionCache] = useState<Record<string, MenuBoardCategory>>({});
+  const [openFilter, setOpenFilter] = useState(false);
+  const [activeModal, setActiveModal] = useState<CategoryModalType>(null);
+  const [previewItem, setPreviewItem] = useState<MenuBoardCategory | null>(null);
+  const [selectedCategory, setSelectedCategory] = useState<MenuBoardCategory | null>(null);
+  const [itemsToDelete, setItemsToDelete] = useState<MenuBoardCategory[]>([]);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [isCloning, setIsCloning] = useState(false);
+
+  const openModal = (name: CategoryModalType) => setActiveModal(name);
+  const closeModal = () => {
+    setActiveModal(null);
+    setSelectedCategory(null);
+    setItemsToDelete([]);
+    setDeleteError(null);
+  };
+
+  const { data: menuBoard } = useQuery({
+    queryKey: ['menuBoard', menuId],
+    queryFn: () => getMenuBoardById(menuId!),
+    enabled: !!menuId,
+    staleTime: 1000 * 60 * 5,
+  });
+
+  const {
+    data: queryData,
+    isFetching,
+    isError,
+    error: queryError,
+  } = useMenuBoardCategoriesData({
+    menuId: menuId!,
+    pagination,
+    sorting,
+    filter: debouncedFilter,
+    advancedFilters: filterInputs,
+    enabled: isHydrated && !!menuId,
+  });
+
+  const categoryList = queryData?.rows ?? [];
+  const pageCount = Math.ceil((queryData?.totalCount || 0) / pagination.pageSize);
+  const error = isError && queryError instanceof Error ? queryError.message : '';
+  const existingNames = categoryList.map((c) => c.name);
+
+  const handleRefresh = () => {
+    queryClient.invalidateQueries({ queryKey: MenuBoardCategoryQueryKeys.all });
+  };
+
+  const getRowId = (row: MenuBoardCategory) => row.menuCategoryId.toString();
+
+  const handleRowSelectionChange = (
+    updaterOrValue: RowSelectionState | ((old: RowSelectionState) => RowSelectionState),
+  ) => {
+    const newSelection =
+      typeof updaterOrValue === 'function' ? updaterOrValue(rowSelection) : updaterOrValue;
+
+    setRowSelection(newSelection);
+
+    setSelectionCache((prev) => {
+      const next = { ...prev };
+      categoryList.forEach((item) => {
+        const id = getRowId(item);
+        if (newSelection[id]) {
+          next[id] = item;
+        }
+      });
+      return next;
+    });
+  };
+
+  const handleDelete = (id: number) => {
+    const category = categoryList.find((c) => c.menuCategoryId === id);
+    if (!category) {
+      return;
+    }
+    setItemsToDelete([category]);
+    setDeleteError(null);
+    openModal('delete');
+  };
+
+  const confirmDelete = async () => {
+    if (itemsToDelete.length === 0 || isDeleting) {
+      return;
+    }
+
+    try {
+      setIsDeleting(true);
+      const results = await Promise.allSettled(
+        itemsToDelete.map((item) => deleteMenuBoardCategory(item.menuCategoryId)),
+      );
+
+      const failed = results.filter((r) => r.status === 'rejected');
+
+      if (failed.length > 0) {
+        const firstRejected = failed[0] as PromiseRejectedResult;
+        const reason = firstRejected.reason;
+        const message =
+          isAxiosError(reason) && reason.response?.data?.message
+            ? reason.response.data.message
+            : t('{{count}} item(s) could not be deleted.', { count: failed.length });
+        setDeleteError(message);
+        setRowSelection({});
+        handleRefresh();
+        return;
+      }
+
+      setRowSelection({});
+      handleRefresh();
+      closeModal();
+    } catch (err) {
+      const message =
+        isAxiosError(err) && err.response?.data?.message
+          ? err.response.data.message
+          : t('Some selected items could not be deleted.');
+      setDeleteError(message);
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const handleConfirmCopy = async (name: string, description: string, code: string) => {
+    if (!selectedCategory || !menuId) {
+      return;
+    }
+
+    try {
+      setIsCloning(true);
+      await copyMenuBoardCategory({
+        menuCategoryId: selectedCategory.menuCategoryId,
+        name,
+        description: description || undefined,
+        code: code || undefined,
+      });
+      notify.success(t('Category copied successfully'));
+      handleRefresh();
+      closeModal();
+    } catch (err) {
+      console.error('Copy category failed', err);
+      notify.error(t('Failed to copy Category'));
+    } finally {
+      setIsCloning(false);
+    }
+  };
+
+  const getAllSelectedItems = (): MenuBoardCategory[] =>
+    Object.keys(rowSelection)
+      .map((id) => selectionCache[id])
+      .filter((item): item is MenuBoardCategory => !!item);
+
+  const columns = getCategoryColumnDefinitions({
+    t,
+    onEdit: (category) => {
+      setSelectedCategory(category);
+      openModal('edit');
+    },
+    onCopy: (category) => {
+      setSelectedCategory(category);
+      openModal('copy');
+    },
+    onDelete: handleDelete,
+    onViewProducts: (category) => {
+      navigate(`/library/menu-boards/${menuId}/categories/${category.menuCategoryId}/products`);
+    },
+    onPreview: (category) => setPreviewItem(category),
+  });
+
+  const bulkActions = getCategoryBulkActions({
+    t,
+    onDelete: () => {
+      const allItems = getAllSelectedItems();
+      setItemsToDelete(allItems);
+      setDeleteError(null);
+      openModal('delete');
+    },
+  });
+
+  const filterOptions = getCategoryFilterKeys(t);
+  const libraryTabs = useFilteredTabs('library');
+
+  const handleResetFilters = () => {
+    setFilterInputs(INITIAL_CATEGORY_FILTER_STATE);
+    setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+  };
+
+  return (
+    <section className="flex h-full w-full min-h-0 relative outline-none overflow-hidden">
+      <div className="flex-1 flex flex-col min-h-0 min-w-0 px-5 pb-5">
+        <div className="flex flex-row justify-between py-4 items-center gap-4">
+          <TabNav activeTab="Menu Boards" navigation={libraryTabs} />
+          <div className="flex items-center gap-2 md:mb-0">
+            <Button
+              variant="primary"
+              className="font-semibold"
+              disabled={!isHydrated}
+              onClick={() => {
+                setSelectedCategory(null);
+                openModal('edit');
+              }}
+              leftIcon={Plus}
+            >
+              {t('Add Category')}
+            </Button>
+          </div>
+        </div>
+
+        <div className="flex flex-col lg:flex-row justify-between items-center gap-4">
+          <div className="w-full lg:flex-1 md:min-w-0">
+            <nav className="flex items-center gap-1 text-sm font-medium text-gray-500">
+              <button
+                className="px-3 py-2 hover:text-gray-900 transition-colors cursor-pointer"
+                onClick={() => navigate('/library/menu-boards')}
+              >
+                {t('Menu Boards')}
+              </button>
+              <ChevronRight size={24} className="p-1 text-gray-500" />
+              <span
+                className="px-3 py-2 text-xibo-blue-500 text-sm font-semibold truncate max-w-xs"
+                title={menuBoard?.name}
+              >
+                {menuBoard?.name ?? `${t('Menu Board')} #${menuId}`}
+              </span>
+            </nav>
+          </div>
+
+          <div className="flex items-center gap-2 w-full xl:w-115 lg:w-75 shrink-0">
+            <div className="relative flex-1 flex">
+              <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
+                <Search className="w-4 h-4 text-gray-400" />
+              </div>
+              <input
+                name="search"
+                value={globalFilter}
+                disabled={!isHydrated}
+                onChange={(e) => {
+                  setGlobalFilter(e.target.value);
+                  setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+                }}
+                placeholder={t('Search categories...')}
+                className="py-2 px-3 pl-10 block h-11.25 bg-gray-100 rounded-lg w-full border-gray-200 disabled:opacity-50 disabled:pointer-events-none disabled:bg-gray-200"
+              />
+            </div>
+            <Button
+              leftIcon={!openFilter ? Filter : FilterX}
+              variant="secondary"
+              disabled={!isHydrated}
+              onClick={() => setOpenFilter((prev) => !prev)}
+              removeTextOnMobile
+            >
+              {t('Filters')}
+            </Button>
+          </div>
+        </div>
+
+        <FilterInputs
+          onChange={(name, value) => {
+            setFilterInputs((prev) => ({ ...prev, [name]: value }));
+            setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+          }}
+          isOpen={openFilter}
+          values={filterInputs}
+          options={filterOptions}
+          onReset={handleResetFilters}
+        />
+
+        {error && (
+          <div className="bg-red-50 border border-red-200 text-red-800 p-4" role="alert">
+            {error}
+          </div>
+        )}
+
+        <div className="min-h-0 flex flex-col">
+          {!isHydrated ? (
+            <div className="flex-1 flex items-center justify-center bg-gray-50 animate-pulse rounded-lg border border-gray-200">
+              <span className="text-gray-400 font-medium">{t('Loading...')}</span>
+            </div>
+          ) : (
+            <DataTable
+              columns={columns}
+              data={categoryList}
+              pageCount={pageCount}
+              pagination={pagination}
+              onPaginationChange={setPagination}
+              sorting={sorting}
+              onSortingChange={setSorting}
+              globalFilter={globalFilter}
+              onGlobalFilterChange={setGlobalFilter}
+              loading={isFetching}
+              rowSelection={rowSelection}
+              onRowSelectionChange={handleRowSelectionChange}
+              onRefresh={handleRefresh}
+              columnPinning={{ left: ['tableSelection'], right: ['tableActions'] }}
+              columnVisibility={columnVisibility}
+              onColumnVisibilityChange={setColumnVisibility}
+              bulkActions={bulkActions}
+              viewMode={null}
+              getRowId={getRowId}
+              tableLabel={t('Categories')}
+            />
+          )}
+        </div>
+      </div>
+
+      <MenuBoardCategoryModals
+        menuId={menuId!}
+        actions={{
+          activeModal,
+          closeModal,
+          handleRefresh,
+          deleteError,
+          isDeleting,
+          isCloning,
+        }}
+        selection={{
+          selectedCategory,
+          itemsToDelete,
+          existingNames,
+        }}
+        handlers={{
+          confirmDelete,
+          handleConfirmCopy,
+        }}
+      />
+
+      <MediaPreviewer
+        mediaId={previewItem?.mediaId ?? null}
+        mediaType={previewItem?.mediaType}
+        fileName={previewItem?.name}
+        onClose={() => setPreviewItem(null)}
+      />
+    </section>
+  );
+}

--- a/frontend/src/pages/Library/MenuBoard/subPages/Categories/MenuBoardCategoriesConfig.tsx
+++ b/frontend/src/pages/Library/MenuBoard/subPages/Categories/MenuBoardCategoriesConfig.tsx
@@ -1,0 +1,196 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type { ColumnDef } from '@tanstack/react-table';
+import type { TFunction } from 'i18next';
+import { CopyCheck, Edit, Trash2 } from 'lucide-react';
+import { type ComponentProps } from 'react';
+
+import type { FilterConfigItem } from '@/components/ui/FilterInputs';
+import type { DataTableBulkAction } from '@/components/ui/table/DataTableBulkActions';
+import { TextCell, ActionsCell, MediaCell } from '@/components/ui/table/cells';
+import type { MenuBoardCategory } from '@/types/menuBoardCategory';
+import type { ActionItem } from '@/types/table';
+
+export interface MenuBoardCategoryFilterInput {
+  menuCategoryId: string;
+  code: string;
+}
+
+export const INITIAL_CATEGORY_FILTER_STATE: MenuBoardCategoryFilterInput = {
+  menuCategoryId: '',
+  code: '',
+};
+
+export const getCategoryFilterKeys = (
+  t: TFunction,
+): FilterConfigItem<MenuBoardCategoryFilterInput>[] => [
+  {
+    label: t('Category ID'),
+    placeholder: t('Enter ID'),
+    name: 'menuCategoryId',
+    type: 'number',
+  },
+  {
+    label: t('Code'),
+    placeholder: t('Enter Code'),
+    name: 'code',
+    type: 'text',
+  },
+];
+
+export interface MenuBoardCategoryActionsProps {
+  t: TFunction;
+  onEdit: (category: MenuBoardCategory) => void;
+  onCopy: (category: MenuBoardCategory) => void;
+  onDelete: (id: number) => void;
+  onViewProducts: (category: MenuBoardCategory) => void;
+  onPreview?: (category: MenuBoardCategory) => void;
+}
+
+export const getCategoryItemActions = ({
+  t,
+  onEdit,
+  onCopy,
+  onDelete,
+  onViewProducts,
+}: MenuBoardCategoryActionsProps): ((category: MenuBoardCategory) => ActionItem[]) => {
+  return (category: MenuBoardCategory) => [
+    {
+      label: t('Edit'),
+      icon: Edit,
+      onClick: () => onEdit(category),
+      isQuickAction: true,
+      variant: 'primary' as const,
+    },
+    {
+      label: t('Edit'),
+      icon: Edit,
+      onClick: () => onEdit(category),
+    },
+    {
+      label: t('Make a Copy'),
+      icon: CopyCheck,
+      onClick: () => onCopy(category),
+    },
+    { isSeparator: true },
+    {
+      label: t('View Products'),
+      isNavigation: true,
+      onClick: () => onViewProducts(category),
+    },
+    { isSeparator: true },
+    {
+      label: t('Delete'),
+      icon: Trash2,
+      onClick: () => onDelete(category.menuCategoryId),
+      variant: 'danger' as const,
+    },
+  ];
+};
+
+export const getCategoryColumnDefinitions = (
+  props: MenuBoardCategoryActionsProps,
+): ColumnDef<MenuBoardCategory>[] => {
+  const { t, onPreview } = props;
+  const getActions = getCategoryItemActions(props);
+
+  return [
+    {
+      accessorKey: 'menuCategoryId',
+      header: t('ID'),
+      size: 60,
+      cell: (info) => <TextCell>{info.getValue<number>()}</TextCell>,
+    },
+    {
+      accessorKey: 'name',
+      header: t('Name'),
+      size: 150,
+      enableHiding: false,
+      cell: (info) => <TextCell weight="bold">{info.getValue<string>()}</TextCell>,
+    },
+    {
+      accessorKey: 'thumbnail',
+      header: t('Media'),
+      size: 100,
+      enableSorting: false,
+      cell: (info) => {
+        const thumb = info.getValue<string | undefined>();
+        if (!thumb) {
+          return <TextCell>-</TextCell>;
+        }
+        return (
+          <MediaCell
+            thumb={thumb}
+            alt={info.row.original.name}
+            mediaType="image"
+            onPreview={onPreview ? () => onPreview(info.row.original) : undefined}
+          />
+        );
+      },
+    },
+    {
+      accessorKey: 'description',
+      header: t('Description'),
+      size: 150,
+      cell: (info) => <TextCell>{info.getValue<string>() || '-'}</TextCell>,
+    },
+    {
+      accessorKey: 'code',
+      header: t('Code'),
+      size: 100,
+      cell: (info) => <TextCell>{info.getValue<string>() || '-'}</TextCell>,
+    },
+    {
+      id: 'tableActions',
+      header: '',
+      size: 120,
+      minSize: 120,
+      maxSize: 120,
+      enableHiding: false,
+      enableResizing: false,
+      cell: ({ row }) => (
+        <ActionsCell
+          row={row}
+          actions={getActions(row.original) as ComponentProps<typeof ActionsCell>['actions']}
+        />
+      ),
+    },
+  ];
+};
+
+interface GetCategoryBulkActionsProps {
+  t: TFunction;
+  onDelete: () => void;
+}
+
+export const getCategoryBulkActions = ({
+  t,
+  onDelete,
+}: GetCategoryBulkActionsProps): DataTableBulkAction<MenuBoardCategory>[] => {
+  return [
+    {
+      label: t('Delete Selected'),
+      icon: Trash2,
+      onClick: onDelete,
+    },
+  ];
+};

--- a/frontend/src/pages/Library/MenuBoard/subPages/Categories/components/AddAndEditMenuBoardCategoryModal.tsx
+++ b/frontend/src/pages/Library/MenuBoard/subPages/Categories/components/AddAndEditMenuBoardCategoryModal.tsx
@@ -1,0 +1,208 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useEffect, useState, useTransition } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import MediaInput from '@/components/ui/forms/MediaInput';
+import TextInput from '@/components/ui/forms/TextInput';
+import Modal from '@/components/ui/modals/Modal';
+import { getMenuBoardCategorySchema } from '@/schema/menuBoard';
+import { createMenuBoardCategory, updateMenuBoardCategory } from '@/services/menuBoardApi';
+import type { MenuBoardCategory } from '@/types/menuBoardCategory';
+
+interface AddAndEditMenuBoardCategoryModalProps {
+  type: 'add' | 'edit';
+  isOpen?: boolean;
+  menuId: string | number;
+  data?: MenuBoardCategory | null;
+  onClose: () => void;
+  onSave: () => void;
+}
+
+interface CategoryDraft {
+  name: string;
+  description: string;
+  code: string;
+  mediaId: number | null;
+}
+
+type CategoryFormErrors = {
+  name?: string;
+  description?: string;
+  code?: string;
+};
+
+const DEFAULT_DRAFT: CategoryDraft = {
+  name: '',
+  description: '',
+  code: '',
+  mediaId: null,
+};
+
+const createDraftFromData = (data?: MenuBoardCategory | null): CategoryDraft => {
+  if (!data) {
+    return { ...DEFAULT_DRAFT };
+  }
+  return {
+    name: data.name ?? '',
+    description: data.description ?? '',
+    code: data.code ?? '',
+    mediaId: data.mediaId ?? null,
+  };
+};
+
+export default function AddAndEditMenuBoardCategoryModal({
+  type,
+  isOpen = true,
+  menuId,
+  onClose,
+  data,
+  onSave,
+}: AddAndEditMenuBoardCategoryModalProps) {
+  const { t } = useTranslation();
+  const [isPending, startTransition] = useTransition();
+  const [apiError, setApiError] = useState<string | undefined>();
+  const [formErrors, setFormErrors] = useState<CategoryFormErrors>({});
+
+  const [draft, setDraft] = useState<CategoryDraft>(() => createDraftFromData(data));
+
+  useEffect(() => {
+    if (isOpen) {
+      setDraft(createDraftFromData(data));
+      setApiError(undefined);
+      setFormErrors({});
+    }
+  }, [data, isOpen]);
+
+  const updateDraft = <K extends keyof CategoryDraft>(field: K, value: CategoryDraft[K]) => {
+    setDraft((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const clearError = (field: keyof CategoryFormErrors) => {
+    setFormErrors((prev) => ({ ...prev, [field]: undefined }));
+  };
+
+  const handleSave = () => {
+    const schema = getMenuBoardCategorySchema(t);
+    const result = schema.safeParse(draft);
+
+    if (!result.success) {
+      const fieldErrors = result.error.flatten().fieldErrors;
+      setFormErrors({
+        name: fieldErrors.name?.[0],
+        description: fieldErrors.description?.[0],
+        code: fieldErrors.code?.[0],
+      });
+      return;
+    }
+
+    setFormErrors({});
+    setApiError(undefined);
+
+    startTransition(async () => {
+      try {
+        if (type === 'edit') {
+          if (!data) {
+            return;
+          }
+          await updateMenuBoardCategory(data.menuCategoryId, draft);
+        } else {
+          await createMenuBoardCategory(menuId, draft);
+        }
+        onSave();
+        onClose();
+      } catch (err: unknown) {
+        const axiosError = err as { response?: { data?: { message?: string } } };
+        setApiError(axiosError.response?.data?.message ?? t('An unexpected error occurred.'));
+      }
+    });
+  };
+
+  return (
+    <Modal
+      title={type === 'add' ? t('Add Category') : t('Edit Category')}
+      onClose={onClose}
+      isOpen={isOpen}
+      isPending={isPending}
+      error={apiError}
+      actions={[
+        { label: t('Cancel'), onClick: onClose, variant: 'secondary', disabled: isPending },
+        { label: isPending ? t('Saving…') : t('Save'), onClick: handleSave, disabled: isPending },
+      ]}
+    >
+      <div className="px-8 pb-8 space-y-4 pt-4">
+        <TextInput
+          name="name"
+          label={t('Name')}
+          placeholder={t('Enter Name')}
+          helpText={t('The Name for this Menu Board Category.')}
+          value={draft.name}
+          error={formErrors.name}
+          onChange={(val) => {
+            updateDraft('name', val);
+            clearError('name');
+          }}
+        />
+
+        <TextInput
+          name="code"
+          label={t('Code')}
+          placeholder={t('Enter Code')}
+          helpText={t('The Code identifier for this Menu Board Category.')}
+          value={draft.code}
+          error={formErrors.code}
+          optional
+          onChange={(val) => {
+            updateDraft('code', val);
+            clearError('code');
+          }}
+        />
+
+        <TextInput
+          name="description"
+          label={t('Description')}
+          placeholder={t('Enter a short description')}
+          helpText={t('The description for this Menu Board Category.')}
+          value={draft.description}
+          error={formErrors.description}
+          optional
+          multiline
+          onChange={(val) => {
+            updateDraft('description', val);
+            clearError('description');
+          }}
+        />
+
+        <MediaInput
+          label={t('Media')}
+          helpText={t('Optionally select an Image or Video to associate with this Category.')}
+          value={draft.mediaId ?? undefined}
+          optional
+          mediaType=""
+          onChange={(val) => {
+            updateDraft('mediaId', val ? Number(val) : null);
+          }}
+        />
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/pages/Library/MenuBoard/subPages/Categories/components/CopyMenuBoardCategoryModal.tsx
+++ b/frontend/src/pages/Library/MenuBoard/subPages/Categories/components/CopyMenuBoardCategoryModal.tsx
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import TextInput from '@/components/ui/forms/TextInput';
+import Modal from '@/components/ui/modals/Modal';
+import type { MenuBoardCategory } from '@/types/menuBoardCategory';
+import { incrementName } from '@/utils/stringUtils';
+
+interface CopyMenuBoardCategoryModalProps {
+  isOpen?: boolean;
+  onClose: () => void;
+  onConfirm: (name: string, description: string, code: string) => void;
+  category: MenuBoardCategory | null;
+  isLoading?: boolean;
+  existingNames: string[];
+}
+
+export default function CopyMenuBoardCategoryModal({
+  isOpen = true,
+  onClose,
+  onConfirm,
+  category,
+  isLoading,
+  existingNames,
+}: CopyMenuBoardCategoryModalProps) {
+  const { t } = useTranslation();
+  const [newName, setNewName] = useState('');
+  const [newDescription, setNewDescription] = useState('');
+  const [newCode, setNewCode] = useState('');
+  const [error, setError] = useState<string | undefined>();
+
+  useEffect(() => {
+    if (isOpen) {
+      if (category) {
+        setNewName(incrementName(category.name));
+        setNewDescription(category.description ?? '');
+        setNewCode(category.code ?? '');
+      } else {
+        setNewName('');
+        setNewDescription('');
+        setNewCode('');
+      }
+    }
+    setError(undefined);
+  }, [category, isOpen]);
+
+  const handleSave = () => {
+    const trimmed = newName.trim();
+
+    if (!trimmed) {
+      setError(t('Name is required'));
+      return;
+    }
+
+    if (existingNames.some((n) => n.toLowerCase() === trimmed.toLowerCase())) {
+      setError(t('A category with this name already exists'));
+      return;
+    }
+
+    setError(undefined);
+    onConfirm(trimmed, newDescription, newCode);
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      title={t('Copy Category')}
+      onClose={onClose}
+      size="sm"
+      actions={[
+        {
+          label: t('Cancel'),
+          onClick: onClose,
+          variant: 'secondary',
+          disabled: isLoading,
+        },
+        {
+          label: isLoading ? t('Saving…') : t('Save'),
+          onClick: handleSave,
+          disabled: isLoading,
+        },
+      ]}
+    >
+      <div className="px-8 pb-8 space-y-4 pt-4">
+        <TextInput
+          name="newName"
+          value={newName}
+          label={t('Name')}
+          helpText={t('The Name for this Menu Board Category.')}
+          error={error}
+          onChange={(val) => {
+            setNewName(val);
+            if (error) {
+              setError(undefined);
+            }
+          }}
+        />
+
+        <TextInput
+          name="newCode"
+          value={newCode}
+          label={t('Code')}
+          helpText={t('The Code identifier for this Menu Board Category.')}
+          optional
+          onChange={(val) => {
+            setNewCode(val);
+          }}
+        />
+
+        <TextInput
+          name="newDescription"
+          value={newDescription}
+          label={t('Description')}
+          helpText={t('The description for this Menu Board Category.')}
+          optional
+          multiline
+          onChange={(val) => {
+            setNewDescription(val);
+          }}
+        />
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/pages/Library/MenuBoard/subPages/Categories/components/DeleteMenuBoardCategoryModal.tsx
+++ b/frontend/src/pages/Library/MenuBoard/subPages/Categories/components/DeleteMenuBoardCategoryModal.tsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Trash2Icon } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import Modal from '@/components/ui/modals/Modal';
+
+interface DeleteMenuBoardCategoryModalProps {
+  isOpen?: boolean;
+  onClose: () => void;
+  onDelete: () => void;
+  itemCount: number;
+  categoryName?: string;
+  error?: string | null;
+  isLoading?: boolean;
+}
+
+export default function DeleteMenuBoardCategoryModal({
+  isOpen = true,
+  onClose,
+  onDelete,
+  categoryName,
+  isLoading,
+  itemCount,
+  error,
+}: DeleteMenuBoardCategoryModalProps) {
+  const { t } = useTranslation();
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      isPending={isLoading}
+      onClose={onClose}
+      actions={[
+        {
+          label: t('Cancel'),
+          onClick: onClose,
+          variant: 'secondary',
+        },
+        {
+          label: isLoading ? t('Deleting…') : t('Yes, Delete'),
+          onClick: onDelete,
+          disabled: isLoading,
+        },
+      ]}
+      size="md"
+    >
+      <div className="flex flex-col p-5 gap-3">
+        <div>
+          <div className="flex justify-center mb-4">
+            <div className="bg-red-100 w-15.5 h-15.5 text-red-800 border-red-50 border-[7px] rounded-full p-3">
+              <Trash2Icon size={26} />
+            </div>
+          </div>
+          <h2 className="text-center text-lg font-semibold mb-2 text-red-800">
+            {itemCount === 1 ? t('Delete Category?') : t('Delete Categories?')}
+          </h2>
+        </div>
+        <p className="text-center text-gray-500">
+          {itemCount === 1 ? (
+            <>
+              {t('Are you sure you want to delete ')}"<strong>{categoryName}</strong>"?{' '}
+              {t('All Products linked to this Category will also be removed.')}
+            </>
+          ) : (
+            <>
+              {t('Are you sure you want to delete ')}
+              <strong>{itemCount}</strong> {t('categories')}?{' '}
+              {t('All Products linked to these Categories will also be removed.')}
+            </>
+          )}
+        </p>
+
+        {error && (
+          <div className="mt-2 text-center">
+            <p className="text-sm font-medium text-red-600">{error}</p>
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/pages/Library/MenuBoard/subPages/Categories/components/MenuBoardCategoryModals.tsx
+++ b/frontend/src/pages/Library/MenuBoard/subPages/Categories/components/MenuBoardCategoryModals.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import AddAndEditMenuBoardCategoryModal from './AddAndEditMenuBoardCategoryModal';
+import CopyMenuBoardCategoryModal from './CopyMenuBoardCategoryModal';
+import DeleteMenuBoardCategoryModal from './DeleteMenuBoardCategoryModal';
+
+import type { MenuBoardCategory } from '@/types/menuBoardCategory';
+
+interface MenuBoardCategoryModalsProps {
+  menuId: string | number;
+  actions: {
+    activeModal: string | null;
+    closeModal: () => void;
+    handleRefresh: () => void;
+    deleteError: string | null;
+    isDeleting: boolean;
+    isCloning: boolean;
+  };
+  selection: {
+    selectedCategory: MenuBoardCategory | null;
+    itemsToDelete: MenuBoardCategory[];
+    existingNames: string[];
+  };
+  handlers: {
+    confirmDelete: () => void;
+    handleConfirmCopy: (name: string, description: string, code: string) => void;
+  };
+}
+
+export function MenuBoardCategoryModals({
+  menuId,
+  actions,
+  selection,
+  handlers,
+}: MenuBoardCategoryModalsProps) {
+  const isModalOpen = (name: string) => actions.activeModal === name;
+
+  return (
+    <>
+      {isModalOpen('edit') && (
+        <AddAndEditMenuBoardCategoryModal
+          type={selection.selectedCategory ? 'edit' : 'add'}
+          menuId={menuId}
+          onClose={actions.closeModal}
+          data={selection.selectedCategory}
+          onSave={actions.handleRefresh}
+        />
+      )}
+
+      {isModalOpen('copy') && (
+        <CopyMenuBoardCategoryModal
+          onClose={actions.closeModal}
+          onConfirm={handlers.handleConfirmCopy}
+          category={selection.selectedCategory}
+          isLoading={actions.isCloning}
+          existingNames={selection.existingNames}
+        />
+      )}
+
+      {isModalOpen('delete') && (
+        <DeleteMenuBoardCategoryModal
+          onClose={actions.closeModal}
+          onDelete={handlers.confirmDelete}
+          itemCount={selection.itemsToDelete.length}
+          categoryName={
+            selection.itemsToDelete.length === 1 ? selection.itemsToDelete[0]?.name : undefined
+          }
+          error={actions.deleteError}
+          isLoading={actions.isDeleting}
+        />
+      )}
+    </>
+  );
+}

--- a/frontend/src/pages/Library/MenuBoard/subPages/Categories/hooks/useMenuBoardCategoriesData.ts
+++ b/frontend/src/pages/Library/MenuBoard/subPages/Categories/hooks/useMenuBoardCategoriesData.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import type { PaginationState, SortingState } from '@tanstack/react-table';
+import type { AxiosError } from 'axios';
+
+import type { MenuBoardCategoryFilterInput } from '../MenuBoardCategoriesConfig';
+
+import { fetchMenuBoardCategories } from '@/services/menuBoardApi';
+
+export const MenuBoardCategoryQueryKeys = {
+  all: ['menuBoardCategory'] as const,
+  list: (menuId: string | number, params: Record<string, unknown>) =>
+    [...MenuBoardCategoryQueryKeys.all, 'list', String(menuId), params] as const,
+};
+
+interface UseMenuBoardCategoriesDataParams {
+  menuId: string | number;
+  pagination: PaginationState;
+  sorting: SortingState;
+  filter: string;
+  advancedFilters: MenuBoardCategoryFilterInput;
+  enabled?: boolean;
+}
+
+export const useMenuBoardCategoriesData = ({
+  menuId,
+  pagination,
+  sorting,
+  filter,
+  advancedFilters,
+  enabled = true,
+}: UseMenuBoardCategoriesDataParams) => {
+  const queryParams = {
+    pageIndex: pagination.pageIndex,
+    pageSize: pagination.pageSize,
+    sorting,
+    filter,
+    ...advancedFilters,
+  };
+
+  return useQuery({
+    queryKey: MenuBoardCategoryQueryKeys.list(menuId, queryParams),
+
+    queryFn: async ({ signal }) => {
+      const startOffset = pagination.pageIndex * pagination.pageSize;
+      const sortBy = sorting?.[0]?.id;
+      const sortDir = sorting?.[0]?.desc ? 'desc' : 'asc';
+      const { menuCategoryId, code } = advancedFilters;
+
+      return fetchMenuBoardCategories(menuId, {
+        start: startOffset,
+        length: pagination.pageSize,
+        keyword: filter,
+        sortBy,
+        sortDir: sorting.length ? sortDir : undefined,
+        signal,
+        menuCategoryId: menuCategoryId ? Number(menuCategoryId) : undefined,
+        code: code || undefined,
+      });
+    },
+
+    enabled: enabled && !!menuId,
+    placeholderData: keepPreviousData,
+    staleTime: 1000 * 60,
+
+    throwOnError: (error: AxiosError) => {
+      return error.response?.status ? error.response.status >= 500 : false;
+    },
+  });
+};

--- a/frontend/src/pages/Library/MenuBoard/subPages/Products/MenuBoardProducts.tsx
+++ b/frontend/src/pages/Library/MenuBoard/subPages/Products/MenuBoardProducts.tsx
@@ -1,0 +1,434 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import type { RowSelectionState } from '@tanstack/react-table';
+import { isAxiosError } from 'axios';
+import { Filter, FilterX, Plus, Search, ChevronRight } from 'lucide-react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import {
+  getProductBulkActions,
+  getProductColumnDefinitions,
+  getProductFilterKeys,
+  INITIAL_PRODUCT_FILTER_STATE,
+  type MenuBoardProductFilterInput,
+} from './MenuBoardProductsConfig';
+import { MenuBoardProductModals } from './components/MenuBoardProductModals';
+import {
+  MenuBoardProductQueryKeys,
+  useMenuBoardProductsData,
+} from './hooks/useMenuBoardProductsData';
+
+import Button from '@/components/ui/Button';
+import FilterInputs from '@/components/ui/FilterInputs';
+import { notify } from '@/components/ui/Notification';
+import TabNav from '@/components/ui/TabNav';
+import { DataTable } from '@/components/ui/table/DataTable';
+import { useFilteredTabs } from '@/hooks/useFilteredTabs';
+import { useTableState } from '@/hooks/useTableState';
+import MediaPreviewer from '@/pages/Library/Media/components/MediaPreviewer';
+import {
+  createMenuBoardProduct,
+  deleteMenuBoardProduct,
+  getCategoryById,
+  getMenuBoardById,
+} from '@/services/menuBoardApi';
+import type { MenuBoardProduct } from '@/types/menuBoardProduct';
+
+type ProductModalType = 'edit' | 'copy' | 'delete' | null;
+
+export default function MenuBoardProducts() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const { menuId, categoryId } = useParams<{ menuId: string; categoryId: string }>();
+
+  const {
+    pagination,
+    setPagination,
+    sorting,
+    setSorting,
+    columnVisibility,
+    setColumnVisibility,
+    globalFilter,
+    debouncedFilter,
+    setGlobalFilter,
+    filterInputs,
+    setFilterInputs,
+    isHydrated,
+  } = useTableState<MenuBoardProductFilterInput>('menuBoardProducts', {
+    pagination: { pageIndex: 0, pageSize: 10 },
+    sorting: [],
+    columnVisibility: { displayOrder: false, calories: false },
+    viewMode: 'table',
+    globalFilter: '',
+    filterInputs: INITIAL_PRODUCT_FILTER_STATE,
+    folderId: null,
+  });
+
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const [selectionCache, setSelectionCache] = useState<Record<string, MenuBoardProduct>>({});
+  const [openFilter, setOpenFilter] = useState(false);
+  const [activeModal, setActiveModal] = useState<ProductModalType>(null);
+  const [previewItem, setPreviewItem] = useState<MenuBoardProduct | null>(null);
+  const [selectedProduct, setSelectedProduct] = useState<MenuBoardProduct | null>(null);
+  const [itemsToDelete, setItemsToDelete] = useState<MenuBoardProduct[]>([]);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [isCloning, setIsCloning] = useState(false);
+
+  const openModal = (name: ProductModalType) => setActiveModal(name);
+  const closeModal = () => {
+    setActiveModal(null);
+    setSelectedProduct(null);
+    setItemsToDelete([]);
+    setDeleteError(null);
+  };
+
+  const { data: menuBoard } = useQuery({
+    queryKey: ['menuBoard', menuId],
+    queryFn: () => getMenuBoardById(menuId!),
+    enabled: !!menuId,
+    staleTime: 1000 * 60 * 5,
+  });
+
+  const { data: category } = useQuery({
+    queryKey: ['menuBoardCategory', menuId, categoryId],
+    queryFn: () => getCategoryById(menuId!, categoryId!),
+    enabled: !!menuId && !!categoryId,
+    staleTime: 1000 * 60 * 5,
+  });
+
+  const {
+    data: queryData,
+    isFetching,
+    isError,
+    error: queryError,
+  } = useMenuBoardProductsData({
+    menuCategoryId: categoryId!,
+    pagination,
+    sorting,
+    filter: debouncedFilter,
+    advancedFilters: filterInputs,
+    enabled: isHydrated && !!categoryId,
+  });
+
+  const productList = queryData?.rows ?? [];
+  const pageCount = Math.ceil((queryData?.totalCount || 0) / pagination.pageSize);
+  const error = isError && queryError instanceof Error ? queryError.message : '';
+
+  const handleRefresh = () => {
+    queryClient.invalidateQueries({ queryKey: MenuBoardProductQueryKeys.all });
+  };
+
+  const getRowId = (row: MenuBoardProduct) => row.menuProductId.toString();
+
+  const handleRowSelectionChange = (
+    updaterOrValue: RowSelectionState | ((old: RowSelectionState) => RowSelectionState),
+  ) => {
+    const newSelection =
+      typeof updaterOrValue === 'function' ? updaterOrValue(rowSelection) : updaterOrValue;
+
+    setRowSelection(newSelection);
+
+    setSelectionCache((prev) => {
+      const next = { ...prev };
+      productList.forEach((item) => {
+        const id = getRowId(item);
+        if (newSelection[id]) {
+          next[id] = item;
+        }
+      });
+      return next;
+    });
+  };
+
+  const handleDelete = (id: number) => {
+    const product = productList.find((p) => p.menuProductId === id);
+    if (!product) {
+      return;
+    }
+    setItemsToDelete([product]);
+    setDeleteError(null);
+    openModal('delete');
+  };
+
+  const confirmDelete = async () => {
+    if (itemsToDelete.length === 0 || isDeleting) {
+      return;
+    }
+
+    try {
+      setIsDeleting(true);
+      const results = await Promise.allSettled(
+        itemsToDelete.map((item) => deleteMenuBoardProduct(item.menuProductId)),
+      );
+
+      const failed = results.filter((r) => r.status === 'rejected');
+
+      if (failed.length > 0) {
+        const firstRejected = failed[0] as PromiseRejectedResult;
+        const reason = firstRejected.reason;
+        const message =
+          isAxiosError(reason) && reason.response?.data?.message
+            ? reason.response.data.message
+            : t('{{count}} item(s) could not be deleted.', { count: failed.length });
+        setDeleteError(message);
+        setRowSelection({});
+        handleRefresh();
+        return;
+      }
+
+      setRowSelection({});
+      handleRefresh();
+      closeModal();
+    } catch (err) {
+      const message =
+        isAxiosError(err) && err.response?.data?.message
+          ? err.response.data.message
+          : t('Some selected items could not be deleted.');
+      setDeleteError(message);
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const handleConfirmCopy = async (newName: string, newPrice: number | null, newCode: string) => {
+    if (!selectedProduct || !categoryId) {
+      return;
+    }
+
+    try {
+      setIsCloning(true);
+      await createMenuBoardProduct(categoryId, {
+        name: newName,
+        price: newPrice,
+        description: selectedProduct.description ?? null,
+        code: newCode || null,
+        displayOrder: selectedProduct.displayOrder ?? null,
+        availability: selectedProduct.availability ?? null,
+        allergyInfo: selectedProduct.allergyInfo ?? null,
+        calories: selectedProduct.calories ?? null,
+        mediaId: selectedProduct.mediaId ?? null,
+      });
+      notify.success(t('Product copied successfully'));
+      handleRefresh();
+      closeModal();
+    } catch (err) {
+      console.error('Copy product failed', err);
+      notify.error(t('Failed to copy Product'));
+    } finally {
+      setIsCloning(false);
+    }
+  };
+
+  const getAllSelectedItems = (): MenuBoardProduct[] =>
+    Object.keys(rowSelection)
+      .map((id) => selectionCache[id])
+      .filter((item): item is MenuBoardProduct => !!item);
+
+  const columns = getProductColumnDefinitions({
+    t,
+    onEdit: (product) => {
+      setSelectedProduct(product);
+      openModal('edit');
+    },
+    onCopy: (product) => {
+      setSelectedProduct(product);
+      openModal('copy');
+    },
+    onDelete: handleDelete,
+    onPreview: (product) => setPreviewItem(product),
+  });
+
+  const bulkActions = getProductBulkActions({
+    t,
+    onDelete: () => {
+      const allItems = getAllSelectedItems();
+      setItemsToDelete(allItems);
+      setDeleteError(null);
+      openModal('delete');
+    },
+  });
+
+  const filterOptions = getProductFilterKeys(t);
+  const libraryTabs = useFilteredTabs('library');
+
+  const handleResetFilters = () => {
+    setFilterInputs(INITIAL_PRODUCT_FILTER_STATE);
+    setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+  };
+
+  return (
+    <section className="flex h-full w-full min-h-0 relative outline-none overflow-hidden">
+      <div className="flex-1 flex flex-col min-h-0 min-w-0 px-5 pb-5">
+        <div className="flex flex-row justify-between py-4 items-center gap-4">
+          <TabNav activeTab="Menu Boards" navigation={libraryTabs} />
+          <div className="flex items-center gap-2 md:mb-0">
+            <Button
+              variant="primary"
+              className="font-semibold"
+              disabled={!isHydrated}
+              onClick={() => {
+                setSelectedProduct(null);
+                openModal('edit');
+              }}
+              leftIcon={Plus}
+            >
+              {t('Add Product')}
+            </Button>
+          </div>
+        </div>
+
+        <div className="flex flex-col lg:flex-row justify-between items-center gap-4">
+          <div className="w-full lg:flex-1 md:min-w-0">
+            <nav className="flex items-center gap-1 text-sm font-medium text-gray-500">
+              <button
+                className="px-3 py-2 hover:text-gray-900 transition-colors cursor-pointer"
+                onClick={() => navigate('/library/menu-boards')}
+              >
+                {t('Menu Boards')}
+              </button>
+              <ChevronRight size={24} className="p-1 text-gray-500" />
+              <button
+                className="px-3 py-2 hover:text-gray-900 transition-colors cursor-pointer"
+                onClick={() => navigate(`/library/menu-boards/${menuId}/categories`)}
+              >
+                {menuBoard?.name ?? `${t('Menu Board')} #${menuId}`}
+              </button>
+              <ChevronRight size={24} className="p-1 text-gray-500" />
+              <span className="px-3 py-2 text-xibo-blue-500 text-sm font-semibold truncate max-w-xs">
+                {category?.name ?? `${t('Category')} #${categoryId}`}
+              </span>
+            </nav>
+          </div>
+
+          <div className="flex items-center gap-2 w-full xl:w-115 lg:w-75 shrink-0">
+            <div className="relative flex-1 flex">
+              <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
+                <Search className="w-4 h-4 text-gray-400" />
+              </div>
+              <input
+                name="search"
+                value={globalFilter}
+                disabled={!isHydrated}
+                onChange={(e) => {
+                  setGlobalFilter(e.target.value);
+                  setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+                }}
+                placeholder={t('Search products...')}
+                className="py-2 px-3 pl-10 block h-11.25 bg-gray-100 rounded-lg w-full border-gray-200 disabled:opacity-50 disabled:pointer-events-none disabled:bg-gray-200"
+              />
+            </div>
+            <Button
+              leftIcon={!openFilter ? Filter : FilterX}
+              variant="secondary"
+              disabled={!isHydrated}
+              onClick={() => setOpenFilter((prev) => !prev)}
+              removeTextOnMobile
+            >
+              {t('Filters')}
+            </Button>
+          </div>
+        </div>
+
+        <FilterInputs
+          onChange={(name, value) => {
+            setFilterInputs((prev) => ({ ...prev, [name]: value }));
+            setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+          }}
+          isOpen={openFilter}
+          values={filterInputs}
+          options={filterOptions}
+          onReset={handleResetFilters}
+        />
+
+        {error && (
+          <div className="bg-red-50 border border-red-200 text-red-800 p-4" role="alert">
+            {error}
+          </div>
+        )}
+
+        <div className="min-h-0 flex flex-col">
+          {!isHydrated ? (
+            <div className="flex-1 flex items-center justify-center bg-gray-50 animate-pulse rounded-lg border border-gray-200">
+              <span className="text-gray-400 font-medium">{t('Loading...')}</span>
+            </div>
+          ) : (
+            <DataTable
+              columns={columns}
+              data={productList}
+              pageCount={pageCount}
+              pagination={pagination}
+              onPaginationChange={setPagination}
+              sorting={sorting}
+              onSortingChange={setSorting}
+              globalFilter={globalFilter}
+              onGlobalFilterChange={setGlobalFilter}
+              loading={isFetching}
+              rowSelection={rowSelection}
+              onRowSelectionChange={handleRowSelectionChange}
+              onRefresh={handleRefresh}
+              columnPinning={{ left: ['tableSelection'], right: ['tableActions'] }}
+              columnVisibility={columnVisibility}
+              onColumnVisibilityChange={setColumnVisibility}
+              bulkActions={bulkActions}
+              viewMode={null}
+              getRowId={getRowId}
+              tableLabel={t('Products')}
+            />
+          )}
+        </div>
+      </div>
+
+      <MenuBoardProductModals
+        menuCategoryId={categoryId!}
+        actions={{
+          activeModal,
+          closeModal,
+          handleRefresh,
+          deleteError,
+          isDeleting,
+          isCloning,
+        }}
+        selection={{
+          selectedProduct,
+          itemsToDelete,
+          existingNames: productList.map((p) => p.name),
+        }}
+        handlers={{
+          confirmDelete,
+          handleConfirmCopy,
+        }}
+      />
+
+      <MediaPreviewer
+        mediaId={previewItem?.mediaId ?? null}
+        mediaType="image"
+        fileName={previewItem?.name}
+        onClose={() => setPreviewItem(null)}
+      />
+    </section>
+  );
+}

--- a/frontend/src/pages/Library/MenuBoard/subPages/Products/MenuBoardProductsConfig.tsx
+++ b/frontend/src/pages/Library/MenuBoard/subPages/Products/MenuBoardProductsConfig.tsx
@@ -1,0 +1,246 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type { ColumnDef } from '@tanstack/react-table';
+import type { TFunction } from 'i18next';
+import { CopyCheck, Edit, Trash2 } from 'lucide-react';
+import { type ComponentProps } from 'react';
+
+import type { FilterConfigItem } from '@/components/ui/FilterInputs';
+import type { DataTableBulkAction } from '@/components/ui/table/DataTableBulkActions';
+import { ActionsCell, CheckMarkCell, MediaCell, TextCell } from '@/components/ui/table/cells';
+import type { MenuBoardProduct } from '@/types/menuBoardProduct';
+import type { ActionItem } from '@/types/table';
+
+export interface MenuBoardProductFilterInput {
+  menuProductId: string;
+  name: string;
+  code: string;
+  availability: string;
+}
+
+export const INITIAL_PRODUCT_FILTER_STATE: MenuBoardProductFilterInput = {
+  menuProductId: '',
+  name: '',
+  code: '',
+  availability: '',
+};
+
+export const getProductFilterKeys = (
+  t: TFunction,
+): FilterConfigItem<MenuBoardProductFilterInput>[] => [
+  {
+    label: t('Product ID'),
+    placeholder: t('Enter ID'),
+    name: 'menuProductId',
+    type: 'number',
+  },
+  {
+    label: t('Name'),
+    placeholder: t('Enter Name'),
+    name: 'name',
+    type: 'text',
+  },
+  {
+    label: t('Code'),
+    placeholder: t('Enter Code'),
+    name: 'code',
+    type: 'text',
+  },
+  {
+    label: t('Availability'),
+    name: 'availability',
+    type: 'select',
+    options: [
+      { label: t('Available'), value: '1' },
+      { label: t('Unavailable'), value: '0' },
+    ],
+  },
+];
+
+export interface MenuBoardProductActionsProps {
+  t: TFunction;
+  onEdit: (product: MenuBoardProduct) => void;
+  onCopy: (product: MenuBoardProduct) => void;
+  onDelete: (id: number) => void;
+  onPreview?: (product: MenuBoardProduct) => void;
+}
+
+export const getProductItemActions = ({
+  t,
+  onEdit,
+  onCopy,
+  onDelete,
+}: MenuBoardProductActionsProps): ((product: MenuBoardProduct) => ActionItem[]) => {
+  return (product: MenuBoardProduct) => [
+    {
+      label: t('Edit'),
+      icon: Edit,
+      onClick: () => onEdit(product),
+      isQuickAction: true,
+      variant: 'primary' as const,
+    },
+    {
+      label: t('Edit'),
+      icon: Edit,
+      onClick: () => onEdit(product),
+    },
+    {
+      label: t('Make a Copy'),
+      icon: CopyCheck,
+      onClick: () => onCopy(product),
+    },
+    { isSeparator: true },
+    {
+      label: t('Delete'),
+      icon: Trash2,
+      onClick: () => onDelete(product.menuProductId),
+      variant: 'danger' as const,
+    },
+  ];
+};
+
+export const getProductColumnDefinitions = (
+  props: MenuBoardProductActionsProps,
+): ColumnDef<MenuBoardProduct>[] => {
+  const { t, onPreview } = props;
+  const getActions = getProductItemActions(props);
+
+  return [
+    {
+      accessorKey: 'menuProductId',
+      header: t('ID'),
+      size: 60,
+      cell: (info) => <TextCell>{info.getValue<number>()}</TextCell>,
+    },
+    {
+      accessorKey: 'name',
+      header: t('Name'),
+      size: 150,
+      enableHiding: false,
+      cell: (info) => <TextCell weight="bold">{info.getValue<string>()}</TextCell>,
+    },
+    {
+      accessorKey: 'mediaId',
+      header: t('Media'),
+      size: 100,
+      enableSorting: false,
+      cell: (info) => {
+        const mediaId = info.getValue<number | undefined>();
+        if (!mediaId) {
+          return <TextCell>-</TextCell>;
+        }
+        return (
+          <MediaCell
+            thumb={`/library/thumbnail/${mediaId}`}
+            alt={info.row.original.name}
+            mediaType="image"
+            onPreview={onPreview ? () => onPreview(info.row.original) : undefined}
+          />
+        );
+      },
+    },
+    {
+      accessorKey: 'description',
+      header: t('Description'),
+      size: 150,
+      cell: (info) => <TextCell>{info.getValue<string>() || '-'}</TextCell>,
+    },
+    {
+      accessorKey: 'allergyInfo',
+      header: t('Allergy Info'),
+      size: 150,
+      cell: (info) => <TextCell>{info.getValue<string>() || '-'}</TextCell>,
+    },
+    {
+      accessorKey: 'code',
+      header: t('Code'),
+      size: 100,
+      cell: (info) => <TextCell>{info.getValue<string>() || '-'}</TextCell>,
+    },
+    {
+      accessorKey: 'price',
+      header: t('Price'),
+      size: 90,
+      cell: (info) => {
+        const val = info.getValue<number | undefined>();
+        return <TextCell>{val !== undefined && val !== null ? String(val) : '-'}</TextCell>;
+      },
+    },
+    {
+      accessorKey: 'availability',
+      header: t('Availability'),
+      size: 130,
+      cell: (info) => <CheckMarkCell active={info.getValue() === 1} />,
+    },
+    {
+      accessorKey: 'displayOrder',
+      header: t('Display Order'),
+      size: 100,
+      cell: (info) => {
+        const val = info.getValue<number | undefined>();
+        return <TextCell>{val !== undefined && val !== null ? String(val) : '-'}</TextCell>;
+      },
+    },
+    {
+      accessorKey: 'calories',
+      header: t('Calories'),
+      size: 90,
+      cell: (info) => {
+        const val = info.getValue<number | undefined>();
+        return <TextCell>{val !== undefined && val !== null ? String(val) : '-'}</TextCell>;
+      },
+    },
+    {
+      id: 'tableActions',
+      header: '',
+      size: 100,
+      minSize: 100,
+      maxSize: 100,
+      enableHiding: false,
+      enableResizing: false,
+      cell: ({ row }) => (
+        <ActionsCell
+          row={row}
+          actions={getActions(row.original) as ComponentProps<typeof ActionsCell>['actions']}
+        />
+      ),
+    },
+  ];
+};
+
+interface GetProductBulkActionsProps {
+  t: TFunction;
+  onDelete: () => void;
+}
+
+export const getProductBulkActions = ({
+  t,
+  onDelete,
+}: GetProductBulkActionsProps): DataTableBulkAction<MenuBoardProduct>[] => {
+  return [
+    {
+      label: t('Delete Selected'),
+      icon: Trash2,
+      onClick: onDelete,
+    },
+  ];
+};

--- a/frontend/src/pages/Library/MenuBoard/subPages/Products/components/AddAndEditMenuBoardProductModal.tsx
+++ b/frontend/src/pages/Library/MenuBoard/subPages/Products/components/AddAndEditMenuBoardProductModal.tsx
@@ -1,0 +1,408 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Minus, Plus } from 'lucide-react';
+import { useEffect, useState, useTransition } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import Button from '@/components/ui/Button';
+import MediaInput from '@/components/ui/forms/MediaInput';
+import NumberInput from '@/components/ui/forms/NumberInput';
+import Switch from '@/components/ui/forms/Switch';
+import TextInput from '@/components/ui/forms/TextInput';
+import Modal from '@/components/ui/modals/Modal';
+import { getMenuBoardProductSchema } from '@/schema/menuBoard';
+import { createMenuBoardProduct, updateMenuBoardProduct } from '@/services/menuBoardApi';
+import type { MenuBoardProduct } from '@/types/menuBoardProduct';
+
+interface AddAndEditMenuBoardProductModalProps {
+  type: 'add' | 'edit';
+  isOpen?: boolean;
+  menuCategoryId: string | number;
+  data?: MenuBoardProduct | null;
+  onClose: () => void;
+  onSave: () => void;
+}
+
+interface ProductOptionRow {
+  id: number;
+  option: string;
+  value: string;
+}
+
+interface ProductDraft {
+  name: string;
+  price: number | null;
+  description: string;
+  code: string;
+  displayOrder: number | null;
+  availability: boolean;
+  allergyInfo: string;
+  calories: number | null;
+  mediaId: number | null;
+  productOptions: ProductOptionRow[];
+}
+
+type ProductFormErrors = {
+  name?: string;
+  price?: string;
+  description?: string;
+  code?: string;
+  displayOrder?: string;
+  allergyInfo?: string;
+  calories?: string;
+};
+
+const DEFAULT_DRAFT: ProductDraft = {
+  name: '',
+  price: null,
+  description: '',
+  code: '',
+  displayOrder: null,
+  availability: true,
+  allergyInfo: '',
+  calories: null,
+  mediaId: null,
+  productOptions: [],
+};
+
+const createDraftFromData = (data?: MenuBoardProduct | null): ProductDraft => {
+  if (!data) {
+    return { ...DEFAULT_DRAFT };
+  }
+  return {
+    name: data.name ?? '',
+    price: data.price ?? null,
+    description: data.description ?? '',
+    code: data.code ?? '',
+    displayOrder: data.displayOrder ?? null,
+    availability: (data.availability ?? 1) === 1,
+    allergyInfo: data.allergyInfo ?? '',
+    calories: data.calories ?? null,
+    mediaId: data.mediaId || null,
+    productOptions: (data.productOptions ?? []).map((o, i) => ({
+      id: i,
+      option: o.option,
+      value: o.value,
+    })),
+  };
+};
+
+type ProductTab = 'general' | 'details' | 'options';
+
+function tabClass(activeTab: ProductTab, tab: ProductTab): string {
+  const isActive = activeTab === tab;
+  return `py-2 px-3 inline-flex items-center gap-2 border-b-2 text-sm font-semibold whitespace-nowrap focus:outline-none transition-all ${
+    isActive ? 'border-blue-600 text-blue-500' : 'border-gray-200 text-gray-500 hover:text-blue-600'
+  }`;
+}
+
+export default function AddAndEditMenuBoardProductModal({
+  type,
+  isOpen = true,
+  menuCategoryId,
+  onClose,
+  data,
+  onSave,
+}: AddAndEditMenuBoardProductModalProps) {
+  const { t } = useTranslation();
+  const [isPending, startTransition] = useTransition();
+  const [apiError, setApiError] = useState<string | undefined>();
+  const [formErrors, setFormErrors] = useState<ProductFormErrors>({});
+  const [activeTab, setActiveTab] = useState<ProductTab>('general');
+
+  const [draft, setDraft] = useState<ProductDraft>(() => createDraftFromData(data));
+
+  useEffect(() => {
+    if (isOpen) {
+      setDraft(createDraftFromData(data));
+      setApiError(undefined);
+      setFormErrors({});
+      setActiveTab('general');
+    }
+  }, [data, isOpen]);
+
+  const updateDraft = <K extends keyof ProductDraft>(field: K, value: ProductDraft[K]) => {
+    setDraft((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const clearError = (field: keyof ProductFormErrors) => {
+    setFormErrors((prev) => ({ ...prev, [field]: undefined }));
+  };
+
+  const tab = (name: ProductTab) => tabClass(activeTab, name);
+
+  const addOption = () => {
+    setDraft((prev) => {
+      const nextId =
+        prev.productOptions.length > 0 ? Math.max(...prev.productOptions.map((r) => r.id)) + 1 : 0;
+      return {
+        ...prev,
+        productOptions: [...prev.productOptions, { id: nextId, option: '', value: '' }],
+      };
+    });
+  };
+
+  const removeOption = (id: number) => {
+    setDraft((prev) => ({
+      ...prev,
+      productOptions: prev.productOptions.filter((r) => r.id !== id),
+    }));
+  };
+
+  const updateOption = (id: number, field: 'option' | 'value', value: string) => {
+    setDraft((prev) => ({
+      ...prev,
+      productOptions: prev.productOptions.map((r) => (r.id === id ? { ...r, [field]: value } : r)),
+    }));
+  };
+
+  const handleSave = () => {
+    const schema = getMenuBoardProductSchema(t);
+    const payload = {
+      ...draft,
+      availability: draft.availability ? 1 : 0,
+      productOptions: draft.productOptions.map(({ option, value }) => ({ option, value })),
+    };
+    const result = schema.safeParse(payload);
+
+    if (!result.success) {
+      const fieldErrors = result.error.flatten().fieldErrors;
+      const errors = {
+        name: fieldErrors.name?.[0],
+        description: fieldErrors.description?.[0],
+        code: fieldErrors.code?.[0],
+        allergyInfo: fieldErrors.allergyInfo?.[0],
+      };
+      setFormErrors(errors);
+      if (errors.name || errors.code) {
+        setActiveTab('general');
+      } else if (errors.description || errors.allergyInfo) {
+        setActiveTab('details');
+      }
+      return;
+    }
+
+    setFormErrors({});
+    setApiError(undefined);
+
+    startTransition(async () => {
+      try {
+        if (type === 'edit') {
+          if (!data) {
+            return;
+          }
+          await updateMenuBoardProduct(data.menuProductId, payload);
+        } else {
+          await createMenuBoardProduct(menuCategoryId, payload);
+        }
+        onSave();
+        onClose();
+      } catch (err: unknown) {
+        const axiosError = err as { response?: { data?: { message?: string } } };
+        setApiError(axiosError.response?.data?.message ?? t('An unexpected error occurred.'));
+      }
+    });
+  };
+
+  return (
+    <Modal
+      title={type === 'add' ? t('Add Product') : t('Edit Product')}
+      onClose={onClose}
+      isOpen={isOpen}
+      isPending={isPending}
+      error={apiError}
+      actions={[
+        { label: t('Cancel'), onClick: onClose, variant: 'secondary', disabled: isPending },
+        { label: isPending ? t('Saving…') : t('Save'), onClick: handleSave, disabled: isPending },
+      ]}
+    >
+      <>
+        <nav className="flex px-4 overflow-x-auto shrink-0" aria-label="Tabs">
+          <button type="button" className={tab('general')} onClick={() => setActiveTab('general')}>
+            {t('General')}
+          </button>
+          <button type="button" className={tab('details')} onClick={() => setActiveTab('details')}>
+            {t('Details')}
+          </button>
+          <button type="button" className={tab('options')} onClick={() => setActiveTab('options')}>
+            {t('Product Options')}
+          </button>
+        </nav>
+
+        <div className="px-8 pb-8 pt-4 space-y-4">
+          {activeTab === 'general' && (
+            <div className="space-y-4">
+              <TextInput
+                name="name"
+                label={t('Name')}
+                placeholder={t('Enter Name')}
+                helpText={t('The Name for this Menu Board Product.')}
+                value={draft.name}
+                error={formErrors.name}
+                onChange={(val) => {
+                  updateDraft('name', val);
+                  clearError('name');
+                }}
+              />
+
+              <NumberInput
+                name="price"
+                label={t('Price')}
+                helpText={t('The Price for this Menu Board Product.')}
+                value={draft.price ?? undefined}
+                onChange={(val) => {
+                  updateDraft('price', val !== undefined ? val : null);
+                }}
+              />
+
+              <NumberInput
+                name="displayOrder"
+                label={t('Display Order')}
+                helpText={t('Set a display order for this item to appear.')}
+                value={draft.displayOrder ?? undefined}
+                onChange={(val) => {
+                  updateDraft('displayOrder', val !== undefined ? Math.round(val) : null);
+                }}
+              />
+
+              <TextInput
+                name="code"
+                label={t('Code')}
+                placeholder={t('Enter Code')}
+                helpText={t('The Code identifier for this Menu Board Product.')}
+                value={draft.code}
+                error={formErrors.code}
+                onChange={(val) => {
+                  updateDraft('code', val);
+                  clearError('code');
+                }}
+              />
+
+              <MediaInput
+                label={t('Media')}
+                helpText={t(
+                  'Optionally select an Image or Video to be associated with this Menu Board Product.',
+                )}
+                value={draft.mediaId ?? undefined}
+                mediaType=""
+                onChange={(val) => {
+                  updateDraft('mediaId', val ? Number(val) : null);
+                }}
+              />
+
+              <Switch
+                label={t('Availability')}
+                helpText={t('Should this Product appear as available?')}
+                checked={draft.availability}
+                onChange={(val) => updateDraft('availability', val)}
+              />
+            </div>
+          )}
+
+          {activeTab === 'details' && (
+            <div className="space-y-4">
+              <TextInput
+                name="description"
+                label={t('Description')}
+                placeholder={t('Enter a short description')}
+                helpText={t('The Description for this Menu Board Product.')}
+                value={draft.description}
+                error={formErrors.description}
+                multiline
+                onChange={(val) => {
+                  updateDraft('description', val);
+                  clearError('description');
+                }}
+              />
+
+              <TextInput
+                name="allergyInfo"
+                label={t('Allergy Information')}
+                placeholder={t('Enter allergy information')}
+                helpText={t('The Allergy Information for this Menu Board Product.')}
+                value={draft.allergyInfo}
+                error={formErrors.allergyInfo}
+                multiline
+                onChange={(val) => {
+                  updateDraft('allergyInfo', val);
+                  clearError('allergyInfo');
+                }}
+              />
+
+              <NumberInput
+                name="calories"
+                label={t('Calories')}
+                helpText={t('How many calories are in this product?')}
+                value={draft.calories ?? undefined}
+                onChange={(val) => {
+                  updateDraft('calories', val !== undefined ? Math.round(val) : null);
+                }}
+              />
+            </div>
+          )}
+
+          {activeTab === 'options' && (
+            <div className="space-y-3">
+              <p className="text-sm text-gray-500">
+                {t(
+                  'If required please provide additional options and their prices for this Product.',
+                )}
+              </p>
+
+              {draft.productOptions.map((row) => (
+                <div key={row.id} className="flex gap-3 items-center">
+                  <input
+                    type="text"
+                    value={row.option}
+                    placeholder={t('Option Name')}
+                    onChange={(e) => updateOption(row.id, 'option', e.target.value)}
+                    className="flex-1 h-11.25 px-3 rounded-lg text-sm border border-gray-200 text-gray-800 placeholder:text-gray-500 hover:border-gray-400 focus:border-xibo-blue-600 focus:ring-xibo-blue-600/25 focus:ring-1 focus:outline-none"
+                  />
+                  <input
+                    type="number"
+                    step="0.01"
+                    min={0}
+                    value={row.value}
+                    placeholder={t('Option Value')}
+                    onChange={(e) => updateOption(row.id, 'value', e.target.value)}
+                    className="flex-1 h-11.25 px-3 rounded-lg text-sm border border-gray-200 text-gray-800 placeholder:text-gray-500 hover:border-gray-400 focus:border-xibo-blue-600 focus:ring-xibo-blue-600/25 focus:ring-1 focus:outline-none"
+                  />
+                  <Button
+                    variant="secondary"
+                    className="h-8 w-8 min-w-8"
+                    onClick={() => removeOption(row.id)}
+                  >
+                    <Minus size={14} />
+                  </Button>
+                </div>
+              ))}
+
+              <Button className="w-full" onClick={addOption}>
+                <Plus size={14} />
+              </Button>
+            </div>
+          )}
+        </div>
+      </>
+    </Modal>
+  );
+}

--- a/frontend/src/pages/Library/MenuBoard/subPages/Products/components/CopyMenuBoardProductModal.tsx
+++ b/frontend/src/pages/Library/MenuBoard/subPages/Products/components/CopyMenuBoardProductModal.tsx
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import NumberInput from '@/components/ui/forms/NumberInput';
+import TextInput from '@/components/ui/forms/TextInput';
+import Modal from '@/components/ui/modals/Modal';
+import type { MenuBoardProduct } from '@/types/menuBoardProduct';
+import { incrementName } from '@/utils/stringUtils';
+
+interface CopyMenuBoardProductModalProps {
+  isOpen?: boolean;
+  onClose: () => void;
+  onConfirm: (newName: string, newPrice: number | null, newCode: string) => void;
+  product: MenuBoardProduct | null;
+  isLoading?: boolean;
+  existingNames: string[];
+}
+
+export default function CopyMenuBoardProductModal({
+  isOpen = true,
+  onClose,
+  onConfirm,
+  product,
+  isLoading,
+  existingNames,
+}: CopyMenuBoardProductModalProps) {
+  const { t } = useTranslation();
+  const [newName, setNewName] = useState('');
+  const [newPrice, setNewPrice] = useState<number | undefined>(undefined);
+  const [newCode, setNewCode] = useState('');
+  const [error, setError] = useState<string | undefined>();
+
+  useEffect(() => {
+    if (isOpen) {
+      if (product) {
+        setNewName(incrementName(product.name));
+        setNewPrice(product.price ?? undefined);
+        setNewCode(product.code ?? '');
+      } else {
+        setNewName('');
+        setNewPrice(undefined);
+        setNewCode('');
+      }
+    }
+    setError(undefined);
+  }, [product, isOpen]);
+
+  const handleSave = () => {
+    const trimmed = newName.trim();
+
+    if (!trimmed) {
+      setError(t('Name is required'));
+      return;
+    }
+
+    if (existingNames.some((n) => n.toLowerCase() === trimmed.toLowerCase())) {
+      setError(t('A product with this name already exists'));
+      return;
+    }
+
+    setError(undefined);
+    onConfirm(trimmed, newPrice !== undefined ? newPrice : null, newCode);
+  };
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      title={t('Copy Product')}
+      onClose={onClose}
+      size="sm"
+      actions={[
+        {
+          label: t('Cancel'),
+          onClick: onClose,
+          variant: 'secondary',
+          disabled: isLoading,
+        },
+        {
+          label: isLoading ? t('Saving…') : t('Save'),
+          onClick: handleSave,
+          disabled: isLoading,
+        },
+      ]}
+    >
+      <div className="px-8 pb-8 space-y-4 pt-4">
+        <TextInput
+          name="newName"
+          value={newName}
+          label={t('Name')}
+          helpText={t('The Name for this Product.')}
+          error={error}
+          onChange={(val) => {
+            setNewName(val);
+            if (error) {
+              setError(undefined);
+            }
+          }}
+        />
+
+        <NumberInput
+          name="newPrice"
+          label={t('Price')}
+          helpText={t('The Price for this Menu Board Product.')}
+          value={newPrice}
+          onChange={(val) => {
+            setNewPrice(val);
+          }}
+        />
+
+        <TextInput
+          name="newCode"
+          value={newCode}
+          label={t('Code')}
+          helpText={t('The Code identifier for this Product.')}
+          optional
+          onChange={(val) => {
+            setNewCode(val);
+          }}
+        />
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/pages/Library/MenuBoard/subPages/Products/components/DeleteMenuBoardProductModal.tsx
+++ b/frontend/src/pages/Library/MenuBoard/subPages/Products/components/DeleteMenuBoardProductModal.tsx
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Trash2Icon } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+import Modal from '@/components/ui/modals/Modal';
+
+interface DeleteMenuBoardProductModalProps {
+  isOpen?: boolean;
+  onClose: () => void;
+  onDelete: () => void;
+  itemCount: number;
+  productName?: string;
+  error?: string | null;
+  isLoading?: boolean;
+}
+
+export default function DeleteMenuBoardProductModal({
+  isOpen = true,
+  onClose,
+  onDelete,
+  productName,
+  isLoading,
+  itemCount,
+  error,
+}: DeleteMenuBoardProductModalProps) {
+  const { t } = useTranslation();
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      isPending={isLoading}
+      onClose={onClose}
+      actions={[
+        {
+          label: t('Cancel'),
+          onClick: onClose,
+          variant: 'secondary',
+        },
+        {
+          label: isLoading ? t('Deleting…') : t('Yes, Delete'),
+          onClick: onDelete,
+          disabled: isLoading,
+        },
+      ]}
+      size="md"
+    >
+      <div className="flex flex-col p-5 gap-3">
+        <div>
+          <div className="flex justify-center mb-4">
+            <div className="bg-red-100 w-15.5 h-15.5 text-red-800 border-red-50 border-[7px] rounded-full p-3">
+              <Trash2Icon size={26} />
+            </div>
+          </div>
+          <h2 className="text-center text-lg font-semibold mb-2 text-red-800">
+            {itemCount === 1 ? t('Delete Product?') : t('Delete Products?')}
+          </h2>
+        </div>
+        <p className="text-center text-gray-500">
+          {itemCount === 1 ? (
+            <>
+              {t('Are you sure you want to delete ')}"<strong>{productName}</strong>"?
+            </>
+          ) : (
+            <>
+              {t('Are you sure you want to delete ')}
+              <strong>{itemCount}</strong> {t('products')}?
+            </>
+          )}
+        </p>
+
+        {error && (
+          <div className="mt-2 text-center">
+            <p className="text-sm font-medium text-red-600">{error}</p>
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/pages/Library/MenuBoard/subPages/Products/components/MenuBoardProductModals.tsx
+++ b/frontend/src/pages/Library/MenuBoard/subPages/Products/components/MenuBoardProductModals.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import AddAndEditMenuBoardProductModal from './AddAndEditMenuBoardProductModal';
+import CopyMenuBoardProductModal from './CopyMenuBoardProductModal';
+import DeleteMenuBoardProductModal from './DeleteMenuBoardProductModal';
+
+import type { MenuBoardProduct } from '@/types/menuBoardProduct';
+
+interface MenuBoardProductModalsProps {
+  menuCategoryId: string | number;
+  actions: {
+    activeModal: string | null;
+    closeModal: () => void;
+    handleRefresh: () => void;
+    deleteError: string | null;
+    isDeleting: boolean;
+    isCloning: boolean;
+  };
+  selection: {
+    selectedProduct: MenuBoardProduct | null;
+    itemsToDelete: MenuBoardProduct[];
+    existingNames: string[];
+  };
+  handlers: {
+    confirmDelete: () => void;
+    handleConfirmCopy: (newName: string, newPrice: number | null, newCode: string) => void;
+  };
+}
+
+export function MenuBoardProductModals({
+  menuCategoryId,
+  actions,
+  selection,
+  handlers,
+}: MenuBoardProductModalsProps) {
+  const isModalOpen = (name: string) => actions.activeModal === name;
+
+  return (
+    <>
+      {isModalOpen('edit') && (
+        <AddAndEditMenuBoardProductModal
+          type={selection.selectedProduct ? 'edit' : 'add'}
+          menuCategoryId={menuCategoryId}
+          onClose={actions.closeModal}
+          data={selection.selectedProduct}
+          onSave={actions.handleRefresh}
+        />
+      )}
+
+      {isModalOpen('copy') && (
+        <CopyMenuBoardProductModal
+          onClose={actions.closeModal}
+          onConfirm={handlers.handleConfirmCopy}
+          product={selection.selectedProduct}
+          existingNames={selection.existingNames}
+          isLoading={actions.isCloning}
+        />
+      )}
+
+      {isModalOpen('delete') && (
+        <DeleteMenuBoardProductModal
+          onClose={actions.closeModal}
+          onDelete={handlers.confirmDelete}
+          itemCount={selection.itemsToDelete.length}
+          productName={
+            selection.itemsToDelete.length === 1 ? selection.itemsToDelete[0]?.name : undefined
+          }
+          error={actions.deleteError}
+          isLoading={actions.isDeleting}
+        />
+      )}
+    </>
+  );
+}

--- a/frontend/src/pages/Library/MenuBoard/subPages/Products/hooks/useMenuBoardProductsData.ts
+++ b/frontend/src/pages/Library/MenuBoard/subPages/Products/hooks/useMenuBoardProductsData.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import type { PaginationState, SortingState } from '@tanstack/react-table';
+import type { AxiosError } from 'axios';
+
+import type { MenuBoardProductFilterInput } from '../MenuBoardProductsConfig';
+
+import { fetchMenuBoardProducts } from '@/services/menuBoardApi';
+
+export const MenuBoardProductQueryKeys = {
+  all: ['menuBoardProduct'] as const,
+  list: (menuCategoryId: string | number, params: Record<string, unknown>) =>
+    [...MenuBoardProductQueryKeys.all, 'list', String(menuCategoryId), params] as const,
+};
+
+interface UseMenuBoardProductsDataParams {
+  menuCategoryId: string | number;
+  pagination: PaginationState;
+  sorting: SortingState;
+  filter: string;
+  advancedFilters: MenuBoardProductFilterInput;
+  enabled?: boolean;
+}
+
+export const useMenuBoardProductsData = ({
+  menuCategoryId,
+  pagination,
+  sorting,
+  filter,
+  advancedFilters,
+  enabled = true,
+}: UseMenuBoardProductsDataParams) => {
+  const queryParams = {
+    pageIndex: pagination.pageIndex,
+    pageSize: pagination.pageSize,
+    sorting,
+    filter,
+    ...advancedFilters,
+  };
+
+  return useQuery({
+    queryKey: MenuBoardProductQueryKeys.list(menuCategoryId, queryParams),
+
+    queryFn: async ({ signal }) => {
+      const startOffset = pagination.pageIndex * pagination.pageSize;
+      const sortBy = sorting?.[0]?.id;
+      const sortDir = sorting?.[0]?.desc ? 'desc' : 'asc';
+      const { menuProductId, name, code, availability } = advancedFilters;
+
+      return fetchMenuBoardProducts(menuCategoryId, {
+        start: startOffset,
+        length: pagination.pageSize,
+        keyword: filter,
+        sortBy,
+        sortDir: sorting.length ? sortDir : undefined,
+        signal,
+        menuProductId: menuProductId ? Number(menuProductId) : undefined,
+        name: name || undefined,
+        code: code || undefined,
+        availability: availability !== '' ? Number(availability) : undefined,
+      });
+    },
+
+    enabled: enabled && !!menuCategoryId,
+    placeholderData: keepPreviousData,
+    staleTime: 1000 * 60,
+
+    throwOnError: (error: AxiosError) => {
+      return error.response?.status ? error.response.status >= 500 : false;
+    },
+  });
+};

--- a/frontend/src/schema/menuBoard.ts
+++ b/frontend/src/schema/menuBoard.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type { TFunction } from 'i18next';
+import { z } from 'zod';
+
+export const getMenuBoardSchema = (t: TFunction) =>
+  z.object({
+    name: z
+      .string()
+      .trim()
+      .min(1, t('Name is required'))
+      .max(255, t('Name must be at most 255 characters')),
+    description: z
+      .string()
+      .max(255, t('Description must be at most 255 characters'))
+      .nullable()
+      .optional(),
+    code: z.string().max(50, t('Code must be at most 50 characters')).optional().nullable(),
+    folderId: z.number().nullable().optional(),
+  });
+
+export type MenuBoardFormValues = z.infer<ReturnType<typeof getMenuBoardSchema>>;
+
+export const getMenuBoardCategorySchema = (t: TFunction) =>
+  z.object({
+    name: z
+      .string()
+      .trim()
+      .min(1, t('Name is required'))
+      .max(255, t('Name must be at most 255 characters')),
+    description: z
+      .string()
+      .max(255, t('Description must be at most 255 characters'))
+      .nullable()
+      .optional(),
+    code: z.string().max(50, t('Code must be at most 50 characters')).optional().nullable(),
+    mediaId: z.number().nullable().optional(),
+  });
+
+export type MenuBoardCategoryFormValues = z.infer<ReturnType<typeof getMenuBoardCategorySchema>>;
+
+export const getMenuBoardProductSchema = (t: TFunction) =>
+  z.object({
+    name: z
+      .string()
+      .trim()
+      .min(1, t('Name is required'))
+      .max(255, t('Name must be at most 255 characters')),
+    price: z.number().nullable().optional(),
+    description: z
+      .string()
+      .max(255, t('Description must be at most 255 characters'))
+      .nullable()
+      .optional(),
+    code: z.string().max(50, t('Code must be at most 50 characters')).optional().nullable(),
+    displayOrder: z.number().int().nullable().optional(),
+    availability: z.number().int().min(0).max(1).nullable().optional(),
+    allergyInfo: z.string().nullable().optional(),
+    calories: z.number().int().nullable().optional(),
+    mediaId: z.number().nullable().optional(),
+  });
+
+export type MenuBoardProductFormValues = z.infer<ReturnType<typeof getMenuBoardProductSchema>>;

--- a/frontend/src/services/menuBoardApi.ts
+++ b/frontend/src/services/menuBoardApi.ts
@@ -1,0 +1,452 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import http from '@/lib/api';
+import type { MenuBoard } from '@/types/menuBoard';
+import type { MenuBoardCategory } from '@/types/menuBoardCategory';
+import type { MenuBoardProduct } from '@/types/menuBoardProduct';
+
+// menuboards
+
+export interface FetchMenuBoardRequest {
+  start: number;
+  length: number;
+  keyword?: string;
+  sortBy?: string;
+  sortDir?: string;
+  signal?: AbortSignal;
+  folderId?: number;
+  menuId?: number;
+  userId?: number;
+  name?: string;
+  code?: string;
+  logicalOperatorName?: string;
+  modifiedDateFrom?: string;
+  modifiedDateTo?: string;
+}
+
+export interface FetchMenuBoardResponse {
+  rows: MenuBoard[];
+  totalCount: number;
+}
+
+export async function fetchMenuBoard(
+  options: FetchMenuBoardRequest = { start: 0, length: 10 },
+): Promise<FetchMenuBoardResponse> {
+  const { signal, ...queryParams } = options;
+
+  const response = await http.get('/menuboards', {
+    params: queryParams,
+    signal,
+  });
+
+  const totalCountHeader = response.headers['x-total-count'];
+  const totalCount = totalCountHeader ? parseInt(totalCountHeader, 10) : 0;
+
+  return { rows: response.data, totalCount };
+}
+
+export async function getMenuBoardById(menuBoardId: string | number): Promise<MenuBoard> {
+  const response = await http.get('/menuboards', {
+    params: { menuId: menuBoardId },
+  });
+
+  return response.data[0];
+}
+
+export interface CreateMenuBoardRequest {
+  name: string;
+  description?: string | null;
+  code?: string | null;
+  folderId?: number | null;
+}
+
+export async function createMenuBoard(data: CreateMenuBoardRequest): Promise<MenuBoard> {
+  const params = new URLSearchParams();
+
+  Object.entries(data).forEach(([key, value]) => {
+    if (value !== undefined && value !== null) {
+      params.append(key, String(value));
+    }
+  });
+
+  const response = await http.post('/menuboard', params.toString(), {
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'X-Requested-With': 'XMLHttpRequest',
+    },
+  });
+
+  return response.data;
+}
+
+export interface UpdateMenuBoardRequest {
+  name: string;
+  description?: string | null;
+  code?: string | null;
+  folderId?: number | null;
+}
+
+export async function updateMenuBoard(
+  menuBoardId: number | string,
+  data: UpdateMenuBoardRequest,
+): Promise<MenuBoard> {
+  const params = new URLSearchParams();
+
+  Object.entries(data).forEach(([key, value]) => {
+    if (value !== undefined && value !== null) {
+      params.append(key, String(value));
+    }
+  });
+
+  const response = await http.put(`/menuboard/${menuBoardId}`, params.toString(), {
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'X-Requested-With': 'XMLHttpRequest',
+    },
+  });
+
+  return response.data;
+}
+
+export interface CopyMenuBoardRequest {
+  menuBoardId: number | string;
+  name: string;
+  description?: string;
+  code?: string;
+}
+
+export async function copyMenuBoard({
+  menuBoardId,
+  name,
+  description,
+  code,
+}: CopyMenuBoardRequest): Promise<MenuBoard> {
+  const params = new URLSearchParams();
+  params.append('name', name);
+  if (description !== undefined) params.append('description', description);
+  if (code !== undefined) params.append('code', code);
+
+  const response = await http.post(`/menuboard/copy/${menuBoardId}`, params.toString(), {
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'X-Requested-With': 'XMLHttpRequest',
+    },
+  });
+
+  return response.data;
+}
+
+export async function deleteMenuBoard(menuBoardId: number | string): Promise<void> {
+  await http.delete(`/menuboard/${menuBoardId}`, {
+    headers: { 'X-Requested-With': 'XMLHttpRequest' },
+  });
+}
+
+export async function selectMenuBoardFolder(
+  menuBoardId: number | string,
+  folderId: number,
+): Promise<void> {
+  const params = new URLSearchParams();
+  params.append('folderId', String(folderId));
+
+  await http.put(`/menuboard/${menuBoardId}/selectfolder`, params.toString(), {
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'X-Requested-With': 'XMLHttpRequest',
+    },
+  });
+}
+
+// Categories
+
+export interface FetchMenuBoardCategoriesRequest {
+  start?: number;
+  length?: number;
+  keyword?: string;
+  sortBy?: string;
+  sortDir?: string;
+  menuCategoryId?: number;
+  name?: string;
+  code?: string;
+  modifiedDateFrom?: string;
+  modifiedDateTo?: string;
+  signal?: AbortSignal;
+}
+
+export interface FetchMenuBoardCategoriesResponse {
+  rows: MenuBoardCategory[];
+  totalCount: number;
+}
+
+export async function fetchMenuBoardCategories(
+  menuId: string | number,
+  options: FetchMenuBoardCategoriesRequest = { start: 0, length: 10 },
+): Promise<FetchMenuBoardCategoriesResponse> {
+  const { signal, ...queryParams } = options;
+
+  const response = await http.get(`/menuboard/${menuId}/categories`, {
+    params: queryParams,
+    signal,
+  });
+
+  const totalCountHeader = response.headers['x-total-count'];
+  const totalCount = totalCountHeader ? parseInt(totalCountHeader, 10) : 0;
+
+  return { rows: response.data, totalCount };
+}
+
+export async function getCategoryById(
+  menuId: string | number,
+  categoryId: string | number,
+): Promise<MenuBoardCategory | undefined> {
+  const response = await http.get(`/menuboard/${menuId}/categories`, {
+    params: { menuCategoryId: categoryId, start: 0, length: 1 },
+  });
+  return response.data[0] as MenuBoardCategory | undefined;
+}
+
+export interface MenuBoardCategoryRequest {
+  name: string;
+  description?: string | null;
+  code?: string | null;
+  mediaId?: number | null;
+}
+
+export async function createMenuBoardCategory(
+  menuId: string | number,
+  data: MenuBoardCategoryRequest,
+): Promise<MenuBoardCategory> {
+  const params = new URLSearchParams();
+
+  Object.entries(data).forEach(([key, value]) => {
+    if (value !== undefined && value !== null) {
+      params.append(key, String(value));
+    }
+  });
+
+  const response = await http.post(`/menuboard/${menuId}/category`, params.toString(), {
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'X-Requested-With': 'XMLHttpRequest',
+    },
+  });
+
+  return response.data;
+}
+
+export async function updateMenuBoardCategory(
+  menuCategoryId: string | number,
+  data: MenuBoardCategoryRequest,
+): Promise<MenuBoardCategory> {
+  const params = new URLSearchParams();
+
+  Object.entries(data).forEach(([key, value]) => {
+    if (value !== undefined && value !== null) {
+      params.append(key, String(value));
+    }
+  });
+
+  const response = await http.put(`/menuboard/${menuCategoryId}/category`, params.toString(), {
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'X-Requested-With': 'XMLHttpRequest',
+    },
+  });
+
+  return response.data;
+}
+
+export async function deleteMenuBoardCategory(menuCategoryId: string | number): Promise<void> {
+  await http.delete(`/menuboard/${menuCategoryId}/category`, {
+    headers: { 'X-Requested-With': 'XMLHttpRequest' },
+  });
+}
+
+export interface CopyMenuBoardCategoryRequest {
+  menuCategoryId: number | string;
+  name: string;
+  description?: string;
+  code?: string;
+}
+
+export async function copyMenuBoardCategory({
+  menuCategoryId,
+  name,
+  description,
+  code,
+}: CopyMenuBoardCategoryRequest): Promise<MenuBoardCategory> {
+  const params = new URLSearchParams();
+  params.append('name', name);
+  if (description !== undefined) params.append('description', description);
+  if (code !== undefined) params.append('code', code);
+
+  const response = await http.post(
+    `/menuboard/category/copy/${menuCategoryId}`,
+    params.toString(),
+    {
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'X-Requested-With': 'XMLHttpRequest',
+      },
+    },
+  );
+
+  return response.data;
+}
+
+// Products
+
+export interface FetchMenuBoardProductsRequest {
+  start?: number;
+  length?: number;
+  keyword?: string;
+  sortBy?: string;
+  sortDir?: string;
+  menuProductId?: number;
+  name?: string;
+  code?: string;
+  availability?: number;
+  signal?: AbortSignal;
+}
+
+export interface FetchMenuBoardProductsResponse {
+  rows: MenuBoardProduct[];
+  totalCount: number;
+}
+
+export async function fetchMenuBoardProducts(
+  menuCategoryId: string | number,
+  options: FetchMenuBoardProductsRequest = { start: 0, length: 10 },
+): Promise<FetchMenuBoardProductsResponse> {
+  const { signal, ...queryParams } = options;
+
+  const response = await http.get(`/menuboard/${menuCategoryId}/products`, {
+    params: queryParams,
+    signal,
+  });
+
+  const totalCountHeader = response.headers['x-total-count'];
+  const totalCount = totalCountHeader ? parseInt(totalCountHeader, 10) : 0;
+
+  return { rows: response.data, totalCount };
+}
+
+export interface FetchMenuBoardProductsForWidgetRequest {
+  menuId?: number;
+  menuProductId?: number;
+  menuCategoryId?: number;
+  name?: string;
+  availability?: number;
+  categories?: string;
+  signal?: AbortSignal;
+}
+
+export async function fetchMenuBoardProductsForWidget(
+  options: FetchMenuBoardProductsForWidgetRequest = {},
+): Promise<MenuBoardProduct[]> {
+  const { signal, ...queryParams } = options;
+
+  const response = await http.get('/menuboard/products', {
+    params: queryParams,
+    signal,
+  });
+
+  return response.data;
+}
+
+export interface MenuBoardProductOptionRequest {
+  option: string;
+  value: string;
+}
+
+export interface MenuBoardProductRequest {
+  name: string;
+  price?: number | null;
+  description?: string | null;
+  code?: string | null;
+  displayOrder?: number | null;
+  availability?: number | null;
+  allergyInfo?: string | null;
+  calories?: number | null;
+  mediaId?: number | null;
+  productOptions?: MenuBoardProductOptionRequest[];
+}
+
+function buildProductParams(data: MenuBoardProductRequest): URLSearchParams {
+  const params = new URLSearchParams();
+  const { productOptions, ...scalar } = data;
+
+  Object.entries(scalar).forEach(([key, value]) => {
+    if (value !== undefined && value !== null) {
+      params.append(key, String(value));
+    }
+  });
+
+  (productOptions ?? []).forEach((opt) => {
+    params.append('productOptions[]', opt.option);
+    params.append('productValues[]', opt.value);
+  });
+
+  return params;
+}
+
+export async function createMenuBoardProduct(
+  menuCategoryId: string | number,
+  data: MenuBoardProductRequest,
+): Promise<MenuBoardProduct> {
+  const response = await http.post(
+    `/menuboard/${menuCategoryId}/product`,
+    buildProductParams(data).toString(),
+    {
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'X-Requested-With': 'XMLHttpRequest',
+      },
+    },
+  );
+
+  return response.data;
+}
+
+export async function updateMenuBoardProduct(
+  menuProductId: string | number,
+  data: MenuBoardProductRequest,
+): Promise<MenuBoardProduct> {
+  const response = await http.put(
+    `/menuboard/${menuProductId}/product`,
+    buildProductParams(data).toString(),
+    {
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'X-Requested-With': 'XMLHttpRequest',
+      },
+    },
+  );
+
+  return response.data;
+}
+
+export async function deleteMenuBoardProduct(menuProductId: string | number): Promise<void> {
+  await http.delete(`/menuboard/${menuProductId}/product`, {
+    headers: { 'X-Requested-With': 'XMLHttpRequest' },
+  });
+}

--- a/frontend/src/types/layout.ts
+++ b/frontend/src/types/layout.ts
@@ -19,7 +19,7 @@
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import type {Tag} from './tag';
+import type { Tag } from './tag';
 
 export interface Layout {
   layoutId: number;

--- a/frontend/src/types/menuBoard.ts
+++ b/frontend/src/types/menuBoard.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type { MenuBoardCategory } from './menuBoardCategory';
+
+export interface MenuBoardPermissions {
+  view?: number;
+  edit?: number;
+  delete?: number;
+  modifyPermissions?: number;
+}
+
+export interface MenuBoard {
+  menuId: number;
+  name: string;
+  description: string;
+  code: string;
+  userId: number;
+  owner: string;
+  modifiedDt: number;
+  folderId: number;
+  permissionsFolderId: number;
+  groupsWithPermissions: string;
+  permissions?: MenuBoardPermissions[];
+  categories?: MenuBoardCategory[];
+}

--- a/frontend/src/types/menuBoardCategory.ts
+++ b/frontend/src/types/menuBoardCategory.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type { MenuBoardProduct } from './menuBoardProduct';
+
+export interface MenuBoardCategory {
+  menuCategoryId: number;
+  menuId: number;
+  name: string;
+  description?: string;
+  code?: string;
+  mediaId?: number;
+  mediaType?: string;
+  modifiedDt?: number;
+  thumbnail?: string;
+  products?: MenuBoardProduct[];
+}

--- a/frontend/src/types/menuBoardProduct.ts
+++ b/frontend/src/types/menuBoardProduct.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export interface MenuBoardProductOption {
+  menuProductId: number;
+  option: string;
+  value: string;
+}
+
+export interface MenuBoardProduct {
+  menuProductId: number;
+  menuCategoryId: number;
+  menuId: number;
+  name: string;
+  price?: number;
+  description?: string;
+  code?: string;
+  displayOrder?: number;
+  availability?: number;
+  allergyInfo?: string;
+  calories?: number;
+  mediaId?: number;
+  productOptions?: MenuBoardProductOption[];
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -23,8 +23,8 @@ import path from 'node:path';
 
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
-import {visualizer} from 'rollup-plugin-visualizer';
-import {defineConfig} from 'vite';
+import { visualizer } from 'rollup-plugin-visualizer';
+import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig(({ mode }) => ({
@@ -61,9 +61,7 @@ export default defineConfig(({ mode }) => ({
     cors: {
       origin: true,
       methods: ['GET', 'OPTIONS'],
-      allowedHeaders: [
-        'Content-Type', 'X-Requested-With', 'Accept', 'Origin', 'X-PREVIEW-JWT',
-      ],
+      allowedHeaders: ['Content-Type', 'X-Requested-With', 'Accept', 'Origin', 'X-PREVIEW-JWT'],
     },
     proxy: {
       '/json': {

--- a/lib/Controller/MenuBoard.php
+++ b/lib/Controller/MenuBoard.php
@@ -106,6 +106,20 @@ class MenuBoard extends Base
         required: false,
         schema: new OA\Schema(type: 'string')
     )]
+    #[OA\Parameter(
+        name: 'modifiedDateFrom',
+        description: 'Filter by modified date (from)',
+        in: 'query',
+        required: false,
+        schema: new OA\Schema(type: 'string')
+    )]
+    #[OA\Parameter(
+        name: 'modifiedDateTo',
+        description: 'Filter by modified date (to)',
+        in: 'query',
+        required: false,
+        schema: new OA\Schema(type: 'string')
+    )]
     #[OA\Response(
         response: 200,
         description: 'successful operation',
@@ -133,6 +147,8 @@ class MenuBoard extends Base
             'code' => $parsedParams->getString('code'),
             'folderId' => $parsedParams->getInt('folderId'),
             'logicalOperatorName' => $parsedParams->getString('logicalOperatorName'),
+            'modifiedDateFrom' => $parsedParams->getDate('modifiedDateFrom'),
+            'modifiedDateTo' => $parsedParams->getDate('modifiedDateTo'),
         ];
 
         $menuBoards = $this->menuBoardFactory->query(
@@ -141,7 +157,7 @@ class MenuBoard extends Base
         );
 
         foreach ($menuBoards as $menuBoard) {
-            if ($this->isApi($request)) {
+            if ($this->isApi($request) || $this->isJson($request)) {
                 continue;
             }
 

--- a/lib/Controller/MenuBoardCategory.php
+++ b/lib/Controller/MenuBoardCategory.php
@@ -159,10 +159,6 @@ class MenuBoardCategory extends Base
 
 
         foreach ($menuBoardCategories as $menuBoardCategory) {
-            if ($this->isApi($request)) {
-                continue;
-            }
-
             if ($menuBoardCategory->mediaId != 0) {
                 $menuBoardCategory->setUnmatchedProperty(
                     'thumbnail',
@@ -173,6 +169,16 @@ class MenuBoardCategory extends Base
                         ['preview' => 1],
                     )
                 );
+                try {
+                    $media = $this->mediaFactory->getById($menuBoardCategory->mediaId);
+                    $menuBoardCategory->setUnmatchedProperty('mediaType', $media->mediaType);
+                } catch (\Exception $e) {
+                    $menuBoardCategory->setUnmatchedProperty('mediaType', null);
+                }
+            }
+
+            if ($this->isApi($request) || $this->isJson($request)) {
+                continue;
             }
 
             $menuBoardCategory->includeProperty('buttons');

--- a/lib/Controller/MenuBoardProduct.php
+++ b/lib/Controller/MenuBoardProduct.php
@@ -171,19 +171,32 @@ class MenuBoardProduct extends Base
         );
 
         foreach ($menuBoardProducts as $menuBoardProduct) {
-            if ($this->isApi($request)) {
+            if ($menuBoardProduct->mediaId != 0) {
+                $menuBoardProduct->setUnmatchedProperty(
+                    'thumbnail',
+                    $this->urlFor(
+                        $request,
+                        'library.download',
+                        ['id' => $menuBoardProduct->mediaId],
+                        ['preview' => 1],
+                    )
+                );
+                try {
+                    $media = $this->mediaFactory->getById($menuBoardProduct->mediaId);
+                    $menuBoardProduct->setUnmatchedProperty('mediaType', $media->mediaType);
+                } catch (\Exception $e) {
+                    $menuBoardProduct->setUnmatchedProperty('mediaType', null);
+                }
+            }
+
+            if ($this->isApi($request) || $this->isJson($request)) {
+                $menuBoardProduct->productOptions = $menuBoardProduct->getOptions();
                 continue;
             }
 
             $menuBoardProduct->includeProperty('buttons');
             $menuBoardProduct->buttons = [];
 
-            if ($menuBoardProduct->mediaId != 0) {
-                $menuBoardProduct->setUnmatchedProperty(
-                    'thumbnail',
-                    $this->urlFor($request, 'library.download', ['id' => $menuBoardProduct->mediaId], ['preview' => 1]),
-                );
-            }
 
             if ($this->getUser()->featureEnabled('menuBoard.modify') && $this->getUser()->checkEditable($menuBoard)) {
                 $menuBoardProduct->buttons[] = [
@@ -378,7 +391,7 @@ class MenuBoardProduct extends Base
         $sanitizedParams = $this->getSanitizer($request->getParams());
 
         $name = $sanitizedParams->getString('name');
-        $mediaId = $sanitizedParams->getInt('mediaId');
+        $mediaId = $sanitizedParams->getInt('mediaId') ?: null;
         $price = $sanitizedParams->getDouble('price');
         $description = $sanitizedParams->getString('description');
         $allergyInfo = $sanitizedParams->getString('allergyInfo');
@@ -559,7 +572,7 @@ class MenuBoardProduct extends Base
         $menuBoardProduct->calories = $sanitizedParams->getInt('calories');
         $menuBoardProduct->displayOrder = $sanitizedParams->getInt('displayOrder');
         $menuBoardProduct->availability = $sanitizedParams->getCheckbox('availability');
-        $menuBoardProduct->mediaId = $sanitizedParams->getInt('mediaId');
+        $menuBoardProduct->mediaId = $sanitizedParams->getInt('mediaId') ?: null;
         $menuBoardProduct->code = $sanitizedParams->getString('code');
         $productOptions = $sanitizedParams->getArray('productOptions', ['default' => []]);
         $productValues = $sanitizedParams->getArray('productValues', ['default' => []]);

--- a/lib/Factory/MenuBoardFactory.php
+++ b/lib/Factory/MenuBoardFactory.php
@@ -265,6 +265,16 @@ class MenuBoardFactory extends BaseFactory
             $params['code'] = '%' . $sanitizedFilter->getString('code') . '%';
         }
 
+        if ($sanitizedFilter->getDate('modifiedDateFrom') !== null) {
+            $body .= ' AND `menu_board`.modifiedDt >= :modifiedDateFrom ';
+            $params['modifiedDateFrom'] = strtotime($sanitizedFilter->getDate('modifiedDateFrom'));
+        }
+
+        if ($sanitizedFilter->getDate('modifiedDateTo') !== null) {
+            $body .= ' AND `menu_board`.modifiedDt <= :modifiedDateTo ';
+            $params['modifiedDateTo'] = strtotime($sanitizedFilter->getDate('modifiedDateTo'));
+        }
+
         // Sorting?
         $order = '';
 

--- a/views/authed-sidebar.twig
+++ b/views/authed-sidebar.twig
@@ -46,7 +46,7 @@
             {% endif %}
 
             {% if currentUser.featureEnabled("menuBoard.view") %}
-                <li class="sidebar-list"><a href="{{ url_for("menuBoard.view") }}">{% trans "Menu Boards" %}</a></li>
+                <li class="sidebar-list"><a href="{{ theme.rootUri() }}prototype/library/menu-boards">{% trans "Menu Boards" %}</a></li>
             {% endif %}
         {% endif %}
 

--- a/views/authed-topbar.twig
+++ b/views/authed-topbar.twig
@@ -99,7 +99,7 @@
             {% endif %}
 
             {% if currentUser.featureEnabled("menuBoard.view") %}
-                <a class="{{ groupElementClass }}" href="{{ url_for("menuBoard.view") }}">{% trans "Menu Boards" %}</a>
+                <a class="{{ groupElementClass }}" href="{{ theme.rootUri() }}prototype/library/menu-boards">{% trans "Menu Boards" %}</a>
             {% endif %}
         {% if countViewable > 1 %}
             </div>


### PR DESCRIPTION
relates to xibosignageltd/xibo-private#1374

- Added `optional` prop to all form components
- New `Switch` form component
- Removed stray `border-b` from tab navs in Display Group, Manage Members, Edit Display, and Dataset RSS modals
- Fixed `useTableState` key in Dataset sub-pages (Columns, Data, RSS) to use a static key
- `EditDisplayModal`: replaced "Authorise display?" dropdown with `Switch`
- Improvements to `MediaInput` and `MediaPreviewer`
- API: added `modifiedDateFrom` / `modifiedDateTo` filter params to Menu Boards endpoint
- API: `isJson` check added alongside `isApi` in Menu Board, Category, and Product controllers so the React frontend receives the same enriched response (thumbnail URLs, mediaType, productOptions)
- API: Category and Product controllers now resolve and return `mediaType` for attached media
- API: `mediaId` coerced to `null` (instead of `0`) on Product add/edit when not provided