### PR TITLE
QA: (Part 1) Display edit form tabs and accessibility

### DIFF
--- a/frontend/src/components/ui/forms/MultiSelectDropdown.tsx
+++ b/frontend/src/components/ui/forms/MultiSelectDropdown.tsx
@@ -32,7 +32,7 @@ import {
   useInteractions,
 } from '@floating-ui/react';
 import { ChevronDown, Search, X } from 'lucide-react';
-import { useLayoutEffect, useRef, useState } from 'react';
+import { useId, useLayoutEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { twMerge } from 'tailwind-merge';
 
@@ -77,6 +77,7 @@ export default function MultiSelectDropdown({
   optional = false,
 }: MultiSelectDropdownProps) {
   const { t } = useTranslation();
+  const id = useId();
   const [isOpen, setIsOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
 
@@ -180,7 +181,10 @@ export default function MultiSelectDropdown({
 
   return (
     <div className={twMerge('flex flex-col gap-1 relative w-full', className)}>
-      <label className="flex items-center justify-between text-sm font-semibold text-gray-500 leading-5">
+      <label
+        id={`${id}-label`}
+        className="flex items-center justify-between text-sm font-semibold text-gray-500 leading-5"
+      >
         <span>{t(label)}</span>
         {optional && <span className="text-xs font-normal text-gray-500">{t('Optional')}</span>}
       </label>
@@ -188,6 +192,12 @@ export default function MultiSelectDropdown({
       <div
         ref={refs.setReference}
         {...getReferenceProps()}
+        role="combobox"
+        aria-expanded={isOpen}
+        aria-haspopup="listbox"
+        aria-labelledby={`${id}-label`}
+        aria-controls={`${id}-listbox`}
+        tabIndex={0}
         className={twMerge(
           'w-full border bg-white border-gray-200 rounded-lg flex items-center cursor-pointer hover:border-gray-400 focus-within:border-xibo-blue-600 focus-within:ring-1 focus-within:ring-xibo-blue-600/25 focus:outline-none transition-colors',
           showTags && value.length > 0 ? 'min-h-11.25 py-2 px-2' : 'h-11.25',
@@ -258,7 +268,12 @@ export default function MultiSelectDropdown({
                 onClick={(e) => e.stopPropagation()}
               />
             </div>
-            <div className="flex flex-col p-2 text-sm overflow-y-auto max-h-75">
+            <div
+              id={`${id}-listbox`}
+              role="listbox"
+              aria-multiselectable="true"
+              className="flex flex-col p-2 text-sm overflow-y-auto max-h-75"
+            >
               {(() => {
                 const allChecked = options.length > 0 && value.length === options.length;
                 const someChecked = value.length > 0 && value.length < options.length;

--- a/frontend/src/components/ui/forms/SelectDropdown.tsx
+++ b/frontend/src/components/ui/forms/SelectDropdown.tsx
@@ -32,7 +32,7 @@ import {
   FloatingPortal,
 } from '@floating-ui/react';
 import { ChevronDown, Search } from 'lucide-react';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useId, useRef } from 'react';
 import type { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { twMerge } from 'tailwind-merge';
@@ -91,6 +91,7 @@ export default function SelectDropdown({
   optional = false,
 }: SelectDropdownProps) {
   const { t } = useTranslation();
+  const id = useId();
 
   const [isOpen, setIsOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
@@ -157,7 +158,10 @@ export default function SelectDropdown({
   return (
     <div className={twMerge('relative overflow-visible', className)}>
       {label && (
-        <label className="flex items-center justify-between text-sm font-semibold text-gray-500 leading-5">
+        <label
+          id={`${id}-label`}
+          className="flex items-center justify-between text-sm font-semibold text-gray-500 leading-5"
+        >
           <span>{t(label)}</span>
           {optional && <span className="text-xs font-normal text-gray-500">{t('Optional')}</span>}
         </label>
@@ -166,6 +170,12 @@ export default function SelectDropdown({
       <div
         ref={refs.setReference}
         {...getReferenceProps()}
+        role="combobox"
+        aria-expanded={isOpen}
+        aria-haspopup="listbox"
+        aria-labelledby={label ? `${id}-label` : undefined}
+        aria-controls={`${id}-listbox`}
+        tabIndex={0}
         className="w-full border bg-white border-gray-200 rounded-lg flex items-center cursor-pointer h-11.25 hover:border-gray-400 focus-within:border-xibo-blue-600 focus-within:ring-1 focus-within:ring-xibo-blue-600/25 focus:outline-none transition-colors"
       >
         {addLeftLabel && leftLabelContent && (
@@ -222,6 +232,8 @@ export default function SelectDropdown({
               </div>
             )}
             <div
+              id={`${id}-listbox`}
+              role="listbox"
               ref={scrollContainerRef}
               className="flex flex-col p-2 text-sm overflow-y-auto max-h-75"
             >
@@ -247,6 +259,8 @@ export default function SelectDropdown({
                 <button
                   key={option.value}
                   type="button"
+                  role="option"
+                  aria-selected={option.value === value}
                   disabled={option.disabled}
                   className={twMerge(
                     'text-left p-2 rounded-lg font-medium flex gap-2 items-center min-w-0',

--- a/frontend/src/components/ui/forms/TagInput.tsx
+++ b/frontend/src/components/ui/forms/TagInput.tsx
@@ -20,7 +20,7 @@
  */
 
 import { X } from 'lucide-react';
-import { useState } from 'react';
+import { useId, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { twMerge } from 'tailwind-merge';
 
@@ -54,6 +54,7 @@ function TagInput({
   optional = false,
 }: TagInputProps) {
   const { t } = useTranslation();
+  const inputId = useId();
   const [input, setInput] = useState('');
   const tags = Array.isArray(value) ? value : [];
 
@@ -98,7 +99,10 @@ function TagInput({
 
   return (
     <div className={twMerge('flex flex-col gap-1 relative w-full', className)}>
-      <label className="flex items-center justify-between text-sm font-semibold text-gray-500 leading-5">
+      <label
+        htmlFor={inputId}
+        className="flex items-center justify-between text-sm font-semibold text-gray-500 leading-5"
+      >
         <span>{!label ? t('Tags') : label}</span>
         {optional && <span className="text-xs font-normal text-gray-500">{t('Optional')}</span>}
       </label>
@@ -132,6 +136,7 @@ function TagInput({
             </span>
           ))}
           <input
+            id={inputId}
             className="flex-1 min-w-30 text-sm p-1 bg-transparent border-none outline-none focus:outline-none focus:ring-0"
             value={input}
             disabled={disabled}

--- a/frontend/src/pages/Displays/Displays/__tests__/Displays.add.test.tsx
+++ b/frontend/src/pages/Displays/Displays/__tests__/Displays.add.test.tsx
@@ -1,0 +1,208 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent, { type UserEvent } from '@testing-library/user-event';
+import type React from 'react';
+import { vi, beforeEach, describe, test, expect } from 'vitest';
+
+import { EMPTY_DISPLAY_TABLE } from './fixtures/display';
+import { renderDisplaysPage } from './helpers/renderDisplaysPage';
+import { mockFetchDisplays } from './mocks/displaysApi';
+
+import { notify } from '@/components/ui/Notification';
+import { addDisplayViaCode } from '@/services/displaysApi';
+import { testQueryClient } from '@/setupTests';
+
+// =============================================================================
+// Module mocks
+// =============================================================================
+
+vi.mock('react-i18next', () => {
+  const t = (key: string) => key;
+  return {
+    useTranslation: () => ({ t, i18n: { changeLanguage: vi.fn() } }),
+    Trans: ({ children }: { children: React.ReactNode }) => children,
+  };
+});
+
+vi.mock('@/services/displaysApi');
+vi.mock('@/services/displayGroupApi', () => ({
+  fetchDisplayGroups: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+  deleteDisplayGroup: vi.fn(),
+}));
+vi.mock('@/services/displayProfileApi', () => ({
+  fetchDisplayProfile: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+  fetchDisplayProfileById: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('@/services/userApi', () => ({
+  fetchUserPreference: vi.fn().mockResolvedValue(null),
+  saveUserPreference: vi.fn().mockResolvedValue(undefined),
+  fetchUsers: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('@/services/folderApi', () => ({
+  fetchFolderById: vi.fn().mockResolvedValue({ id: 1, text: 'Root' }),
+  fetchFolderTree: vi.fn().mockResolvedValue([]),
+  searchFolders: vi.fn().mockResolvedValue([]),
+  fetchContextButtons: vi.fn().mockResolvedValue({ create: true }),
+  selectFolder: vi.fn().mockResolvedValue({ success: true }),
+}));
+vi.mock('@/components/ui/modals/Modal');
+vi.mock('@/components/ui/FolderActionModals', () => ({ default: () => null }));
+vi.mock('@/components/ui/Notification', () => ({
+  notify: { success: vi.fn(), error: vi.fn() },
+}));
+vi.mock('../hooks/useDisplaysFilterOptions', () => ({
+  useDisplaysFilterOptions: () => ({ filterOptions: [], isLoading: false }),
+}));
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const openAddModal = async (user: UserEvent) => {
+  renderDisplaysPage();
+  const addButton = await screen.findByRole('button', { name: /add display/i });
+  await user.click(addButton);
+  await screen.findByRole('dialog', { name: /add display via code/i });
+};
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('Displays page - add display', () => {
+  beforeEach(() => {
+    testQueryClient.clear();
+    vi.clearAllMocks();
+    mockFetchDisplays(EMPTY_DISPLAY_TABLE);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Clicking the Add Display button on the page header opens the Add modal.
+  // ---------------------------------------------------------------------------
+  test('clicking Add Display opens the Add Display modal', async () => {
+    const user = userEvent.setup();
+    await openAddModal(user);
+
+    expect(screen.getByRole('dialog', { name: /add display via code/i })).toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // The Save button must be disabled until the user has typed something into
+  // the code field — submitting an empty code would be a no-op on the server.
+  // ---------------------------------------------------------------------------
+  test('Save button is disabled when the code field is empty', async () => {
+    const user = userEvent.setup();
+    await openAddModal(user);
+
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Typing any non-whitespace character into the code field enables the button.
+  // ---------------------------------------------------------------------------
+  test('Save button becomes enabled once a code is typed', async () => {
+    const user = userEvent.setup();
+    await openAddModal(user);
+
+    await user.type(screen.getByRole('textbox', { name: /code/i }), 'ABC-123');
+
+    expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Clicking Cancel must close the modal without contacting the server.
+  // ---------------------------------------------------------------------------
+  test('Cancel closes the modal without calling the API', async () => {
+    const user = userEvent.setup();
+    await openAddModal(user);
+
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(screen.queryByRole('dialog', { name: /add display via code/i })).not.toBeInTheDocument();
+    expect(addDisplayViaCode).not.toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // A correct code triggers the success notification and closes the modal.
+  // The notification message "CMS Credentials Added" confirms to the user that
+  // the CMS address and key have been accepted by the authentication service.
+  // ---------------------------------------------------------------------------
+  test('correct code shows "CMS Credentials Added" notification and closes the modal', async () => {
+    const user = userEvent.setup();
+    vi.mocked(addDisplayViaCode).mockResolvedValue(undefined);
+
+    await openAddModal(user);
+    await user.type(screen.getByRole('textbox', { name: /code/i }), 'VALID-CODE');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(notify.success).toHaveBeenCalledWith('CMS Credentials Added');
+    });
+    expect(screen.queryByRole('dialog', { name: /add display via code/i })).not.toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // A wrong code returns an error from the server. The modal must stay open
+  // and show the exact message so the user knows what went wrong.
+  // ---------------------------------------------------------------------------
+  test('wrong code keeps the modal open and shows the server error message', async () => {
+    const user = userEvent.setup();
+    vi.mocked(addDisplayViaCode).mockRejectedValueOnce({
+      response: {
+        data: {
+          message:
+            'The code provided does not match. Please double-check the code shown on the device you are trying to connect.',
+        },
+      },
+    });
+
+    await openAddModal(user);
+    await user.type(screen.getByRole('textbox', { name: /code/i }), 'WRONG-CODE');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(screen.getByRole('dialog', { name: /add display via code/i })).toBeInTheDocument();
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'The code provided does not match. Please double-check the code shown on the device you are trying to connect.',
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // The code field must be blank every time the modal opens so a previously
+  // typed (and rejected) code cannot accidentally be submitted for a different
+  // display. The useEffect in AddDisplayModal resets state whenever isOpen
+  // flips from false back to true.
+  // ---------------------------------------------------------------------------
+  test('code field is blank when the modal is reopened after being closed', async () => {
+    const user = userEvent.setup();
+    await openAddModal(user);
+
+    await user.type(screen.getByRole('textbox', { name: /code/i }), 'LEFTOVER-CODE');
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+    // Reopen the modal
+    await user.click(screen.getByRole('button', { name: /add display/i }));
+    await screen.findByRole('dialog', { name: /add display via code/i });
+
+    expect(screen.getByRole('textbox', { name: /code/i })).toHaveValue('');
+  });
+});

--- a/frontend/src/pages/Displays/Displays/__tests__/Displays.delete.test.tsx
+++ b/frontend/src/pages/Displays/Displays/__tests__/Displays.delete.test.tsx
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent, { type UserEvent } from '@testing-library/user-event';
+import type React from 'react';
+import { vi, beforeEach, describe, test, expect } from 'vitest';
+
+import { mockDisplay, SINGLE_DISPLAY } from './fixtures/display';
+import { renderDisplaysPage } from './helpers/renderDisplaysPage';
+import { mockFetchDisplays } from './mocks/displaysApi';
+
+import { deleteDisplay } from '@/services/displaysApi';
+import { testQueryClient } from '@/setupTests';
+
+// =============================================================================
+// Module mocks
+// =============================================================================
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { changeLanguage: vi.fn() } }),
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock('@/services/displaysApi');
+vi.mock('@/services/displayGroupApi', () => ({
+  fetchDisplayGroups: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+  deleteDisplayGroup: vi.fn(),
+}));
+vi.mock('@/services/displayProfileApi', () => ({
+  fetchDisplayProfile: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+  fetchDisplayProfileById: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('@/services/userApi', () => ({
+  fetchUserPreference: vi.fn().mockResolvedValue(null),
+  saveUserPreference: vi.fn().mockResolvedValue(undefined),
+  fetchUsers: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('@/services/folderApi', () => ({
+  fetchFolderById: vi.fn().mockResolvedValue({ id: 1, text: 'Root' }),
+  fetchFolderTree: vi.fn().mockResolvedValue([]),
+  searchFolders: vi.fn().mockResolvedValue([]),
+  fetchContextButtons: vi.fn().mockResolvedValue({ create: true }),
+  selectFolder: vi.fn().mockResolvedValue({ success: true }),
+}));
+vi.mock('@/components/ui/modals/Modal');
+vi.mock('@/components/ui/FolderActionModals', () => ({ default: () => null }));
+vi.mock('../hooks/useDisplaysFilterOptions', () => ({
+  useDisplaysFilterOptions: () => ({ filterOptions: [], isLoading: false }),
+}));
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const openDeleteModal = async (user: UserEvent) => {
+  await screen.findByText(mockDisplay.display);
+
+  const checkboxes = screen.getAllByRole('checkbox', { name: /Select row/i });
+  await user.click(checkboxes[1]!);
+
+  const deleteBtn = await screen.findByRole('button', { name: /Delete Selected/i });
+  await user.click(deleteBtn);
+
+  return screen.findByRole('dialog');
+};
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('Delete Display', () => {
+  beforeEach(() => {
+    testQueryClient.clear();
+    vi.clearAllMocks();
+    mockFetchDisplays(SINGLE_DISPLAY);
+    vi.mocked(deleteDisplay).mockResolvedValue(undefined);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Selecting a row and clicking Delete Selected opens the confirmation modal.
+  // ---------------------------------------------------------------------------
+  test('Delete Selected opens the confirmation modal', async () => {
+    const user = userEvent.setup();
+    renderDisplaysPage();
+
+    const dialog = await openDeleteModal(user);
+
+    expect(dialog).toBeInTheDocument();
+    expect(within(dialog).getByText('Delete Display?')).toBeInTheDocument();
+    expect(within(dialog).getByText(mockDisplay.display)).toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Clicking Cancel closes the modal without calling the API.
+  // ---------------------------------------------------------------------------
+  test('Cancel closes the modal without calling deleteDisplay', async () => {
+    const user = userEvent.setup();
+    renderDisplaysPage();
+    await openDeleteModal(user);
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+    expect(deleteDisplay).not.toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Clicking "Yes, Delete" on success calls deleteDisplay and closes modal.
+  // ---------------------------------------------------------------------------
+  test('successful delete calls deleteDisplay and closes the modal', async () => {
+    const user = userEvent.setup();
+    vi.mocked(deleteDisplay).mockResolvedValueOnce(undefined);
+
+    renderDisplaysPage();
+    await openDeleteModal(user);
+
+    await user.click(screen.getByRole('button', { name: 'Yes, Delete' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+    expect(deleteDisplay).toHaveBeenCalledTimes(1);
+    expect(deleteDisplay).toHaveBeenCalledWith(mockDisplay.displayId);
+  });
+
+  // ---------------------------------------------------------------------------
+  // While deletion is in progress, the confirm button should switch to
+  // "Deleting…" and be disabled so the user cannot submit a second time.
+  // ---------------------------------------------------------------------------
+  test('Yes, Delete button is disabled with loading label while deletion is in progress', async () => {
+    const user = userEvent.setup();
+    let resolveDelete!: () => void;
+    const controlledPromise = new Promise<void>((resolve) => {
+      resolveDelete = resolve;
+    });
+    vi.mocked(deleteDisplay).mockReturnValue(controlledPromise);
+
+    renderDisplaysPage();
+    await openDeleteModal(user);
+
+    await user.click(screen.getByRole('button', { name: 'Yes, Delete' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Deleting…' })).toBeDisabled();
+    });
+    expect(deleteDisplay).toHaveBeenCalledTimes(1);
+
+    // Resolve and wait for the component to settle before the test tears down.
+    resolveDelete();
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Delete modal shows error and stays open when deletion fails.
+  // ---------------------------------------------------------------------------
+  test('failed delete keeps the modal open and shows an error', async () => {
+    const user = userEvent.setup();
+    vi.mocked(deleteDisplay).mockRejectedValueOnce(new Error('Cannot delete display'));
+
+    renderDisplaysPage();
+    await openDeleteModal(user);
+
+    await user.click(screen.getByRole('button', { name: 'Yes, Delete' }));
+
+    expect(deleteDisplay).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText(/could not be deleted/i)).toBeInTheDocument();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Displays/Displays/__tests__/edit/edit.form.test.tsx
+++ b/frontend/src/pages/Displays/Displays/__tests__/edit/edit.form.test.tsx
@@ -1,0 +1,237 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type React from 'react';
+import { vi, beforeEach, describe, test, expect } from 'vitest';
+
+import { buildDisplay, mockDisplay } from '../fixtures/display';
+
+import { renderEditModal } from './helpers/renderEditModal';
+
+import { updateDisplay } from '@/services/displaysApi';
+import { testQueryClient } from '@/setupTests';
+
+// =============================================================================
+// Module mocks
+// =============================================================================
+
+vi.mock('react-i18next', () => {
+  const t = (key: string) => key;
+  return {
+    useTranslation: () => ({ t, i18n: { changeLanguage: vi.fn() } }),
+    Trans: ({ children }: { children: React.ReactNode }) => children,
+  };
+});
+
+vi.mock('@/services/displaysApi', () => ({
+  updateDisplay: vi.fn(),
+  fetchDisplayVenues: vi.fn().mockResolvedValue([]),
+  fetchDisplayLocales: vi.fn().mockResolvedValue([]),
+  fetchDisplays: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+}));
+vi.mock('@/services/displayProfileApi', () => ({
+  fetchDisplayProfile: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+  fetchDisplayProfileById: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('@/services/folderApi', () => ({
+  fetchFolderById: vi.fn().mockResolvedValue({ id: 1, text: 'Root' }),
+  fetchFolderTree: vi.fn().mockResolvedValue([]),
+  searchFolders: vi.fn().mockResolvedValue([]),
+  fetchContextButtons: vi.fn().mockResolvedValue({ create: true }),
+  selectFolder: vi.fn().mockResolvedValue({ success: true }),
+}));
+vi.mock('@/services/layoutsApi', () => ({
+  fetchLayouts: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+}));
+vi.mock('@/services/playerSoftwareApi', () => ({
+  fetchPlayerSoftware: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+}));
+vi.mock('@/services/daypartApi', () => ({
+  fetchDaypart: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+}));
+vi.mock('@/components/ui/modals/Modal');
+vi.mock('@/components/ui/forms/SelectFolder', () => ({
+  default: ({ selectedId }: { selectedId?: number | null }) => (
+    <div data-testid="mock-select-folder" data-folder-id={selectedId ?? ''} />
+  ),
+}));
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('Display - edit form fields', () => {
+  beforeEach(() => {
+    testQueryClient.clear();
+    vi.clearAllMocks();
+    vi.mocked(updateDisplay).mockResolvedValue(mockDisplay);
+  });
+
+  // ---------------------------------------------------------------------------
+  // When opening the edit form the Display name field should already show the
+  // current display name so the user does not have to retype it.
+  // ---------------------------------------------------------------------------
+  test('Display name field is pre-populated with the existing display name', async () => {
+    await renderEditModal();
+
+    expect(screen.getByRole('textbox', { name: /^Display$/i })).toHaveValue(mockDisplay.display);
+  });
+
+  // ---------------------------------------------------------------------------
+  // The user should be able to clear the name and type a new value, and the
+  // field should reflect exactly what they typed.
+  // ---------------------------------------------------------------------------
+  test('Display name field is editable and reflects typed input', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+
+    const nameInput = screen.getByRole('textbox', { name: /^Display$/i });
+    await user.clear(nameInput);
+    await user.type(nameInput, 'Updated Display');
+
+    expect(nameInput).toHaveValue('Updated Display');
+  });
+
+  // ---------------------------------------------------------------------------
+  // The Description field should be pre-populated with the display's current
+  // description. When description is null the draft initialises to empty string.
+  // ---------------------------------------------------------------------------
+  test('Description field is pre-populated with the existing description', async () => {
+    const description = 'My existing description';
+    await renderEditModal({ data: buildDisplay({ description }) });
+
+    expect(screen.getByRole('textbox', { name: /description/i })).toHaveValue(description);
+  });
+
+  // ---------------------------------------------------------------------------
+  // If the user clears the Display name and tries to save, a "Name is required"
+  // validation error must appear and the API must not be called.
+  // ---------------------------------------------------------------------------
+  test('Save with empty name shows validation error and does not call updateDisplay', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+
+    await user.clear(screen.getByRole('textbox', { name: /^Display$/i }));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(await screen.findByText('Name is required')).toBeInTheDocument();
+    expect(updateDisplay).not.toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // When the user saves valid data, updateDisplay should be called with the
+  // correct payload and onClose should be called once the save succeeds.
+  // ---------------------------------------------------------------------------
+  test('Successful save calls updateDisplay with correct payload and calls onClose', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    await renderEditModal({ onClose });
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(updateDisplay).toHaveBeenCalledWith(
+        mockDisplay.displayId,
+        expect.objectContaining({
+          display: mockDisplay.display,
+          licensed: mockDisplay.licensed,
+        }),
+      );
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Clicking Cancel should call onClose immediately without touching the server.
+  // ---------------------------------------------------------------------------
+  test('Clicking Cancel closes the modal without saving', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    await renderEditModal({ onClose });
+
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(updateDisplay).not.toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // If the server rejects the save the modal must stay open and the error
+  // message from the API response must be visible.
+  // ---------------------------------------------------------------------------
+  test('Failed save keeps the modal open and shows the error', async () => {
+    const user = userEvent.setup();
+    vi.mocked(updateDisplay).mockRejectedValueOnce({
+      message: 'Request failed with status code 422',
+      response: { data: { message: 'Display name already exists' } },
+    });
+
+    await renderEditModal();
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(updateDisplay).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(await screen.findByRole('alert')).toHaveTextContent('Display name already exists');
+  });
+
+  // ---------------------------------------------------------------------------
+  // While a save is in progress the Save button must switch to "Saving…" and
+  // be disabled so the user cannot submit the form a second time.
+  // ---------------------------------------------------------------------------
+  test('Save button is disabled with loading label while save is in progress', async () => {
+    const user = userEvent.setup();
+    let resolvePromise!: () => void;
+    const controlledPromise = new Promise<typeof mockDisplay>((resolve) => {
+      resolvePromise = () => resolve(mockDisplay);
+    });
+    vi.mocked(updateDisplay).mockReturnValue(controlledPromise);
+
+    await renderEditModal();
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Saving…' })).toBeDisabled();
+    });
+    expect(updateDisplay).toHaveBeenCalledTimes(1);
+
+    resolvePromise();
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Save' })).toBeEnabled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // The Reference tab should render the five reference input fields (ref1–ref5).
+  // ---------------------------------------------------------------------------
+  test('Reference tab renders reference input fields', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+
+    await user.click(screen.getByRole('tab', { name: 'Reference' }));
+
+    const refInputs = screen.getAllByRole('textbox', { name: /reference/i });
+    expect(refInputs).toHaveLength(5);
+  });
+});

--- a/frontend/src/pages/Displays/Displays/__tests__/edit/edit.test.tsx
+++ b/frontend/src/pages/Displays/Displays/__tests__/edit/edit.test.tsx
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type React from 'react';
+import { vi, beforeEach, describe, test, expect } from 'vitest';
+
+import type EditDisplayModalComponent from '../../components/EditDisplayModal';
+import { mockDisplay, SINGLE_DISPLAY } from '../fixtures/display';
+import { renderDisplaysPage } from '../helpers/renderDisplaysPage';
+import { mockFetchDisplays } from '../mocks/displaysApi';
+
+import { fetchDisplays } from '@/services/displaysApi';
+import { testQueryClient } from '@/setupTests';
+import type { Display } from '@/types/display';
+
+// =============================================================================
+// Module mocks
+// =============================================================================
+
+vi.mock('react-i18next', () => {
+  const t = (key: string) => key;
+  return {
+    useTranslation: () => ({ t, i18n: { changeLanguage: vi.fn() } }),
+    Trans: ({ children }: { children: React.ReactNode }) => children,
+  };
+});
+
+vi.mock('@/services/displaysApi');
+vi.mock('@/services/displayGroupApi', () => ({
+  fetchDisplayGroups: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+  deleteDisplayGroup: vi.fn(),
+}));
+vi.mock('@/services/displayProfileApi', () => ({
+  fetchDisplayProfile: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+  fetchDisplayProfileById: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('@/services/userApi', () => ({
+  fetchUserPreference: vi.fn().mockResolvedValue(null),
+  saveUserPreference: vi.fn().mockResolvedValue(undefined),
+  fetchUsers: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('@/services/folderApi', () => ({
+  fetchFolderById: vi.fn().mockResolvedValue({ id: 1, text: 'Root' }),
+  fetchFolderTree: vi.fn().mockResolvedValue([]),
+  searchFolders: vi.fn().mockResolvedValue([]),
+  fetchContextButtons: vi.fn().mockResolvedValue({ create: true }),
+  selectFolder: vi.fn().mockResolvedValue({ success: true }),
+}));
+vi.mock('@/components/ui/modals/Modal');
+vi.mock('@/components/ui/FolderActionModals', () => ({ default: () => null }));
+vi.mock('../../hooks/useDisplaysFilterOptions', () => ({
+  useDisplaysFilterOptions: () => ({ filterOptions: [], isLoading: false }),
+}));
+
+// These tests verify page-level behaviour only: does clicking Edit open the
+// modal, and does clicking Save refresh the table? Form field logic belongs in
+// a separate form test, so the real modal is replaced with a minimal stub that
+// acts purely as a behavioural trigger.
+//
+// The stub calls onSave() to simulate the user completing a save. The page's
+// onSave handler ignores the argument — it only calls handleRefresh(), which
+// invalidates the React Query cache. The updated row comes from the queued
+// mockResolvedValueOnce response, not from anything passed to onSave.
+vi.mock('../../components/EditDisplayModal', () => ({
+  default: ({ data, onClose, onSave }: React.ComponentProps<typeof EditDisplayModalComponent>) => (
+    <div role="dialog" aria-label="Edit Display">
+      <button onClick={() => onClose()}>Cancel</button>
+      <button onClick={() => onSave(data as Display)}>Save Display</button>
+    </div>
+  ),
+}));
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+const updatedDisplay = { ...mockDisplay, display: 'Test Display - Edited' };
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('Displays page - edit', () => {
+  beforeEach(() => {
+    testQueryClient.clear();
+    vi.clearAllMocks();
+    mockFetchDisplays(SINGLE_DISPLAY);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Clicking the Edit quick action on a row opens the Edit modal.
+  // ---------------------------------------------------------------------------
+  test('opens the Edit modal when the Edit action is clicked on a row', async () => {
+    const user = userEvent.setup();
+    renderDisplaysPage();
+
+    // Wait for the row to be rendered before looking for the action button.
+    await screen.findByText(mockDisplay.display);
+    const editButton = await screen.findByRole('button', { name: /edit/i });
+    await user.click(editButton);
+
+    expect(await screen.findByRole('dialog', { name: /edit display/i })).toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // After the user saves their changes, the table should reload and show the
+  // updated name. We also verify the page actually asked the server for fresh
+  // data rather than just patching the display locally.
+  // ---------------------------------------------------------------------------
+  test('saving an edit refreshes the table and shows the updated row name', async () => {
+    const user = userEvent.setup();
+    renderDisplaysPage();
+
+    // Wait for the original row to appear before interacting.
+    expect(await screen.findByText(mockDisplay.display)).toBeInTheDocument();
+
+    const editButton = await screen.findByRole('button', { name: /edit/i });
+    await user.click(editButton);
+
+    // Queue the updated data so the table gets it when it re-fetches after save.
+    vi.mocked(fetchDisplays).mockResolvedValueOnce({
+      rows: [updatedDisplay],
+      totalCount: 1,
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Save Display' }));
+
+    // Await the new name first — this confirms the refetch completed.
+    // Only then check the old name is gone, because keepPreviousData keeps the
+    // old row visible during the fetch, so a synchronous negative check before
+    // this point would fail.
+    expect(await screen.findByText(updatedDisplay.display)).toBeInTheDocument();
+    expect(screen.queryByText(mockDisplay.display)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Displays/Displays/__tests__/edit/helpers/renderEditModal.tsx
+++ b/frontend/src/pages/Displays/Displays/__tests__/edit/helpers/renderEditModal.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import type React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+
+import EditDisplayModal from '../../../components/EditDisplayModal';
+import { mockDisplay, mockUser } from '../../fixtures/display';
+
+import { UserProvider } from '@/context/UserContext';
+import { testQueryClient } from '@/setupTests';
+
+// Shared render helper for EditDisplayModal tests.
+// vi.mock() calls must still live in each consuming test file — Vitest hoists
+// them per-file. This helper only owns the JSX wrapper.
+export const renderEditModal = async (
+  overrides: Partial<React.ComponentProps<typeof EditDisplayModal>> = {},
+) => {
+  const defaults = {
+    isOpen: true,
+    data: mockDisplay,
+    onClose: vi.fn(),
+    onSave: vi.fn(),
+  };
+  const utils = render(
+    <QueryClientProvider client={testQueryClient}>
+      <UserProvider initialUser={mockUser}>
+        <MemoryRouter>
+          <EditDisplayModal {...defaults} {...overrides} />
+        </MemoryRouter>
+      </UserProvider>
+    </QueryClientProvider>,
+  );
+  await screen.findByRole('dialog');
+  return utils;
+};

--- a/frontend/src/pages/Displays/Displays/__tests__/edit/tabs/advanced.test.tsx
+++ b/frontend/src/pages/Displays/Displays/__tests__/edit/tabs/advanced.test.tsx
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type React from 'react';
+import { vi, beforeEach, describe, test, expect } from 'vitest';
+
+import { renderEditModal } from '../helpers/renderEditModal';
+
+import { testQueryClient } from '@/setupTests';
+
+// =============================================================================
+// Module mocks
+// =============================================================================
+
+vi.mock('react-i18next', () => {
+  const t = (key: string) => key;
+  return {
+    useTranslation: () => ({ t, i18n: { changeLanguage: vi.fn() } }),
+    Trans: ({ children }: { children: React.ReactNode }) => children,
+  };
+});
+
+vi.mock('@/services/displaysApi', () => ({
+  updateDisplay: vi.fn(),
+  fetchDisplayVenues: vi.fn().mockResolvedValue([]),
+  fetchDisplayLocales: vi.fn().mockResolvedValue([]),
+  fetchDisplays: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+}));
+vi.mock('@/services/displayProfileApi', () => ({
+  fetchDisplayProfile: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+  fetchDisplayProfileById: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('@/services/folderApi', () => ({
+  fetchFolderById: vi.fn().mockResolvedValue({ id: 1, text: 'Root' }),
+  fetchFolderTree: vi.fn().mockResolvedValue([]),
+  searchFolders: vi.fn().mockResolvedValue([]),
+  fetchContextButtons: vi.fn().mockResolvedValue({ create: true }),
+  selectFolder: vi.fn().mockResolvedValue({ success: true }),
+}));
+vi.mock('@/services/layoutsApi', () => ({
+  fetchLayouts: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+}));
+vi.mock('@/services/playerSoftwareApi', () => ({
+  fetchPlayerSoftware: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+}));
+vi.mock('@/services/daypartApi', () => ({
+  fetchDaypart: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+}));
+vi.mock('@/components/ui/modals/Modal');
+vi.mock('@/components/ui/forms/SelectFolder', () => ({
+  default: ({ selectedId }: { selectedId?: number | null }) => (
+    <div data-testid="mock-select-folder" data-folder-id={selectedId ?? ''} />
+  ),
+}));
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('Display - edit form: Advanced tab', () => {
+  beforeEach(() => {
+    testQueryClient.clear();
+    vi.clearAllMocks();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Clear Cached Data
+  // Draft initialises clearCachedData to 1 regardless of the stored value,
+  // so the checkbox is always checked when the modal opens.
+  // ---------------------------------------------------------------------------
+
+  test('clear cached data checkbox is checked by default when the modal opens', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+    await user.click(screen.getByRole('tab', { name: 'Advanced' }));
+
+    expect(screen.getByRole('checkbox', { name: /clear cached data/i })).toBeChecked();
+  });
+
+  test('clear cached data checkbox can be toggled', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+    await user.click(screen.getByRole('tab', { name: 'Advanced' }));
+
+    const checkbox = screen.getByRole('checkbox', { name: /clear cached data/i });
+    await user.click(checkbox);
+    expect(checkbox).not.toBeChecked();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Reconfigure XMR
+  // rekeyXmr is hardcoded to 0 on every modal open — it is a one-shot action,
+  // not pre-populated from stored data (same pattern as clearCachedData).
+  // ---------------------------------------------------------------------------
+
+  test('reconfigure XMR checkbox is unchecked by default when the modal opens', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+    await user.click(screen.getByRole('tab', { name: 'Advanced' }));
+
+    expect(screen.getByRole('checkbox', { name: /reconfigure xmr/i })).not.toBeChecked();
+  });
+
+  test('reconfigure XMR checkbox can be toggled', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+    await user.click(screen.getByRole('tab', { name: 'Advanced' }));
+
+    const checkbox = screen.getByRole('checkbox', { name: /reconfigure xmr/i });
+    expect(checkbox).not.toBeChecked();
+    await user.click(checkbox);
+    expect(checkbox).toBeChecked();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Interleave Default (SelectDropdown with role="combobox")
+  // ---------------------------------------------------------------------------
+
+  test('interleave default combobox is present', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+    await user.click(screen.getByRole('tab', { name: 'Advanced' }));
+
+    expect(screen.getByRole('combobox', { name: /interleave default/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Displays/Displays/__tests__/edit/tabs/details.test.tsx
+++ b/frontend/src/pages/Displays/Displays/__tests__/edit/tabs/details.test.tsx
@@ -1,0 +1,491 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type React from 'react';
+import { vi, beforeEach, describe, test, expect } from 'vitest';
+
+import { buildDisplay } from '../../fixtures/display';
+import { renderEditModal } from '../helpers/renderEditModal';
+
+import { fetchDisplayLocales, updateDisplay } from '@/services/displaysApi';
+import { testQueryClient } from '@/setupTests';
+
+// =============================================================================
+// Module mocks
+// =============================================================================
+
+vi.mock('react-i18next', () => {
+  const t = (key: string) => key;
+  return {
+    useTranslation: () => ({ t, i18n: { changeLanguage: vi.fn() } }),
+    Trans: ({ children }: { children: React.ReactNode }) => children,
+  };
+});
+
+vi.mock('@/services/displaysApi', () => ({
+  updateDisplay: vi.fn(),
+  fetchDisplayVenues: vi.fn().mockResolvedValue([]),
+  fetchDisplayLocales: vi.fn().mockResolvedValue([]),
+  fetchDisplays: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+}));
+vi.mock('@/services/displayProfileApi', () => ({
+  fetchDisplayProfile: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+  fetchDisplayProfileById: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('@/services/folderApi', () => ({
+  fetchFolderById: vi.fn().mockResolvedValue({ id: 1, text: 'Root' }),
+  fetchFolderTree: vi.fn().mockResolvedValue([]),
+  searchFolders: vi.fn().mockResolvedValue([]),
+  fetchContextButtons: vi.fn().mockResolvedValue({ create: true }),
+  selectFolder: vi.fn().mockResolvedValue({ success: true }),
+}));
+vi.mock('@/services/layoutsApi', () => ({
+  fetchLayouts: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+}));
+vi.mock('@/services/playerSoftwareApi', () => ({
+  fetchPlayerSoftware: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+}));
+vi.mock('@/services/daypartApi', () => ({
+  fetchDaypart: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+}));
+vi.mock('@/components/ui/modals/Modal');
+vi.mock('@/components/ui/forms/SelectFolder', () => ({
+  default: ({ selectedId }: { selectedId?: number | null }) => (
+    <div data-testid="mock-select-folder" data-folder-id={selectedId ?? ''} />
+  ),
+}));
+vi.mock('@/components/ui/forms/TimezoneSelect', () => ({
+  default: ({
+    id,
+    value,
+    onChange,
+  }: {
+    id?: string;
+    value: string;
+    onChange: (v: string) => void;
+    helpText?: string;
+  }) => (
+    <div>
+      <label htmlFor={id}>Timezone</label>
+      <select
+        id={id}
+        role="combobox"
+        aria-label="Timezone"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      >
+        <option value=""></option>
+        <option value="UTC">(GMT) UTC</option>
+        <option value="Europe/London">(GMT+1) Europe, London</option>
+      </select>
+    </div>
+  ),
+}));
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('Display - edit form: Details tab', () => {
+  beforeEach(() => {
+    testQueryClient.clear();
+    vi.clearAllMocks();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Latitude
+  // ---------------------------------------------------------------------------
+
+  test('latitude is pre-populated with the existing value', async () => {
+    const user = userEvent.setup();
+    await renderEditModal({ data: buildDisplay({ latitude: 51.5 }) });
+    await user.click(screen.getByRole('tab', { name: 'Details' }));
+
+    expect(screen.getByRole('spinbutton', { name: /latitude/i })).toHaveValue(51.5);
+  });
+
+  test('latitude is editable and reflects typed input', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+    await user.click(screen.getByRole('tab', { name: 'Details' }));
+
+    const input = screen.getByRole('spinbutton', { name: /latitude/i });
+    await user.clear(input);
+    await user.type(input, '48');
+
+    expect(input).toHaveValue(48);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Longitude
+  // ---------------------------------------------------------------------------
+
+  test('longitude is pre-populated with the existing value', async () => {
+    const user = userEvent.setup();
+    await renderEditModal({ data: buildDisplay({ longitude: -0.1 }) });
+    await user.click(screen.getByRole('tab', { name: 'Details' }));
+
+    expect(screen.getByRole('spinbutton', { name: /longitude/i })).toHaveValue(-0.1);
+  });
+
+  test('longitude is editable and reflects typed input', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+    await user.click(screen.getByRole('tab', { name: 'Details' }));
+
+    const input = screen.getByRole('spinbutton', { name: /longitude/i });
+    await user.clear(input);
+    await user.type(input, '2');
+
+    expect(input).toHaveValue(2);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Address
+  // ---------------------------------------------------------------------------
+
+  test('address is pre-populated with the existing value', async () => {
+    const user = userEvent.setup();
+    await renderEditModal({ data: buildDisplay({ address: '123 Main St' }) });
+    await user.click(screen.getByRole('tab', { name: 'Details' }));
+
+    expect(screen.getByRole('textbox', { name: /address/i })).toHaveValue('123 Main St');
+  });
+
+  test('address is editable and reflects typed input', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+    await user.click(screen.getByRole('tab', { name: 'Details' }));
+
+    const input = screen.getByRole('textbox', { name: /address/i });
+    await user.clear(input);
+    await user.type(input, '456 New Road');
+
+    expect(input).toHaveValue('456 New Road');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Screen size
+  // ---------------------------------------------------------------------------
+
+  test('screen size is pre-populated with the existing value', async () => {
+    const user = userEvent.setup();
+    await renderEditModal({ data: buildDisplay({ screenSize: 55 }) });
+    await user.click(screen.getByRole('tab', { name: 'Details' }));
+
+    expect(screen.getByRole('spinbutton', { name: /screen size/i })).toHaveValue(55);
+  });
+
+  test('screen size is editable and reflects typed input', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+    await user.click(screen.getByRole('tab', { name: 'Details' }));
+
+    const input = screen.getByRole('spinbutton', { name: /screen size/i });
+    await user.clear(input);
+    await user.type(input, '75');
+
+    expect(input).toHaveValue(75);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Is mobile?
+  // ---------------------------------------------------------------------------
+
+  test('is mobile checkbox reflects the existing value', async () => {
+    const user = userEvent.setup();
+    await renderEditModal({ data: buildDisplay({ isMobile: 1 }) });
+    await user.click(screen.getByRole('tab', { name: 'Details' }));
+
+    expect(screen.getByRole('checkbox', { name: /is mobile/i })).toBeChecked();
+  });
+
+  test('is mobile checkbox can be toggled', async () => {
+    const user = userEvent.setup();
+    await renderEditModal({ data: buildDisplay({ isMobile: 0 }) });
+    await user.click(screen.getByRole('tab', { name: 'Details' }));
+
+    const checkbox = screen.getByRole('checkbox', { name: /is mobile/i });
+    expect(checkbox).not.toBeChecked();
+    await user.click(checkbox);
+    expect(checkbox).toBeChecked();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Is outdoor?
+  // ---------------------------------------------------------------------------
+
+  test('is outdoor checkbox reflects the existing value', async () => {
+    const user = userEvent.setup();
+    await renderEditModal({ data: buildDisplay({ isOutdoor: 1 }) });
+    await user.click(screen.getByRole('tab', { name: 'Details' }));
+
+    expect(screen.getByRole('checkbox', { name: /is outdoor/i })).toBeChecked();
+  });
+
+  test('is outdoor checkbox can be toggled', async () => {
+    const user = userEvent.setup();
+    await renderEditModal({ data: buildDisplay({ isOutdoor: 0 }) });
+    await user.click(screen.getByRole('tab', { name: 'Details' }));
+
+    const checkbox = screen.getByRole('checkbox', { name: /is outdoor/i });
+    expect(checkbox).not.toBeChecked();
+    await user.click(checkbox);
+    expect(checkbox).toBeChecked();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Cost per play
+  // ---------------------------------------------------------------------------
+
+  test('cost per play is pre-populated with the existing value', async () => {
+    const user = userEvent.setup();
+    await renderEditModal({ data: buildDisplay({ costPerPlay: 2.5 }) });
+    await user.click(screen.getByRole('tab', { name: 'Details' }));
+
+    expect(screen.getByRole('spinbutton', { name: /cost per play/i })).toHaveValue(2.5);
+  });
+
+  test('cost per play is editable and reflects typed input', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+    await user.click(screen.getByRole('tab', { name: 'Details' }));
+
+    const input = screen.getByRole('spinbutton', { name: /cost per play/i });
+    await user.clear(input);
+    await user.type(input, '5');
+
+    expect(input).toHaveValue(5);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Impressions per play
+  // ---------------------------------------------------------------------------
+
+  test('impressions per play is pre-populated with the existing value', async () => {
+    const user = userEvent.setup();
+    await renderEditModal({ data: buildDisplay({ impressionsPerPlay: 100 }) });
+    await user.click(screen.getByRole('tab', { name: 'Details' }));
+
+    expect(screen.getByRole('spinbutton', { name: /impressions per play/i })).toHaveValue(100);
+  });
+
+  test('impressions per play is editable and reflects typed input', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+    await user.click(screen.getByRole('tab', { name: 'Details' }));
+
+    const input = screen.getByRole('spinbutton', { name: /impressions per play/i });
+    await user.clear(input);
+    await user.type(input, '200');
+
+    expect(input).toHaveValue(200);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Timezone (TimezoneSelect → SelectDropdown with role="combobox")
+  // ---------------------------------------------------------------------------
+
+  test('timezone combobox is present', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+    await user.click(screen.getByRole('tab', { name: 'Details' }));
+
+    expect(screen.getByRole('combobox', { name: /timezone/i })).toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Languages (MultiSelectDropdown with role="combobox")
+  // ---------------------------------------------------------------------------
+
+  test('languages combobox is present', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+    await user.click(screen.getByRole('tab', { name: 'Details' }));
+
+    expect(screen.getByRole('combobox', { name: /languages/i })).toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Display Type (SelectDropdown with role="combobox")
+  // ---------------------------------------------------------------------------
+
+  test('display type combobox is present', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+    await user.click(screen.getByRole('tab', { name: 'Details' }));
+
+    expect(screen.getByRole('combobox', { name: /display type/i })).toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Venue (SelectDropdown with role="combobox")
+  // ---------------------------------------------------------------------------
+
+  test('venue combobox is present', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+    await user.click(screen.getByRole('tab', { name: 'Details' }));
+
+    expect(screen.getByRole('combobox', { name: /venue/i })).toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Edge cases — null number fields render as empty (not 0)
+  //
+  // latitude, longitude, and screenSize default to null in the fixture.
+  // The component passes `value={draft.field ?? undefined}` to NumberInput,
+  // which leaves the input uncontrolled (empty). toHaveValue(null) is the
+  // @testing-library assertion for an empty number input.
+  //
+  // This matters because 0 is a valid geographic coordinate, so null and 0
+  // must render differently — null as blank, 0 as the digit "0".
+  // ---------------------------------------------------------------------------
+
+  test('latitude renders as empty when not set', async () => {
+    const user = userEvent.setup();
+    await renderEditModal({ data: buildDisplay({ latitude: null }) });
+    await user.click(screen.getByRole('tab', { name: 'Details' }));
+
+    expect(screen.getByRole('spinbutton', { name: /latitude/i })).toHaveValue(null);
+  });
+
+  test('longitude renders as empty when not set', async () => {
+    const user = userEvent.setup();
+    await renderEditModal({ data: buildDisplay({ longitude: null }) });
+    await user.click(screen.getByRole('tab', { name: 'Details' }));
+
+    expect(screen.getByRole('spinbutton', { name: /longitude/i })).toHaveValue(null);
+  });
+
+  test('screen size renders as empty when not set', async () => {
+    const user = userEvent.setup();
+    await renderEditModal({ data: buildDisplay({ screenSize: null }) });
+    await user.click(screen.getByRole('tab', { name: 'Details' }));
+
+    expect(screen.getByRole('spinbutton', { name: /screen size/i })).toHaveValue(null);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Edge cases — zero is a valid value and must not be treated as falsy
+  //
+  // A display on the equator (latitude 0), the prime meridian (longitude 0),
+  // or with a 0-inch screen size is real. If the component used
+  // `onChange={(v) => set('field', v || null)}` then typing 0 would silently
+  // store null. The `?? null` pattern avoids this.
+  // ---------------------------------------------------------------------------
+
+  // BUG: onChange uses `v || null` which treats 0 as falsy — typing 0 stores
+  // null in the draft, so the save payload contains null instead of 0.
+  // The DOM shows 0 (uncontrolled input) so the input value alone cannot
+  // catch this; we check the updateDisplay payload instead.
+  // Marked test.fails until the bug is fixed (change `v || null` to `v ?? null`).
+
+  test.fails('typing 0 into latitude saves 0, not null', async () => {
+    const user = userEvent.setup();
+    vi.mocked(updateDisplay).mockResolvedValue(undefined as never);
+    await renderEditModal({ data: buildDisplay({ latitude: null }) });
+    await user.click(screen.getByRole('tab', { name: 'Details' }));
+
+    await user.type(screen.getByRole('spinbutton', { name: /latitude/i }), '0');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(updateDisplay).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ latitude: 0 }),
+      );
+    });
+  });
+
+  test.fails('typing 0 into longitude saves 0, not null', async () => {
+    const user = userEvent.setup();
+    vi.mocked(updateDisplay).mockResolvedValue(undefined as never);
+    await renderEditModal({ data: buildDisplay({ longitude: null }) });
+    await user.click(screen.getByRole('tab', { name: 'Details' }));
+
+    await user.type(screen.getByRole('spinbutton', { name: /longitude/i }), '0');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(updateDisplay).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ longitude: 0 }),
+      );
+    });
+  });
+
+  test.fails('typing 0 into screen size saves 0, not null', async () => {
+    const user = userEvent.setup();
+    vi.mocked(updateDisplay).mockResolvedValue(undefined as never);
+    await renderEditModal({ data: buildDisplay({ screenSize: null }) });
+    await user.click(screen.getByRole('tab', { name: 'Details' }));
+
+    await user.type(screen.getByRole('spinbutton', { name: /screen size/i }), '0');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(updateDisplay).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ screenSize: 0 }),
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Edge case — timezone pre-populated with the saved value
+  //
+  // When a display has a saved timezone the combobox must show that value on
+  // open, not the placeholder. TimezoneSelect builds its options from
+  // Intl.supportedValuesOf, so 'UTC' is guaranteed to be available.
+  // ---------------------------------------------------------------------------
+
+  test('timezone combobox shows the saved timezone value', async () => {
+    const user = userEvent.setup();
+    await renderEditModal({ data: buildDisplay({ timeZone: 'UTC' }) });
+    await user.click(screen.getByRole('tab', { name: 'Details' }));
+
+    expect(screen.getByRole('combobox', { name: /timezone/i })).toHaveTextContent('(GMT) UTC');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Edge case — languages pre-populated with the saved value
+  //
+  // The display stores languages as a comma-separated string ('en'). The modal
+  // splits it into an array and passes it to MultiSelectDropdown. The dropdown
+  // resolves the value to a human-readable label using the options returned by
+  // fetchDisplayLocales. This test verifies the full chain: stored string →
+  // split array → option label shown in the combobox.
+  // ---------------------------------------------------------------------------
+
+  test('languages combobox shows the saved language label', async () => {
+    const user = userEvent.setup();
+    vi.mocked(fetchDisplayLocales).mockResolvedValueOnce([{ id: 'en', value: 'English' }]);
+
+    await renderEditModal({ data: buildDisplay({ languages: 'en' }) });
+    await user.click(screen.getByRole('tab', { name: 'Details' }));
+
+    const combobox = screen.getByRole('combobox', { name: /languages/i });
+    await waitFor(() => expect(combobox).toHaveTextContent('English'));
+  });
+});

--- a/frontend/src/pages/Displays/Displays/__tests__/edit/tabs/general.test.tsx
+++ b/frontend/src/pages/Displays/Displays/__tests__/edit/tabs/general.test.tsx
@@ -1,0 +1,197 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type React from 'react';
+import { vi, beforeEach, describe, test, expect } from 'vitest';
+
+import { buildDisplay, mockDisplay } from '../../fixtures/display';
+import { renderEditModal } from '../helpers/renderEditModal';
+
+import { testQueryClient } from '@/setupTests';
+
+// =============================================================================
+// Module mocks
+// =============================================================================
+
+vi.mock('react-i18next', () => {
+  const t = (key: string) => key;
+  return {
+    useTranslation: () => ({ t, i18n: { changeLanguage: vi.fn() } }),
+    Trans: ({ children }: { children: React.ReactNode }) => children,
+  };
+});
+
+vi.mock('@/services/displaysApi', () => ({
+  updateDisplay: vi.fn(),
+  fetchDisplayVenues: vi.fn().mockResolvedValue([]),
+  fetchDisplayLocales: vi.fn().mockResolvedValue([]),
+  fetchDisplays: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+}));
+vi.mock('@/services/displayProfileApi', () => ({
+  fetchDisplayProfile: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+  fetchDisplayProfileById: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('@/services/folderApi', () => ({
+  fetchFolderById: vi.fn().mockResolvedValue({ id: 1, text: 'Root' }),
+  fetchFolderTree: vi.fn().mockResolvedValue([]),
+  searchFolders: vi.fn().mockResolvedValue([]),
+  fetchContextButtons: vi.fn().mockResolvedValue({ create: true }),
+  selectFolder: vi.fn().mockResolvedValue({ success: true }),
+}));
+vi.mock('@/services/layoutsApi', () => ({
+  fetchLayouts: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+}));
+vi.mock('@/services/playerSoftwareApi', () => ({
+  fetchPlayerSoftware: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+}));
+vi.mock('@/services/daypartApi', () => ({
+  fetchDaypart: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+}));
+vi.mock('@/components/ui/modals/Modal');
+vi.mock('@/components/ui/forms/SelectFolder', () => ({
+  default: ({ selectedId }: { selectedId?: number | null }) => (
+    <div data-testid="mock-select-folder" data-folder-id={selectedId ?? ''} />
+  ),
+}));
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('Display - edit form: General tab', () => {
+  beforeEach(() => {
+    testQueryClient.clear();
+    vi.clearAllMocks();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Display name
+  // ---------------------------------------------------------------------------
+
+  test('display name is pre-populated with the existing value', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+    await user.click(screen.getByRole('tab', { name: 'General' }));
+
+    expect(screen.getByRole('textbox', { name: /^Display$/i })).toHaveValue(mockDisplay.display);
+  });
+
+  test('display name is editable and reflects typed input', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+    await user.click(screen.getByRole('tab', { name: 'General' }));
+
+    const input = screen.getByRole('textbox', { name: /^Display$/i });
+    await user.clear(input);
+    await user.type(input, 'Updated Display');
+
+    expect(input).toHaveValue('Updated Display');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Hardware Key
+  // ---------------------------------------------------------------------------
+
+  test('hardware key is pre-populated with the existing value', async () => {
+    const user = userEvent.setup();
+    await renderEditModal({ data: buildDisplay({ license: 'HW-KEY-001' }) });
+    await user.click(screen.getByRole('tab', { name: 'General' }));
+
+    expect(screen.getByRole('textbox', { name: /hardware key/i })).toHaveValue('HW-KEY-001');
+  });
+
+  test('hardware key is editable and reflects typed input', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+    await user.click(screen.getByRole('tab', { name: 'General' }));
+
+    const input = screen.getByRole('textbox', { name: /hardware key/i });
+    await user.clear(input);
+    await user.type(input, 'NEW-HW-KEY');
+
+    expect(input).toHaveValue('NEW-HW-KEY');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Description
+  // ---------------------------------------------------------------------------
+
+  test('description is pre-populated with the existing value', async () => {
+    const user = userEvent.setup();
+    await renderEditModal({ data: buildDisplay({ description: 'A test description' }) });
+    await user.click(screen.getByRole('tab', { name: 'General' }));
+
+    expect(screen.getByRole('textbox', { name: /description/i })).toHaveValue('A test description');
+  });
+
+  test('description is editable and reflects typed input', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+    await user.click(screen.getByRole('tab', { name: 'General' }));
+
+    const input = screen.getByRole('textbox', { name: /description/i });
+    await user.clear(input);
+    await user.type(input, 'Updated description');
+
+    expect(input).toHaveValue('Updated description');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Tags
+  // ---------------------------------------------------------------------------
+
+  test('tags input is present and accepts input', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+    await user.click(screen.getByRole('tab', { name: 'General' }));
+
+    const tagsInput = screen.getByRole('textbox', { name: /^Tags$/i });
+    expect(tagsInput).toBeInTheDocument();
+    await user.type(tagsInput, 'my-tag');
+    expect(tagsInput).toHaveValue('my-tag');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Authorise display (Switch — role="switch")
+  // ---------------------------------------------------------------------------
+
+  test('authorise display switch is present', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+    await user.click(screen.getByRole('tab', { name: 'General' }));
+
+    expect(screen.getByRole('switch', { name: /authorise/i })).toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Default Layout (SelectDropdown)
+  // ---------------------------------------------------------------------------
+
+  test('default layout combobox is present', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+    await user.click(screen.getByRole('tab', { name: 'General' }));
+
+    expect(screen.getByRole('combobox', { name: /default layout/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Displays/Displays/__tests__/edit/tabs/maintenance.test.tsx
+++ b/frontend/src/pages/Displays/Displays/__tests__/edit/tabs/maintenance.test.tsx
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type React from 'react';
+import { vi, beforeEach, describe, test, expect } from 'vitest';
+
+import { buildDisplay } from '../../fixtures/display';
+import { renderEditModal } from '../helpers/renderEditModal';
+
+import { testQueryClient } from '@/setupTests';
+
+// =============================================================================
+// Module mocks
+// =============================================================================
+
+vi.mock('react-i18next', () => {
+  const t = (key: string) => key;
+  return {
+    useTranslation: () => ({ t, i18n: { changeLanguage: vi.fn() } }),
+    Trans: ({ children }: { children: React.ReactNode }) => children,
+  };
+});
+
+vi.mock('@/services/displaysApi', () => ({
+  updateDisplay: vi.fn(),
+  fetchDisplayVenues: vi.fn().mockResolvedValue([]),
+  fetchDisplayLocales: vi.fn().mockResolvedValue([]),
+  fetchDisplays: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+}));
+vi.mock('@/services/displayProfileApi', () => ({
+  fetchDisplayProfile: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+  fetchDisplayProfileById: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('@/services/folderApi', () => ({
+  fetchFolderById: vi.fn().mockResolvedValue({ id: 1, text: 'Root' }),
+  fetchFolderTree: vi.fn().mockResolvedValue([]),
+  searchFolders: vi.fn().mockResolvedValue([]),
+  fetchContextButtons: vi.fn().mockResolvedValue({ create: true }),
+  selectFolder: vi.fn().mockResolvedValue({ success: true }),
+}));
+vi.mock('@/services/layoutsApi', () => ({
+  fetchLayouts: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+}));
+vi.mock('@/services/playerSoftwareApi', () => ({
+  fetchPlayerSoftware: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+}));
+vi.mock('@/services/daypartApi', () => ({
+  fetchDaypart: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+}));
+vi.mock('@/components/ui/modals/Modal');
+vi.mock('@/components/ui/forms/SelectFolder', () => ({
+  default: ({ selectedId }: { selectedId?: number | null }) => (
+    <div data-testid="mock-select-folder" data-folder-id={selectedId ?? ''} />
+  ),
+}));
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('Display - edit form: Maintenance tab', () => {
+  beforeEach(() => {
+    testQueryClient.clear();
+    vi.clearAllMocks();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Use the Global Timeout?
+  // ---------------------------------------------------------------------------
+
+  test('alert timeout checkbox reflects the existing value', async () => {
+    const user = userEvent.setup();
+    await renderEditModal({ data: buildDisplay({ alertTimeout: 1 }) });
+    await user.click(screen.getByRole('tab', { name: 'Maintenance' }));
+
+    expect(screen.getByRole('checkbox', { name: /use the global timeout/i })).toBeChecked();
+  });
+
+  test('alert timeout checkbox can be toggled', async () => {
+    const user = userEvent.setup();
+    await renderEditModal({ data: buildDisplay({ alertTimeout: 0 }) });
+    await user.click(screen.getByRole('tab', { name: 'Maintenance' }));
+
+    const checkbox = screen.getByRole('checkbox', { name: /use the global timeout/i });
+    expect(checkbox).not.toBeChecked();
+    await user.click(checkbox);
+    expect(checkbox).toBeChecked();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Email Alerts (SelectDropdown with role="combobox")
+  // ---------------------------------------------------------------------------
+
+  test('email alerts combobox is present', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+    await user.click(screen.getByRole('tab', { name: 'Maintenance' }));
+
+    expect(screen.getByRole('combobox', { name: /email alerts/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Displays/Displays/__tests__/edit/tabs/reference.test.tsx
+++ b/frontend/src/pages/Displays/Displays/__tests__/edit/tabs/reference.test.tsx
@@ -1,0 +1,235 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type React from 'react';
+import { vi, beforeEach, describe, test, expect } from 'vitest';
+
+import { buildDisplay } from '../../fixtures/display';
+import { renderEditModal } from '../helpers/renderEditModal';
+
+import { testQueryClient } from '@/setupTests';
+
+// =============================================================================
+// Module mocks
+// =============================================================================
+
+// Enhanced t: supports {{key}} interpolation so ref field labels resolve to
+// "Reference 1", "Reference 2", etc. rather than the raw key "Reference {{n}}".
+vi.mock('react-i18next', () => {
+  const t = (key: string, options?: Record<string, unknown>) => {
+    if (!options) return key;
+    return key.replace(/\{\{(\w+)\}\}/g, (_, k) => String(options[k] ?? `{{${k}}}`));
+  };
+  return {
+    useTranslation: () => ({ t, i18n: { changeLanguage: vi.fn() } }),
+    Trans: ({ children }: { children: React.ReactNode }) => children,
+  };
+});
+
+vi.mock('@/services/displaysApi', () => ({
+  updateDisplay: vi.fn(),
+  fetchDisplayVenues: vi.fn().mockResolvedValue([]),
+  fetchDisplayLocales: vi.fn().mockResolvedValue([]),
+  fetchDisplays: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+}));
+vi.mock('@/services/displayProfileApi', () => ({
+  fetchDisplayProfile: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+  fetchDisplayProfileById: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('@/services/folderApi', () => ({
+  fetchFolderById: vi.fn().mockResolvedValue({ id: 1, text: 'Root' }),
+  fetchFolderTree: vi.fn().mockResolvedValue([]),
+  searchFolders: vi.fn().mockResolvedValue([]),
+  fetchContextButtons: vi.fn().mockResolvedValue({ create: true }),
+  selectFolder: vi.fn().mockResolvedValue({ success: true }),
+}));
+vi.mock('@/services/layoutsApi', () => ({
+  fetchLayouts: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+}));
+vi.mock('@/services/playerSoftwareApi', () => ({
+  fetchPlayerSoftware: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+}));
+vi.mock('@/services/daypartApi', () => ({
+  fetchDaypart: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+}));
+vi.mock('@/components/ui/modals/Modal');
+vi.mock('@/components/ui/forms/SelectFolder', () => ({
+  default: ({ selectedId }: { selectedId?: number | null }) => (
+    <div data-testid="mock-select-folder" data-folder-id={selectedId ?? ''} />
+  ),
+}));
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('Display - edit form: Reference tab', () => {
+  beforeEach(() => {
+    testQueryClient.clear();
+    vi.clearAllMocks();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Reference 1
+  // ---------------------------------------------------------------------------
+
+  test('reference 1 is pre-populated with the existing value', async () => {
+    const user = userEvent.setup();
+    await renderEditModal({ data: buildDisplay({ ref1: 'REF-001' }) });
+    await user.click(screen.getByRole('tab', { name: 'Reference' }));
+
+    expect(screen.getByRole('textbox', { name: /^Reference 1$/i })).toHaveValue('REF-001');
+  });
+
+  test('reference 1 is editable and reflects typed input', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+    await user.click(screen.getByRole('tab', { name: 'Reference' }));
+
+    const input = screen.getByRole('textbox', { name: /^Reference 1$/i });
+    await user.clear(input);
+    await user.type(input, 'new-ref-1');
+
+    expect(input).toHaveValue('new-ref-1');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Reference 2
+  // ---------------------------------------------------------------------------
+
+  test('reference 2 is pre-populated with the existing value', async () => {
+    const user = userEvent.setup();
+    await renderEditModal({ data: buildDisplay({ ref2: 'REF-002' }) });
+    await user.click(screen.getByRole('tab', { name: 'Reference' }));
+
+    expect(screen.getByRole('textbox', { name: /^Reference 2$/i })).toHaveValue('REF-002');
+  });
+
+  test('reference 2 is editable and reflects typed input', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+    await user.click(screen.getByRole('tab', { name: 'Reference' }));
+
+    const input = screen.getByRole('textbox', { name: /^Reference 2$/i });
+    await user.clear(input);
+    await user.type(input, 'new-ref-2');
+
+    expect(input).toHaveValue('new-ref-2');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Reference 3
+  // ---------------------------------------------------------------------------
+
+  test('reference 3 is pre-populated with the existing value', async () => {
+    const user = userEvent.setup();
+    await renderEditModal({ data: buildDisplay({ ref3: 'REF-003' }) });
+    await user.click(screen.getByRole('tab', { name: 'Reference' }));
+
+    expect(screen.getByRole('textbox', { name: /^Reference 3$/i })).toHaveValue('REF-003');
+  });
+
+  test('reference 3 is editable and reflects typed input', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+    await user.click(screen.getByRole('tab', { name: 'Reference' }));
+
+    const input = screen.getByRole('textbox', { name: /^Reference 3$/i });
+    await user.clear(input);
+    await user.type(input, 'new-ref-3');
+
+    expect(input).toHaveValue('new-ref-3');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Reference 4
+  // ---------------------------------------------------------------------------
+
+  test('reference 4 is pre-populated with the existing value', async () => {
+    const user = userEvent.setup();
+    await renderEditModal({ data: buildDisplay({ ref4: 'REF-004' }) });
+    await user.click(screen.getByRole('tab', { name: 'Reference' }));
+
+    expect(screen.getByRole('textbox', { name: /^Reference 4$/i })).toHaveValue('REF-004');
+  });
+
+  test('reference 4 is editable and reflects typed input', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+    await user.click(screen.getByRole('tab', { name: 'Reference' }));
+
+    const input = screen.getByRole('textbox', { name: /^Reference 4$/i });
+    await user.clear(input);
+    await user.type(input, 'new-ref-4');
+
+    expect(input).toHaveValue('new-ref-4');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Reference 5
+  // ---------------------------------------------------------------------------
+
+  test('reference 5 is pre-populated with the existing value', async () => {
+    const user = userEvent.setup();
+    await renderEditModal({ data: buildDisplay({ ref5: 'REF-005' }) });
+    await user.click(screen.getByRole('tab', { name: 'Reference' }));
+
+    expect(screen.getByRole('textbox', { name: /^Reference 5$/i })).toHaveValue('REF-005');
+  });
+
+  test('reference 5 is editable and reflects typed input', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+    await user.click(screen.getByRole('tab', { name: 'Reference' }));
+
+    const input = screen.getByRole('textbox', { name: /^Reference 5$/i });
+    await user.clear(input);
+    await user.type(input, 'new-ref-5');
+
+    expect(input).toHaveValue('new-ref-5');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Custom ID
+  // ---------------------------------------------------------------------------
+
+  test('custom ID is pre-populated with the existing value', async () => {
+    const user = userEvent.setup();
+    await renderEditModal({ data: buildDisplay({ customId: 'CUSTOM-001' }) });
+    await user.click(screen.getByRole('tab', { name: 'Reference' }));
+
+    expect(screen.getByRole('textbox', { name: /custom id/i })).toHaveValue('CUSTOM-001');
+  });
+
+  test('custom ID is editable and reflects typed input', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+    await user.click(screen.getByRole('tab', { name: 'Reference' }));
+
+    const input = screen.getByRole('textbox', { name: /custom id/i });
+    await user.clear(input);
+    await user.type(input, 'NEW-CUSTOM');
+
+    expect(input).toHaveValue('NEW-CUSTOM');
+  });
+});

--- a/frontend/src/pages/Displays/Displays/__tests__/edit/tabs/remote.test.tsx
+++ b/frontend/src/pages/Displays/Displays/__tests__/edit/tabs/remote.test.tsx
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type React from 'react';
+import { vi, beforeEach, describe, test, expect } from 'vitest';
+
+import { buildDisplay } from '../../fixtures/display';
+import { renderEditModal } from '../helpers/renderEditModal';
+
+import { testQueryClient } from '@/setupTests';
+
+// =============================================================================
+// Module mocks
+// =============================================================================
+
+vi.mock('react-i18next', () => {
+  const t = (key: string) => key;
+  return {
+    useTranslation: () => ({ t, i18n: { changeLanguage: vi.fn() } }),
+    Trans: ({ children }: { children: React.ReactNode }) => children,
+  };
+});
+
+vi.mock('@/services/displaysApi', () => ({
+  updateDisplay: vi.fn(),
+  fetchDisplayVenues: vi.fn().mockResolvedValue([]),
+  fetchDisplayLocales: vi.fn().mockResolvedValue([]),
+  fetchDisplays: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+}));
+vi.mock('@/services/displayProfileApi', () => ({
+  fetchDisplayProfile: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+  fetchDisplayProfileById: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('@/services/folderApi', () => ({
+  fetchFolderById: vi.fn().mockResolvedValue({ id: 1, text: 'Root' }),
+  fetchFolderTree: vi.fn().mockResolvedValue([]),
+  searchFolders: vi.fn().mockResolvedValue([]),
+  fetchContextButtons: vi.fn().mockResolvedValue({ create: true }),
+  selectFolder: vi.fn().mockResolvedValue({ success: true }),
+}));
+vi.mock('@/services/layoutsApi', () => ({
+  fetchLayouts: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+}));
+vi.mock('@/services/playerSoftwareApi', () => ({
+  fetchPlayerSoftware: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+}));
+vi.mock('@/services/daypartApi', () => ({
+  fetchDaypart: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+}));
+vi.mock('@/components/ui/modals/Modal');
+vi.mock('@/components/ui/forms/SelectFolder', () => ({
+  default: ({ selectedId }: { selectedId?: number | null }) => (
+    <div data-testid="mock-select-folder" data-folder-id={selectedId ?? ''} />
+  ),
+}));
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('Display - edit form: Remote tab', () => {
+  beforeEach(() => {
+    testQueryClient.clear();
+    vi.clearAllMocks();
+  });
+
+  // ---------------------------------------------------------------------------
+  // TeamViewer Serial
+  // ---------------------------------------------------------------------------
+
+  test('TeamViewer serial is pre-populated with the existing value', async () => {
+    const user = userEvent.setup();
+    await renderEditModal({ data: buildDisplay({ teamViewerSerial: 'TV-123456' }) });
+    await user.click(screen.getByRole('tab', { name: 'Remote' }));
+
+    expect(screen.getByRole('textbox', { name: /teamviewer serial/i })).toHaveValue('TV-123456');
+  });
+
+  test('TeamViewer serial is editable and reflects typed input', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+    await user.click(screen.getByRole('tab', { name: 'Remote' }));
+
+    const input = screen.getByRole('textbox', { name: /teamviewer serial/i });
+    await user.clear(input);
+    await user.type(input, 'TV-NEW-789');
+
+    expect(input).toHaveValue('TV-NEW-789');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Webkey Serial
+  // ---------------------------------------------------------------------------
+
+  test('Webkey serial is pre-populated with the existing value', async () => {
+    const user = userEvent.setup();
+    await renderEditModal({ data: buildDisplay({ webkeySerial: 'WK-654321' }) });
+    await user.click(screen.getByRole('tab', { name: 'Remote' }));
+
+    expect(screen.getByRole('textbox', { name: /webkey serial/i })).toHaveValue('WK-654321');
+  });
+
+  test('Webkey serial is editable and reflects typed input', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+    await user.click(screen.getByRole('tab', { name: 'Remote' }));
+
+    const input = screen.getByRole('textbox', { name: /webkey serial/i });
+    await user.clear(input);
+    await user.type(input, 'WK-NEW-987');
+
+    expect(input).toHaveValue('WK-NEW-987');
+  });
+});

--- a/frontend/src/pages/Displays/Displays/__tests__/edit/tabs/settings.test.tsx
+++ b/frontend/src/pages/Displays/Displays/__tests__/edit/tabs/settings.test.tsx
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type React from 'react';
+import { vi, beforeEach, describe, test, expect } from 'vitest';
+
+import { renderEditModal } from '../helpers/renderEditModal';
+
+import { testQueryClient } from '@/setupTests';
+
+// =============================================================================
+// Module mocks
+// =============================================================================
+
+vi.mock('react-i18next', () => {
+  const t = (key: string) => key;
+  return {
+    useTranslation: () => ({ t, i18n: { changeLanguage: vi.fn() } }),
+    Trans: ({ children }: { children: React.ReactNode }) => children,
+  };
+});
+
+vi.mock('@/services/displaysApi', () => ({
+  updateDisplay: vi.fn(),
+  fetchDisplayVenues: vi.fn().mockResolvedValue([]),
+  fetchDisplayLocales: vi.fn().mockResolvedValue([]),
+  fetchDisplays: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+}));
+vi.mock('@/services/displayProfileApi', () => ({
+  fetchDisplayProfile: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+  fetchDisplayProfileById: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('@/services/folderApi', () => ({
+  fetchFolderById: vi.fn().mockResolvedValue({ id: 1, text: 'Root' }),
+  fetchFolderTree: vi.fn().mockResolvedValue([]),
+  searchFolders: vi.fn().mockResolvedValue([]),
+  fetchContextButtons: vi.fn().mockResolvedValue({ create: true }),
+  selectFolder: vi.fn().mockResolvedValue({ success: true }),
+}));
+vi.mock('@/services/layoutsApi', () => ({
+  fetchLayouts: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+}));
+vi.mock('@/services/playerSoftwareApi', () => ({
+  fetchPlayerSoftware: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+}));
+vi.mock('@/services/daypartApi', () => ({
+  fetchDaypart: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+}));
+vi.mock('@/components/ui/modals/Modal');
+vi.mock('@/components/ui/forms/SelectFolder', () => ({
+  default: ({ selectedId }: { selectedId?: number | null }) => (
+    <div data-testid="mock-select-folder" data-folder-id={selectedId ?? ''} />
+  ),
+}));
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('Display - edit form: Settings tab', () => {
+  beforeEach(() => {
+    testQueryClient.clear();
+    vi.clearAllMocks();
+  });
+
+  // When no display profile is assigned and the default profile returns no
+  // settings, the tab shows a "no settings" message rather than the overrides
+  // table. This smoke test confirms the tab renders without errors.
+  test('shows no-settings message when no profile is configured', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+    await user.click(screen.getByRole('tab', { name: 'Settings' }));
+
+    expect(await screen.findByText('No settings available for this profile.')).toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Settings Profile (SelectDropdown with role="combobox")
+  // ---------------------------------------------------------------------------
+
+  test('settings profile combobox is present', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+    await user.click(screen.getByRole('tab', { name: 'Settings' }));
+
+    expect(screen.getByRole('combobox', { name: /settings profile/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Displays/Displays/__tests__/edit/tabs/wol.test.tsx
+++ b/frontend/src/pages/Displays/Displays/__tests__/edit/tabs/wol.test.tsx
@@ -1,0 +1,207 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type React from 'react';
+import { vi, beforeEach, describe, test, expect } from 'vitest';
+
+import { buildDisplay } from '../../fixtures/display';
+import { renderEditModal } from '../helpers/renderEditModal';
+
+import { testQueryClient } from '@/setupTests';
+
+// =============================================================================
+// Module mocks
+// =============================================================================
+
+vi.mock('react-i18next', () => {
+  const t = (key: string) => key;
+  return {
+    useTranslation: () => ({ t, i18n: { changeLanguage: vi.fn() } }),
+    Trans: ({ children }: { children: React.ReactNode }) => children,
+  };
+});
+
+vi.mock('@/services/displaysApi', () => ({
+  updateDisplay: vi.fn(),
+  fetchDisplayVenues: vi.fn().mockResolvedValue([]),
+  fetchDisplayLocales: vi.fn().mockResolvedValue([]),
+  fetchDisplays: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+}));
+vi.mock('@/services/displayProfileApi', () => ({
+  fetchDisplayProfile: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+  fetchDisplayProfileById: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('@/services/folderApi', () => ({
+  fetchFolderById: vi.fn().mockResolvedValue({ id: 1, text: 'Root' }),
+  fetchFolderTree: vi.fn().mockResolvedValue([]),
+  searchFolders: vi.fn().mockResolvedValue([]),
+  fetchContextButtons: vi.fn().mockResolvedValue({ create: true }),
+  selectFolder: vi.fn().mockResolvedValue({ success: true }),
+}));
+vi.mock('@/services/layoutsApi', () => ({
+  fetchLayouts: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+}));
+vi.mock('@/services/playerSoftwareApi', () => ({
+  fetchPlayerSoftware: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+}));
+vi.mock('@/services/daypartApi', () => ({
+  fetchDaypart: vi.fn().mockResolvedValue({ rows: [], totalCount: 0 }),
+}));
+vi.mock('@/components/ui/modals/Modal');
+vi.mock('@/components/ui/forms/SelectFolder', () => ({
+  default: ({ selectedId }: { selectedId?: number | null }) => (
+    <div data-testid="mock-select-folder" data-folder-id={selectedId ?? ''} />
+  ),
+}));
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('Display - edit form: Wake on LAN tab', () => {
+  beforeEach(() => {
+    testQueryClient.clear();
+    vi.clearAllMocks();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Enable Wake on LAN
+  // ---------------------------------------------------------------------------
+
+  test('enable wake on LAN checkbox reflects the existing value', async () => {
+    const user = userEvent.setup();
+    await renderEditModal({ data: buildDisplay({ wakeOnLanEnabled: 1 }) });
+    await user.click(screen.getByRole('tab', { name: 'Wake on LAN' }));
+
+    expect(screen.getByRole('checkbox', { name: /enable wake on lan/i })).toBeChecked();
+  });
+
+  test('enable wake on LAN checkbox can be toggled', async () => {
+    const user = userEvent.setup();
+    await renderEditModal({ data: buildDisplay({ wakeOnLanEnabled: 0 }) });
+    await user.click(screen.getByRole('tab', { name: 'Wake on LAN' }));
+
+    const checkbox = screen.getByRole('checkbox', { name: /enable wake on lan/i });
+    expect(checkbox).not.toBeChecked();
+    await user.click(checkbox);
+    expect(checkbox).toBeChecked();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Broadcast Address
+  // ---------------------------------------------------------------------------
+
+  test('broadcast address is pre-populated with the existing value', async () => {
+    const user = userEvent.setup();
+    await renderEditModal({ data: buildDisplay({ broadCastAddress: '192.168.1.255' }) });
+    await user.click(screen.getByRole('tab', { name: 'Wake on LAN' }));
+
+    expect(screen.getByRole('textbox', { name: /broadcast address/i })).toHaveValue(
+      '192.168.1.255',
+    );
+  });
+
+  test('broadcast address is editable and reflects typed input', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+    await user.click(screen.getByRole('tab', { name: 'Wake on LAN' }));
+
+    const input = screen.getByRole('textbox', { name: /broadcast address/i });
+    await user.clear(input);
+    await user.type(input, '10.0.0.255');
+
+    expect(input).toHaveValue('10.0.0.255');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Wake on LAN SecureOn
+  // ---------------------------------------------------------------------------
+
+  test('wake on LAN SecureOn is pre-populated with the existing value', async () => {
+    const user = userEvent.setup();
+    await renderEditModal({ data: buildDisplay({ secureOn: 'AA-BB-CC-DD-EE-FF' }) });
+    await user.click(screen.getByRole('tab', { name: 'Wake on LAN' }));
+
+    expect(screen.getByRole('textbox', { name: /secureon/i })).toHaveValue('AA-BB-CC-DD-EE-FF');
+  });
+
+  test('wake on LAN SecureOn is editable and reflects typed input', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+    await user.click(screen.getByRole('tab', { name: 'Wake on LAN' }));
+
+    const input = screen.getByRole('textbox', { name: /secureon/i });
+    await user.clear(input);
+    await user.type(input, '11-22-33-44-55-66');
+
+    expect(input).toHaveValue('11-22-33-44-55-66');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Wake on LAN Time
+  // ---------------------------------------------------------------------------
+
+  test('wake on LAN time is pre-populated with the existing value', async () => {
+    const user = userEvent.setup();
+    await renderEditModal({ data: buildDisplay({ wakeOnLanTime: '07:00' }) });
+    await user.click(screen.getByRole('tab', { name: 'Wake on LAN' }));
+
+    expect(screen.getByRole('textbox', { name: /wake on lan time/i })).toHaveValue('07:00');
+  });
+
+  test('wake on LAN time is editable and reflects typed input', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+    await user.click(screen.getByRole('tab', { name: 'Wake on LAN' }));
+
+    const input = screen.getByRole('textbox', { name: /wake on lan time/i });
+    await user.clear(input);
+    await user.type(input, '08:30');
+
+    expect(input).toHaveValue('08:30');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Wake on LAN CIDR
+  // ---------------------------------------------------------------------------
+
+  test('wake on LAN CIDR is pre-populated with the existing value', async () => {
+    const user = userEvent.setup();
+    await renderEditModal({ data: buildDisplay({ cidr: '24' }) });
+    await user.click(screen.getByRole('tab', { name: 'Wake on LAN' }));
+
+    expect(screen.getByRole('textbox', { name: /wake on lan cidr/i })).toHaveValue('24');
+  });
+
+  test('wake on LAN CIDR is editable and reflects typed input', async () => {
+    const user = userEvent.setup();
+    await renderEditModal();
+    await user.click(screen.getByRole('tab', { name: 'Wake on LAN' }));
+
+    const input = screen.getByRole('textbox', { name: /wake on lan cidr/i });
+    await user.clear(input);
+    await user.type(input, '16');
+
+    expect(input).toHaveValue('16');
+  });
+});

--- a/frontend/src/pages/Displays/Displays/__tests__/fixtures/display.ts
+++ b/frontend/src/pages/Displays/Displays/__tests__/fixtures/display.ts
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type { FetchDisplaysResponse } from '@/services/displaysApi';
+import type { Display } from '@/types/display';
+import type { User } from '@/types/user';
+
+// -----------------------------------------------------------------------------
+// Factory that produces a Display with safe minimal defaults.
+// Only fields used in assertions carry meaningful values — everything else
+// is set to the zero value for its type so the component renders without errors.
+//
+// displayId: 1     — asserted in delete tests
+// display: 'Test Display' — asserted in render and modal tests
+// displayGroupId: 1 — required by action hooks
+// folderId / permissionsFolderId: 1 — required by SelectFolder stub
+// -----------------------------------------------------------------------------
+export const buildDisplay = (overrides: Partial<Display> = {}): Display => ({
+  displayId: 1,
+  display: 'Test Display',
+  description: null,
+  displayTypeId: null,
+  displayType: null,
+  venueId: null,
+  address: null,
+  isMobile: 0,
+  languages: null,
+  screenSize: null,
+  isOutdoor: 0,
+  customId: null,
+  costPerPlay: null,
+  impressionsPerPlay: null,
+  ref1: null,
+  ref2: null,
+  ref3: null,
+  ref4: null,
+  ref5: null,
+  auditingUntil: null,
+  defaultLayoutId: 1,
+  license: '',
+  licensed: 1,
+  loggedIn: 0,
+  lastAccessed: null,
+  incSchedule: 0,
+  emailAlert: 0,
+  alertTimeout: 0,
+  clientAddress: null,
+  mediaInventoryStatus: 0,
+  macAddress: null,
+  lastChanged: null,
+  numberOfMacAddressChanges: 0,
+  lastWakeOnLanCommandSent: null,
+  wakeOnLanEnabled: 0,
+  wakeOnLanTime: null,
+  broadCastAddress: null,
+  secureOn: null,
+  cidr: null,
+  latitude: null,
+  longitude: null,
+  clientType: null,
+  clientVersion: null,
+  clientCode: null,
+  displayProfileId: null,
+  displayProfile: null,
+  currentLayoutId: null,
+  screenShotRequested: 0,
+  storageAvailableSpace: null,
+  storageTotalSpace: null,
+  displayGroupId: 1,
+  currentLayout: null,
+  defaultLayout: null,
+  displayGroups: [],
+  xmrChannel: null,
+  xmrPubKey: null,
+  lastCommandSuccess: 0,
+  deviceName: null,
+  timeZone: null,
+  tags: [],
+  overrideConfig: [],
+  bandwidthLimit: null,
+  newCmsAddress: null,
+  newCmsKey: null,
+  orientation: null,
+  resolution: null,
+  commercialLicence: 0,
+  teamViewerSerial: null,
+  webkeySerial: null,
+  groupsWithPermissions: null,
+  isPlayerSupported: null,
+  createdDt: null,
+  modifiedDt: null,
+  folderId: 1,
+  permissionsFolderId: 1,
+  countFaults: 0,
+  lanIpAddress: null,
+  syncGroupId: null,
+  osVersion: null,
+  osSdk: null,
+  manufacturer: null,
+  brand: null,
+  model: null,
+  ...overrides,
+});
+
+export const mockDisplay = buildDisplay();
+
+export const SINGLE_DISPLAY: FetchDisplaysResponse = {
+  rows: [mockDisplay],
+  totalCount: 1,
+};
+
+export const EMPTY_DISPLAY_TABLE: FetchDisplaysResponse = {
+  rows: [],
+  totalCount: 0,
+};
+
+// The default logged-in user for display tests.
+export const mockUser: User = {
+  userId: 1,
+  userName: 'TestUser',
+  userTypeId: 1,
+  groupId: 1,
+  features: { 'folder.view': true },
+  settings: {
+    defaultTimezone: 'UTC',
+    defaultLanguage: 'en',
+    DATE_FORMAT_JS: 'DD/MM/YYYY',
+    TIME_FORMAT_JS: 'HH:mm',
+  },
+};
+
+// Query keys that mirror what useTableState builds internally.
+export const queryKeys = {
+  displaysPage: ['userPref', 'displays_page'] as const,
+};

--- a/frontend/src/pages/Displays/Displays/__tests__/helpers/renderDisplaysPage.tsx
+++ b/frontend/src/pages/Displays/Displays/__tests__/helpers/renderDisplaysPage.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import DisplaysPage from '../../Displays';
+import { mockUser, queryKeys } from '../fixtures/display';
+
+import { UserProvider } from '@/context/UserContext';
+import { testQueryClient } from '@/setupTests';
+
+// Renders the full Displays page inside all required context providers.
+// Call testQueryClient.clear() and vi.clearAllMocks() in beforeEach to
+// guarantee test isolation before using this helper.
+export const renderDisplaysPage = () => {
+  testQueryClient.setQueryData(queryKeys.displaysPage, null);
+  return render(
+    <QueryClientProvider client={testQueryClient}>
+      <UserProvider initialUser={mockUser}>
+        <MemoryRouter>
+          <DisplaysPage />
+        </MemoryRouter>
+      </UserProvider>
+    </QueryClientProvider>,
+  );
+};

--- a/frontend/src/pages/Displays/Displays/__tests__/mocks/displaysApi.ts
+++ b/frontend/src/pages/Displays/Displays/__tests__/mocks/displaysApi.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { vi } from 'vitest';
+
+import { useDisplaysData } from '../../hooks/useDisplaysData';
+
+import { fetchDisplays } from '@/services/displaysApi';
+import type { FetchDisplaysResponse } from '@/services/displaysApi';
+
+export type UseDisplaysReturn = ReturnType<typeof useDisplaysData>;
+
+// Makes fetchDisplays return the provided data (integration-style tests).
+// Requires vi.mock('@/services/displaysApi') at the test file level.
+export const mockFetchDisplays = (rawData: FetchDisplaysResponse) => {
+  vi.mocked(fetchDisplays).mockResolvedValue(rawData);
+};
+
+// Mocks the data hook directly (for search/pagination unit tests).
+// Requires vi.mock('../../hooks/useDisplaysData') at the test file level.
+export const mockDisplaysData = (rawData: FetchDisplaysResponse) => {
+  vi.mocked(useDisplaysData).mockReturnValue({
+    data: rawData,
+    isFetching: false,
+    isError: false,
+    error: null,
+  } as unknown as UseDisplaysReturn);
+};

--- a/frontend/src/pages/Displays/Displays/components/EditDisplayModal.tsx
+++ b/frontend/src/pages/Displays/Displays/components/EditDisplayModal.tsx
@@ -867,50 +867,107 @@ export default function EditDisplayModal({
       ]}
     >
       <div className="flex flex-col h-full overflow-y-hidden overflow-x-visible px-4">
-        <nav className="flex px-4 overflow-x-auto shrink-0" aria-label="Tabs">
-          <button type="button" className={tab('general')} onClick={() => setActiveTab('general')}>
+        <div
+          role="tablist"
+          aria-label={t('Display settings tabs')}
+          className="flex px-4 overflow-x-auto shrink-0"
+        >
+          <button
+            role="tab"
+            type="button"
+            id="tab-general"
+            aria-selected={activeTab === 'general'}
+            aria-controls="tabpanel-display"
+            className={tab('general')}
+            onClick={() => setActiveTab('general')}
+          >
             {t('General')}
           </button>
-          <button type="button" className={tab('details')} onClick={() => setActiveTab('details')}>
+          <button
+            role="tab"
+            type="button"
+            id="tab-details"
+            aria-selected={activeTab === 'details'}
+            aria-controls="tabpanel-display"
+            className={tab('details')}
+            onClick={() => setActiveTab('details')}
+          >
             {t('Details')}
           </button>
           <button
+            role="tab"
             type="button"
+            id="tab-reference"
+            aria-selected={activeTab === 'reference'}
+            aria-controls="tabpanel-display"
             className={tab('reference')}
             onClick={() => setActiveTab('reference')}
           >
             {t('Reference')}
           </button>
           <button
+            role="tab"
             type="button"
+            id="tab-maintenance"
+            aria-selected={activeTab === 'maintenance'}
+            aria-controls="tabpanel-display"
             className={tab('maintenance')}
             onClick={() => setActiveTab('maintenance')}
           >
             {t('Maintenance')}
           </button>
-          <button type="button" className={tab('wol')} onClick={() => setActiveTab('wol')}>
+          <button
+            role="tab"
+            type="button"
+            id="tab-wol"
+            aria-selected={activeTab === 'wol'}
+            aria-controls="tabpanel-display"
+            className={tab('wol')}
+            onClick={() => setActiveTab('wol')}
+          >
             {t('Wake on LAN')}
           </button>
           <button
+            role="tab"
             type="button"
+            id="tab-settings"
+            aria-selected={activeTab === 'settings'}
+            aria-controls="tabpanel-display"
             className={tab('settings')}
             onClick={() => setActiveTab('settings')}
           >
             {t('Settings')}
           </button>
-          <button type="button" className={tab('remote')} onClick={() => setActiveTab('remote')}>
+          <button
+            role="tab"
+            type="button"
+            id="tab-remote"
+            aria-selected={activeTab === 'remote'}
+            aria-controls="tabpanel-display"
+            className={tab('remote')}
+            onClick={() => setActiveTab('remote')}
+          >
             {t('Remote')}
           </button>
           <button
+            role="tab"
             type="button"
+            id="tab-advanced"
+            aria-selected={activeTab === 'advanced'}
+            aria-controls="tabpanel-display"
             className={tab('advanced')}
             onClick={() => setActiveTab('advanced')}
           >
             {t('Advanced')}
           </button>
-        </nav>
+        </div>
 
-        <div className="flex-1 overflow-y-auto py-4 px-8 space-y-4">
+        <div
+          role="tabpanel"
+          id="tabpanel-display"
+          aria-labelledby={`tab-${activeTab}`}
+          className="flex-1 overflow-y-auto py-4 px-8 space-y-4"
+        >
           {activeTab === 'general' && (
             <>
               <div className="relative z-20">


### PR DESCRIPTION
- Display Edit form tab tests
- https://github.com/xibosignageltd/xibo-private/issues/1343

- Add and Delete display modals. Fixed accessibility issues in the edit modal's tab  navigation and the shared SelectDropdown, MultiSelectDropdown, and TagInput components so the tests could query them by role.