### PR TITLE
Datasets: fixed missing ownership checks when exporting csv

### DIFF
--- a/lib/Controller/DataSet.php
+++ b/lib/Controller/DataSet.php
@@ -1375,8 +1375,13 @@ class DataSet extends Base
         $i = 0;
         $dataSet = $this->dataSetFactory->getById($id);
 
+        if (!$this->getUser()->checkEditable($dataSet)) {
+            throw new AccessDeniedException();
+        }
+
         // Create a CSV file
-        $tempFileName = $this->getConfig()->getSetting('LIBRARY_LOCATION') . 'temp/' . Random::generateString() .'.csv';
+        $tempFileName = $this->getConfig()->getSetting('LIBRARY_LOCATION') . 'temp/' .
+            Random::generateString() .'.csv';
 
         $out = fopen($tempFileName, 'w');
 


### PR DESCRIPTION
## Changes
- Added user ownership checks for exporting CSV in datasets 

Relates to https://github.com/xibosignageltd/xibo-private/issues/1420