### PR TITLE
QA: Change workflow based on PR base branch

### DIFF
--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -5,9 +5,29 @@ on:
     types: [created]
 
 jobs:
+  check-base-branch:
+    name: Check PR Base Branch
+    runs-on: ubuntu-latest
+    if: github.event.issue.pull_request && contains(github.event.comment.body, 'TEST:')
+    outputs:
+      base_ref: ${{ steps.pr_info.outputs.base_ref }}
+    steps:
+      - name: Get PR base branch
+        id: pr_info
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            core.setOutput('base_ref', pr.data.base.ref);
+
   phpunit:
     name: Run PHPUnit
-    if: github.event.issue.pull_request && contains(github.event.comment.body, 'TEST:')
+    needs: check-base-branch
+    if: needs.check-base-branch.outputs.base_ref == 'develop'
     runs-on: ubuntu-latest
 
     steps:
@@ -75,8 +95,8 @@ jobs:
 
   vitest:
     name: Run Vitest
-    needs: phpunit
-    if: github.event.issue.pull_request && contains(github.event.comment.body, 'TEST:')
+    needs: [check-base-branch, phpunit]
+    if: needs.check-base-branch.outputs.base_ref == 'develop'
     runs-on: ubuntu-latest
 
     steps:
@@ -164,8 +184,8 @@ jobs:
 
   comment:
     name: Post Result Comment
-    needs: [phpunit, vitest]
-    if: always() && github.event.issue.pull_request && contains(github.event.comment.body, 'TEST:')
+    needs: [check-base-branch, phpunit, vitest]
+    if: always() && needs.check-base-branch.outputs.base_ref == 'develop'
     runs-on: ubuntu-latest
     steps:
       - name: Add workflow result as comment on PR
@@ -191,3 +211,168 @@ jobs:
               repo: context.repo.repo,
               body: body
             })
+
+  cypress:
+    name: Build Containers and Run Cypress (release44)
+    needs: check-base-branch
+    if: needs.check-base-branch.outputs.base_ref == 'release44'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Get branch of PR
+        uses: xt0rted/pull-request-comment-branch@v1
+        id: comment-branch
+
+      - name: Set latest commit status as pending
+        uses: myrotvorets/set-commit-status-action@master
+        with:
+          sha: ${{ steps.comment-branch.outputs.head_sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: pending
+
+      - name: Checkout PR branch ${{ steps.comment-branch.outputs.head_ref }}
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.comment-branch.outputs.head_sha }}
+
+      - name: Check Comment
+        id: check_comment
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          if [[ "$COMMENT_BODY" =~ ^TEST:\ (all|\*)$ ]]; then
+            test_all=true
+          elif [[ "$COMMENT_BODY" =~ ^TEST:(.*?)END$ ]]; then
+            specs="${BASH_REMATCH[1]}"
+            IFS=',' read -ra content_array <<< "$specs"
+            content_array=("${content_array[@]// /}")
+            content_array=("${content_array[@]#/}")
+            content_array=("${content_array[@]%/}")
+            for ((i=0; i<${#content_array[@]}; i++)); do
+              content_array[$i]="/app/cypress/e2e/${content_array[$i]}"
+            done
+            content_no_spaces="$(IFS=','; echo "${content_array[*]}")"
+            echo "spec_content=$content_no_spaces" >> $GITHUB_ENV
+          else
+            echo "Comment does not match the expected format."
+            exit 1
+          fi
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull
+        run: |
+          docker pull mysql:8.4
+          docker pull ghcr.io/xibosignage/xibo-xmr:latest
+          docker pull ghcr.io/xibosignage/xibo-cms:test-${{ github.event.issue.number }}
+
+      - name: Run
+        run: |
+          docker run --name cms-db -e MYSQL_RANDOM_ROOT_PASSWORD=yes -e MYSQL_DATABASE=cms -e MYSQL_USER=cms -e MYSQL_PASSWORD=jenkins -d mysql:8.4
+          docker run --name cms-xmr -d ghcr.io/xibosignage/xibo-xmr:latest
+          docker run --name cms-web -e MYSQL_HOST=cms-db -e MYSQL_USER=cms -e MYSQL_PASSWORD=jenkins -e CMS_DEV_MODE=true -e XMR_HOST=cms-xmr -e CMS_USAGE_REPORT=false -e INSTALL_TYPE=ci -e MYSQL_BACKUP_ENABLED=false --link cms-db --link cms-xmr -d ghcr.io/xibosignage/xibo-cms:test-${{ github.event.issue.number }}
+
+      - name: Wait for CMS
+        run: |
+          docker exec -t cms-web /bin/bash -c "/usr/local/bin/wait-for-command.sh -q -t 300 -c \"nc -z localhost 80\""
+          docker cp cms-web:/var/www/cms/web/settings.php web/settings.php
+          docker exec -t cms-web /bin/bash -c "chown -R www-data.www-data /var/www/cms"
+          docker exec --user www-data -t cms-web /bin/bash -c "cd /var/www/cms; /usr/bin/php bin/run.php 1"
+          sleep 5
+
+      - name: Seed Database
+        run: |
+          docker exec cms-db mysql -ucms -pjenkins cms -e "UPDATE setting SET value=\"6v4RduQhaw5Q\" WHERE setting = \"SERVER_KEY\" "
+          docker exec cms-db mysql -ucms -pjenkins cms -e "INSERT INTO task (name, class, status, isActive, configFile, options, schedule) VALUES ('Seed Database', '\\\\Xibo\\\\XTR\\\\SeedDatabaseTask', 2, 1, '/tasks/seed-database.task', '{}', '* * * * * *')"
+          docker exec --user www-data -t cms-web /bin/bash -c "cd /var/www/cms; /usr/bin/php bin/run.php \"Seed Database\""
+          sleep 5
+
+      - name: Run PHP Unit
+        run: |
+          docker exec --user www-data -t cms-web /bin/bash -c "cd /var/www/cms; php vendor/bin/phpunit --log-junit results.xml"
+
+      - run: |
+          rm package.json
+          rm package-lock.json
+
+      - name: Configure Testmo
+        uses: actions/setup-node@v3
+        with:
+          node-version: 22
+
+      - run: npm install --no-save @testmo/testmo-cli
+
+      - run: |
+          npx testmo automation:resources:add-field --name git --type string \
+            --value ${GITHUB_SHA:0:7} --resources resources.json
+          RUN_URL="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          npx testmo automation:resources:add-link --name build \
+            --url $RUN_URL --resources resources.json
+
+      - name: Run Cypress
+        id: cypress
+        run: |
+          docker pull ghcr.io/xibosignage/xibo-cms:cypress
+          docker exec cms-db mysql -ucms -pjenkins cms -e "INSERT INTO oauth_clients (id, secret, name, userId, authCode, clientCredentials) VALUES ('MrGPc7e3IL1hA6w13l7Ru5giygxmNiafGNhFv89d', 'Pk6DdDgu2HzSoepcMHRabY60lDEvQ9ucTejYvc5dOgNVSNaOJirCUM83oAzlwe0KBiGR2Nhi6ltclyNC1rmcq0CiJZXzE42KfeatQ4j9npr6nMIQAzMal8O8RiYrIoono306CfyvSSJRfVfKExIjj0ZyE4TUrtPezJbKmvkVDzh8aj3kbanDKatirhwpfqfVdfgsqVNjzIM9ZgKHnbrTX7nNULL3BtxxNGgDMuCuvKiJFrLSyIIz1F4SNrHwHz', 'cypress', 1, 0, 1)"
+          docker exec cms-db mysql -ucms -pjenkins cms -e "INSERT INTO oauth_client_scopes (clientId, scopeId) VALUES ('MrGPc7e3IL1hA6w13l7Ru5giygxmNiafGNhFv89d', 'all') ON DUPLICATE KEY UPDATE scopeId = scopeId"
+          if [[ "$test_all" == true ]]; then
+            npx testmo automation:run:submit \
+              --instance "$TESTMO_URL" \
+              --project-id 3 \
+              --name "Cypress Tests" \
+              --source "github-action" \
+              --resources resources.json \
+              --results cypress/results/*.xml \
+              --  docker run --ipc=host --name cms-cypress --link=cms-web:web -v $(pwd)/cypress.config.js:/app/cypress.config.js -v $(pwd)/cypress:/app/cypress ghcr.io/xibosignage/xibo-cms:cypress bash -c "CYPRESS_baseUrl=http://web /app/node_modules/.bin/cypress run --config screenshotsFolder=/app/cypress/results,video=false --reporter junit --reporter-options 'mochaFile=/app/cypress/results/results_cypress_[hash].xml,toConsole=true' && chown -R 1001:1001 /app/cypress/results && exit \${PIPESTATUS[0]};"
+          else
+            npx testmo automation:run:submit \
+              --instance "$TESTMO_URL" \
+              --project-id 3 \
+              --name "Cypress Tests" \
+              --source "github-action" \
+              --resources resources.json \
+              --results cypress/results/*.xml \
+              -- docker run --ipc=host --name cms-cypress --link=cms-web:web -v $(pwd)/cypress.config.js:/app/cypress.config.js -v $(pwd)/cypress:/app/cypress ghcr.io/xibosignage/xibo-cms:cypress bash -c "CYPRESS_baseUrl=http://web /app/node_modules/.bin/cypress run --config screenshotsFolder=/app/cypress/results,video=false --spec \"$spec_content\" --reporter junit --reporter-options 'mochaFile=/app/cypress/results/results_cypress_[hash].xml,toConsole=true' && chown -R 1001:1001 /app/cypress/results && exit \${PIPESTATUS[0]};"
+          fi
+        continue-on-error: true
+        env:
+          TESTMO_URL: ${{ secrets.TESTMO_URL }}
+          TESTMO_TOKEN: ${{ secrets.TESTMO_TOKEN }}
+
+      - name: Check Cypress exit code
+        run: |
+          if [[ ${{ steps.cypress.outcome }} == 'success' ]]; then
+            echo "Cypress tests succeeded"
+          else
+            echo "Cypress tests failed with exit code ${{ steps.cypress.exitCode }}"
+            exit 1
+          fi
+
+      - name: Add workflow result as comment on PR
+        uses: actions/github-script@v6
+        if: always()
+        with:
+          script: |
+            const name = '${{ github.workflow }}';
+            const url = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
+            const success = '${{ job.status }}' === 'success';
+            const body = `${name}: ${success ? 'succeeded ✅' : 'failed ❌'}\n${url}`;
+
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            })
+
+      - name: Set latest commit status as ${{ job.status }}
+        uses: myrotvorets/set-commit-status-action@master
+        if: always()
+        with:
+          sha: ${{ steps.comment-branch.outputs.head_sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: ${{ job.status }}


### PR DESCRIPTION
GitHub always goes to the main branch (develop) to pick up the test instructions

- develop uses Vitest for frontend tests
- release44 uses Cypress for E2E tests
