### PR TITLE
Added Menu Board tests

### DIFF
--- a/frontend/src/pages/Library/MenuBoard/__tests__/AddAndEditMenuBoardModal.test.tsx
+++ b/frontend/src/pages/Library/MenuBoard/__tests__/AddAndEditMenuBoardModal.test.tsx
@@ -1,0 +1,229 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import AddAndEditMenuBoardModal from '../components/AddAndEditMenuBoardModal';
+
+import { renderWithProviders, mockMenuBoard } from './MenuBoardSetup';
+
+// -- Module mocks --
+
+const mockCreateMenuBoard = vi.fn();
+const mockUpdateMenuBoard = vi.fn();
+
+vi.mock('@/services/menuBoardApi', () => ({
+  createMenuBoard: (...args: unknown[]) => mockCreateMenuBoard(...args),
+  updateMenuBoard: (...args: unknown[]) => mockUpdateMenuBoard(...args),
+}));
+
+vi.mock('@/hooks/usePermissions', () => ({
+  usePermissions: () => ({ canViewFolders: false }),
+}));
+
+vi.mock('@/components/ui/forms/SelectFolder', () => ({ default: () => null }));
+vi.mock('@/components/ui/modals/Modal');
+
+// -- Helpers --
+
+function renderAddModal() {
+  const mockOnClose = vi.fn();
+  const mockOnSave = vi.fn();
+  renderWithProviders(
+    <AddAndEditMenuBoardModal type="add" onClose={mockOnClose} onSave={mockOnSave} />,
+  );
+  return { mockOnClose, mockOnSave };
+}
+
+function renderEditModal(dataOverrides = {}) {
+  const mockOnClose = vi.fn();
+  const mockOnSave = vi.fn();
+  const board = mockMenuBoard(dataOverrides);
+  renderWithProviders(
+    <AddAndEditMenuBoardModal
+      type="edit"
+      data={board}
+      onClose={mockOnClose}
+      onSave={mockOnSave}
+    />,
+  );
+  return { mockOnClose, mockOnSave, board };
+}
+
+// -- Tests --
+
+describe('AddAndEditMenuBoardModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Scenarios 1, 2 — add with valid data
+  describe('Add mode', () => {
+    it('renders "Add Menu Board" title with empty fields', () => {
+      renderAddModal();
+
+      expect(screen.getByRole('dialog', { name: 'Add Menu Board' })).toBeInTheDocument();
+      expect(screen.getByLabelText('Name')).toHaveValue('');
+      expect(screen.getByLabelText(/^Code/, { exact: false })).toHaveValue('');
+      expect(screen.getByLabelText(/^Description/, { exact: false })).toHaveValue('');
+    });
+
+    it('calls createMenuBoard with name, description, and code on save', async () => {
+      const user = userEvent.setup();
+      mockCreateMenuBoard.mockResolvedValue(mockMenuBoard());
+      const { mockOnSave, mockOnClose } = renderAddModal();
+
+      await user.type(screen.getByLabelText('Name'), 'New Board');
+      await user.type(screen.getByLabelText('Code', { exact: false }), 'NB_01');
+      await user.type(screen.getByLabelText('Description', { exact: false }), 'A description');
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      await waitFor(() => {
+        expect(mockCreateMenuBoard).toHaveBeenCalledWith(
+          expect.objectContaining({ name: 'New Board', code: 'NB_01', description: 'A description' }),
+        );
+        expect(mockOnSave).toHaveBeenCalled();
+        expect(mockOnClose).toHaveBeenCalled();
+      });
+    });
+
+    // Scenario 3 — empty name
+    it('shows validation error when name is empty on save', async () => {
+      const user = userEvent.setup();
+      renderAddModal();
+
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      expect(screen.getByText('Name is required')).toBeInTheDocument();
+      expect(mockCreateMenuBoard).not.toHaveBeenCalled();
+    });
+
+    // Scenario 4 — whitespace-only name
+    it('shows validation error when name is only whitespace', async () => {
+      const user = userEvent.setup();
+      renderAddModal();
+
+      await user.type(screen.getByLabelText('Name'), '   ');
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      expect(screen.getByText('Name is required')).toBeInTheDocument();
+      expect(mockCreateMenuBoard).not.toHaveBeenCalled();
+    });
+
+    it('clears the name error once the user types a valid name', async () => {
+      const user = userEvent.setup();
+      renderAddModal();
+
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+      expect(screen.getByText('Name is required')).toBeInTheDocument();
+
+      await user.type(screen.getByLabelText('Name'), 'B');
+      expect(screen.queryByText('Name is required')).not.toBeInTheDocument();
+    });
+
+    it('displays API error message when createMenuBoard rejects', async () => {
+      const user = userEvent.setup();
+      mockCreateMenuBoard.mockRejectedValue({
+        response: { data: { message: 'Server error from API' } },
+      });
+      renderAddModal();
+
+      await user.type(screen.getByLabelText('Name'), 'Bad Board');
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Server error from API')).toBeInTheDocument();
+      });
+    });
+  });
+
+  // Scenarios 19, 22, 23 — edit mode
+  describe('Edit mode', () => {
+    it('renders "Edit Menu Board" title and pre-populates fields', () => {
+      renderEditModal({ name: 'Existing Board', description: 'Existing desc', code: 'EB_01' });
+
+      expect(screen.getByRole('dialog', { name: 'Edit Menu Board' })).toBeInTheDocument();
+      expect(screen.getByLabelText('Name')).toHaveValue('Existing Board');
+      expect(screen.getByLabelText('Code', { exact: false })).toHaveValue('EB_01');
+      expect(screen.getByLabelText('Description', { exact: false })).toHaveValue('Existing desc');
+    });
+
+    it('calls updateMenuBoard with changed name on save', async () => {
+      const user = userEvent.setup();
+      mockUpdateMenuBoard.mockResolvedValue(mockMenuBoard({ name: 'Updated Board' }));
+      const { mockOnSave, board } = renderEditModal({ name: 'Old Name' });
+
+      await user.clear(screen.getByLabelText('Name'));
+      await user.type(screen.getByLabelText('Name'), 'Updated Board');
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      await waitFor(() => {
+        expect(mockUpdateMenuBoard).toHaveBeenCalledWith(
+          board.menuId,
+          expect.objectContaining({ name: 'Updated Board' }),
+        );
+        expect(mockOnSave).toHaveBeenCalled();
+      });
+    });
+
+    it('shows validation error when name is cleared on edit save', async () => {
+      const user = userEvent.setup();
+      renderEditModal({ name: 'Has A Name' });
+
+      await user.clear(screen.getByLabelText('Name'));
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      expect(screen.getByText('Name is required')).toBeInTheDocument();
+      expect(mockUpdateMenuBoard).not.toHaveBeenCalled();
+    });
+
+    it('updates description and code fields', async () => {
+      const user = userEvent.setup();
+      mockUpdateMenuBoard.mockResolvedValue(mockMenuBoard());
+      const { board } = renderEditModal({ name: 'Board', description: '', code: '' });
+
+      await user.type(screen.getByLabelText('Description', { exact: false }), 'New Desc');
+      await user.type(screen.getByLabelText('Code', { exact: false }), 'NEW_CODE');
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      await waitFor(() => {
+        expect(mockUpdateMenuBoard).toHaveBeenCalledWith(
+          board.menuId,
+          expect.objectContaining({ description: 'New Desc', code: 'NEW_CODE' }),
+        );
+      });
+    });
+  });
+
+  describe('Cancel button', () => {
+    it('calls onClose when Cancel is clicked', async () => {
+      const user = userEvent.setup();
+      const { mockOnClose } = renderAddModal();
+
+      await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      expect(mockOnClose).toHaveBeenCalled();
+      expect(mockCreateMenuBoard).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/pages/Library/MenuBoard/__tests__/CopyMenuBoardModal.test.tsx
+++ b/frontend/src/pages/Library/MenuBoard/__tests__/CopyMenuBoardModal.test.tsx
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import CopyMenuBoardModal from '../components/CopyMenuBoardModal';
+
+import { renderWithProviders, mockMenuBoard } from './MenuBoardSetup';
+
+vi.mock('@/components/ui/modals/Modal');
+
+describe('CopyMenuBoardModal', () => {
+  const mockOnClose = vi.fn();
+  const mockOnConfirm = vi.fn();
+  const existingNames = ['Existing Board', 'Another Board'];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not render when isOpen is false', () => {
+    renderWithProviders(
+      <CopyMenuBoardModal
+        isOpen={false}
+        onClose={mockOnClose}
+        onConfirm={mockOnConfirm}
+        menuBoard={null}
+        existingNames={existingNames}
+      />,
+    );
+
+    expect(screen.queryByText('Copy Menu Board')).not.toBeInTheDocument();
+  });
+
+  // Scenario 141 — copy creates new board; name is auto-incremented
+  it('initializes with incremented name and pre-fills code and description from source board', () => {
+    const board = mockMenuBoard({ name: 'Summer Menu', description: 'Summer desc', code: 'SM_01' });
+
+    renderWithProviders(
+      <CopyMenuBoardModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onConfirm={mockOnConfirm}
+        menuBoard={board}
+        existingNames={existingNames}
+      />,
+    );
+
+    expect(screen.getByLabelText('Name')).toHaveValue('Summer Menu (1)');
+    expect(screen.getByLabelText('Description', { exact: false })).toHaveValue('Summer desc');
+    expect(screen.getByLabelText('Code', { exact: false })).toHaveValue('SM_01');
+  });
+
+  it('shows error when submitting with empty name', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <CopyMenuBoardModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onConfirm={mockOnConfirm}
+        menuBoard={null}
+        existingNames={existingNames}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(screen.getByText('Name is required')).toBeInTheDocument();
+    expect(mockOnConfirm).not.toHaveBeenCalled();
+  });
+
+  it('shows error when submitting with a duplicate name (case-insensitive)', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <CopyMenuBoardModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onConfirm={mockOnConfirm}
+        menuBoard={null}
+        existingNames={existingNames}
+      />,
+    );
+
+    await user.type(screen.getByLabelText('Name'), 'existing board');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(screen.getByText('A menu board with this name already exists')).toBeInTheDocument();
+    expect(mockOnConfirm).not.toHaveBeenCalled();
+  });
+
+  it('submits with trimmed name, description, and code', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <CopyMenuBoardModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onConfirm={mockOnConfirm}
+        menuBoard={null}
+        existingNames={existingNames}
+      />,
+    );
+
+    await user.type(screen.getByLabelText('Name'), '  Unique Board Name  ');
+    await user.type(screen.getByLabelText('Code', { exact: false }), 'UBN');
+    await user.type(screen.getByLabelText('Description', { exact: false }), 'Copied description');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(mockOnConfirm).toHaveBeenCalledWith('Unique Board Name', 'Copied description', 'UBN');
+  });
+
+  it('clears error once user modifies the name', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <CopyMenuBoardModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onConfirm={mockOnConfirm}
+        menuBoard={null}
+        existingNames={existingNames}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    expect(screen.getByText('Name is required')).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText('Name'), 'X');
+    expect(screen.queryByText('Name is required')).not.toBeInTheDocument();
+  });
+
+  it('shows loading state and disables buttons when isLoading is true', () => {
+    renderWithProviders(
+      <CopyMenuBoardModal
+        isOpen={true}
+        onClose={mockOnClose}
+        onConfirm={mockOnConfirm}
+        menuBoard={null}
+        existingNames={existingNames}
+        isLoading={true}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Saving…' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+  });
+});

--- a/frontend/src/pages/Library/MenuBoard/__tests__/DeleteMenuBoardModal.test.tsx
+++ b/frontend/src/pages/Library/MenuBoard/__tests__/DeleteMenuBoardModal.test.tsx
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import DeleteMenuBoardModal from '../components/DeleteMenuBoardModal';
+
+import { renderWithProviders } from './MenuBoardSetup';
+
+vi.mock('@/components/ui/modals/Modal');
+
+describe('DeleteMenuBoardModal', () => {
+  const mockOnClose = vi.fn();
+  const mockOnDelete = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Scenario 26 — single board deletion message
+  it('shows single-board confirmation message with board name', () => {
+    renderWithProviders(
+      <DeleteMenuBoardModal
+        onClose={mockOnClose}
+        onDelete={mockOnDelete}
+        itemCount={1}
+        menuBoardName="Summer Menu"
+      />,
+    );
+
+    expect(screen.getByText('Delete Menu Board?')).toBeInTheDocument();
+    expect(screen.getByText('Summer Menu')).toBeInTheDocument();
+  });
+
+  // Scenario 27 — bulk delete confirmation
+  it('shows plural confirmation message with count when deleting multiple boards', () => {
+    renderWithProviders(
+      <DeleteMenuBoardModal
+        onClose={mockOnClose}
+        onDelete={mockOnDelete}
+        itemCount={3}
+      />,
+    );
+
+    expect(screen.getByText('Delete Menu Boards?')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  it('calls onDelete when "Yes, Delete" is clicked', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <DeleteMenuBoardModal
+        onClose={mockOnClose}
+        onDelete={mockOnDelete}
+        itemCount={1}
+        menuBoardName="Board X"
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Yes, Delete' }));
+
+    expect(mockOnDelete).toHaveBeenCalled();
+    expect(mockOnClose).not.toHaveBeenCalled();
+  });
+
+  it('calls onClose when Cancel is clicked', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <DeleteMenuBoardModal
+        onClose={mockOnClose}
+        onDelete={mockOnDelete}
+        itemCount={1}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(mockOnClose).toHaveBeenCalled();
+    expect(mockOnDelete).not.toHaveBeenCalled();
+  });
+
+  it('displays the error message when error prop is provided', () => {
+    renderWithProviders(
+      <DeleteMenuBoardModal
+        onClose={mockOnClose}
+        onDelete={mockOnDelete}
+        itemCount={1}
+        error="Could not delete: board is in use"
+      />,
+    );
+
+    expect(screen.getByText('Could not delete: board is in use')).toBeInTheDocument();
+  });
+
+  it('shows "Deleting…" label and disables button while loading', () => {
+    renderWithProviders(
+      <DeleteMenuBoardModal
+        onClose={mockOnClose}
+        onDelete={mockOnDelete}
+        itemCount={1}
+        isLoading={true}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Deleting…' })).toBeDisabled();
+  });
+
+  it('does not render when isOpen is false', () => {
+    renderWithProviders(
+      <DeleteMenuBoardModal
+        isOpen={false}
+        onClose={mockOnClose}
+        onDelete={mockOnDelete}
+        itemCount={1}
+        menuBoardName="Hidden Board"
+      />,
+    );
+
+    expect(screen.queryByText('Delete Menu Board?')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Library/MenuBoard/__tests__/MenuBoardSetup.tsx
+++ b/frontend/src/pages/Library/MenuBoard/__tests__/MenuBoardSetup.tsx
@@ -85,7 +85,7 @@ export const mockMenuBoardCategory = (overrides = {}): MenuBoardCategory =>
     name: 'Test Category',
     description: 'A test category description',
     code: 'CAT_01',
-    mediaId: null,
+    mediaId: undefined,
     ...overrides,
   }) as MenuBoardCategory;
 
@@ -102,7 +102,7 @@ export const mockMenuBoardProduct = (overrides = {}): MenuBoardProduct =>
     availability: 1,
     allergyInfo: '',
     calories: 200,
-    mediaId: null,
+    mediaId: undefined,
     productOptions: [],
     ...overrides,
   }) as MenuBoardProduct;

--- a/frontend/src/pages/Library/MenuBoard/__tests__/MenuBoardSetup.tsx
+++ b/frontend/src/pages/Library/MenuBoard/__tests__/MenuBoardSetup.tsx
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+
+import type { MenuBoard } from '@/types/menuBoard';
+import type { MenuBoardCategory } from '@/types/menuBoardCategory';
+import type { MenuBoardProduct } from '@/types/menuBoardProduct';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (str: string) => str,
+    i18n: { changeLanguage: () => new Promise(() => {}) },
+  }),
+}));
+
+vi.mock('@/components/ui/Notification', () => ({
+  notify: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+export function renderWithProviders(ui: ReactElement, { route = '/' } = {}) {
+  const testQueryClient = createTestQueryClient();
+
+  return render(
+    <QueryClientProvider client={testQueryClient}>
+      <MemoryRouter initialEntries={[route]}>{ui}</MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+export const mockMenuBoard = (overrides = {}): MenuBoard =>
+  ({
+    menuId: 1,
+    name: 'Test Menu Board',
+    description: 'A test description',
+    code: 'TMB_01',
+    userId: 10,
+    owner: 'testuser',
+    modifiedDt: 1700000000,
+    folderId: 1,
+    permissionsFolderId: 1,
+    groupsWithPermissions: '',
+    ...overrides,
+  }) as MenuBoard;
+
+export const mockMenuBoardCategory = (overrides = {}): MenuBoardCategory =>
+  ({
+    menuCategoryId: 1,
+    menuId: 1,
+    name: 'Test Category',
+    description: 'A test category description',
+    code: 'CAT_01',
+    mediaId: null,
+    ...overrides,
+  }) as MenuBoardCategory;
+
+export const mockMenuBoardProduct = (overrides = {}): MenuBoardProduct =>
+  ({
+    menuProductId: 1,
+    menuCategoryId: 1,
+    menuId: 1,
+    name: 'Test Product',
+    price: 9.99,
+    description: 'A test product',
+    code: 'PROD_01',
+    displayOrder: 1,
+    availability: 1,
+    allergyInfo: '',
+    calories: 200,
+    mediaId: null,
+    productOptions: [],
+    ...overrides,
+  }) as MenuBoardProduct;

--- a/frontend/src/pages/Library/MenuBoard/__tests__/useMenuBoardActions.test.tsx
+++ b/frontend/src/pages/Library/MenuBoard/__tests__/useMenuBoardActions.test.tsx
@@ -1,0 +1,264 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import type { TFunction } from 'i18next';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { useMenuBoardActions } from '../hooks/useMenuBoardActions';
+
+import { mockMenuBoard } from './MenuBoardSetup';
+
+const mockDeleteMenuBoard = vi.fn();
+const mockCopyMenuBoard = vi.fn();
+
+vi.mock('@/services/menuBoardApi', () => ({
+  deleteMenuBoard: (...args: unknown[]) => mockDeleteMenuBoard(...args),
+  copyMenuBoard: (...args: unknown[]) => mockCopyMenuBoard(...args),
+}));
+
+const mockSelectFolder = vi.fn();
+vi.mock('@/services/folderApi', () => ({
+  selectFolder: (...args: unknown[]) => mockSelectFolder(...args),
+}));
+
+const mockNotifySuccess = vi.fn();
+const mockNotifyError = vi.fn();
+const mockNotifyInfo = vi.fn();
+const mockNotifyWarning = vi.fn();
+vi.mock('@/components/ui/Notification', () => ({
+  notify: {
+    success: (...args: unknown[]) => mockNotifySuccess(...args),
+    error: (...args: unknown[]) => mockNotifyError(...args),
+    info: (...args: unknown[]) => mockNotifyInfo(...args),
+    warning: (...args: unknown[]) => mockNotifyWarning(...args),
+  },
+}));
+
+describe('useMenuBoardActions', () => {
+  const mockT = ((str: string) => str) as unknown as TFunction;
+  const mockHandleRefresh = vi.fn();
+  const mockCloseModal = vi.fn();
+  const mockSetRowSelection = vi.fn();
+  const mockSetItemsToMove = vi.fn();
+
+  const renderActions = () =>
+    renderHook(() =>
+      useMenuBoardActions({
+        t: mockT,
+        handleRefresh: mockHandleRefresh,
+        closeModal: mockCloseModal,
+        setRowSelection: mockSetRowSelection,
+        setItemsToMove: mockSetItemsToMove,
+      }),
+    );
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('initializes with default states', () => {
+    const { result } = renderActions();
+
+    expect(result.current.isDeleting).toBe(false);
+    expect(result.current.isCloning).toBe(false);
+    expect(result.current.deleteError).toBeNull();
+  });
+
+  // Scenarios 26, 30 — successful delete
+  describe('confirmDelete', () => {
+    it('deletes all selected boards and triggers callbacks', async () => {
+      mockDeleteMenuBoard.mockResolvedValue({});
+      const { result } = renderActions();
+
+      const items = [mockMenuBoard({ menuId: 1 }), mockMenuBoard({ menuId: 2 })];
+
+      await act(async () => {
+        await result.current.confirmDelete(items);
+      });
+
+      expect(mockDeleteMenuBoard).toHaveBeenCalledTimes(2);
+      expect(mockDeleteMenuBoard).toHaveBeenCalledWith(1);
+      expect(mockDeleteMenuBoard).toHaveBeenCalledWith(2);
+      expect(mockSetRowSelection).toHaveBeenCalledWith({});
+      expect(mockHandleRefresh).toHaveBeenCalled();
+      expect(mockCloseModal).toHaveBeenCalled();
+      expect(result.current.isDeleting).toBe(false);
+    });
+
+    it('sets deleteError and does not close modal when a deletion fails', async () => {
+      mockDeleteMenuBoard
+        .mockResolvedValueOnce({})
+        .mockRejectedValueOnce(new Error('Network Error'));
+      const { result } = renderActions();
+
+      await act(async () => {
+        await result.current.confirmDelete([
+          mockMenuBoard({ menuId: 1 }),
+          mockMenuBoard({ menuId: 2 }),
+        ]);
+      });
+
+      expect(result.current.deleteError).toBeTruthy();
+      expect(mockHandleRefresh).toHaveBeenCalled();
+      expect(mockCloseModal).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when itemsToDelete is empty', async () => {
+      const { result } = renderActions();
+
+      await act(async () => {
+        await result.current.confirmDelete([]);
+      });
+
+      expect(mockDeleteMenuBoard).not.toHaveBeenCalled();
+    });
+
+    it('exposes setDeleteError to clear the error externally', () => {
+      const { result } = renderActions();
+
+      act(() => {
+        result.current.setDeleteError('some error');
+      });
+
+      expect(result.current.deleteError).toBe('some error');
+
+      act(() => {
+        result.current.setDeleteError(null);
+      });
+
+      expect(result.current.deleteError).toBeNull();
+    });
+  });
+
+  // Scenario 141 — copy via handleConfirmClone
+  describe('handleConfirmClone', () => {
+    it('calls copyMenuBoard and shows success notification', async () => {
+      mockCopyMenuBoard.mockResolvedValue(mockMenuBoard({ menuId: 99, name: 'Copy' }));
+      const { result } = renderActions();
+
+      await act(async () => {
+        await result.current.handleConfirmClone(
+          mockMenuBoard({ menuId: 5 }),
+          'Copy',
+          'desc',
+          'CP',
+        );
+      });
+
+      expect(mockCopyMenuBoard).toHaveBeenCalledWith({
+        menuBoardId: 5,
+        name: 'Copy',
+        description: 'desc',
+        code: 'CP',
+      });
+      expect(mockNotifySuccess).toHaveBeenCalledWith('Menu Board copied successfully');
+      expect(mockHandleRefresh).toHaveBeenCalled();
+      expect(mockCloseModal).toHaveBeenCalled();
+      expect(result.current.isCloning).toBe(false);
+    });
+
+    it('shows error notification when copy fails', async () => {
+      mockCopyMenuBoard.mockRejectedValue(new Error('Network Error'));
+      const { result } = renderActions();
+
+      await act(async () => {
+        await result.current.handleConfirmClone(mockMenuBoard({ menuId: 5 }), 'Copy', '', '');
+      });
+
+      expect(mockNotifyError).toHaveBeenCalledWith('Failed to copy Menu Board');
+      expect(mockNotifySuccess).not.toHaveBeenCalled();
+      expect(mockCloseModal).not.toHaveBeenCalled();
+      expect(result.current.isCloning).toBe(false);
+    });
+
+    it('does nothing when selectedMenuBoard is null', async () => {
+      const { result } = renderActions();
+
+      await act(async () => {
+        await result.current.handleConfirmClone(null, 'Copy', '', '');
+      });
+
+      expect(mockCopyMenuBoard).not.toHaveBeenCalled();
+    });
+  });
+
+  // Scenario 31 — move to folder
+  describe('handleConfirmMove', () => {
+    it('moves all boards and shows info notification on full success', async () => {
+      mockSelectFolder.mockResolvedValue({ success: true });
+      const { result } = renderActions();
+
+      const items = [mockMenuBoard({ menuId: 1 }), mockMenuBoard({ menuId: 2 })];
+
+      await act(async () => {
+        await result.current.handleConfirmMove(items, 10);
+      });
+
+      expect(mockSelectFolder).toHaveBeenCalledTimes(2);
+      expect(mockSelectFolder).toHaveBeenCalledWith({
+        folderId: 10,
+        targetId: 1,
+        targetType: 'menuboard',
+      });
+      expect(mockNotifyInfo).toHaveBeenCalled();
+      expect(mockHandleRefresh).toHaveBeenCalled();
+      expect(mockCloseModal).toHaveBeenCalled();
+    });
+
+    it('shows error notification when all moves fail', async () => {
+      mockSelectFolder.mockResolvedValue({ success: false });
+      const { result } = renderActions();
+
+      await act(async () => {
+        await result.current.handleConfirmMove([mockMenuBoard({ menuId: 1 })], 10);
+      });
+
+      expect(mockNotifyError).toHaveBeenCalledWith('Failed to move items.');
+    });
+
+    it('shows warning notification when some moves fail', async () => {
+      mockSelectFolder
+        .mockResolvedValueOnce({ success: true })
+        .mockResolvedValueOnce({ success: false });
+      const { result } = renderActions();
+
+      await act(async () => {
+        await result.current.handleConfirmMove(
+          [mockMenuBoard({ menuId: 1 }), mockMenuBoard({ menuId: 2 })],
+          10,
+        );
+      });
+
+      expect(mockNotifyWarning).toHaveBeenCalled();
+    });
+
+    it('does nothing when itemsToMove is empty', async () => {
+      const { result } = renderActions();
+
+      await act(async () => {
+        await result.current.handleConfirmMove([], 10);
+      });
+
+      expect(mockSelectFolder).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/pages/Library/MenuBoard/subPages/Categories/__tests__/AddAndEditMenuBoardCategoryModal.test.tsx
+++ b/frontend/src/pages/Library/MenuBoard/subPages/Categories/__tests__/AddAndEditMenuBoardCategoryModal.test.tsx
@@ -1,0 +1,224 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import AddAndEditMenuBoardCategoryModal from '../components/AddAndEditMenuBoardCategoryModal';
+
+import {
+  renderWithProviders,
+  mockMenuBoardCategory,
+} from '../../../__tests__/MenuBoardSetup';
+
+// -- Module mocks --
+
+const mockCreateMenuBoardCategory = vi.fn();
+const mockUpdateMenuBoardCategory = vi.fn();
+
+vi.mock('@/services/menuBoardApi', () => ({
+  createMenuBoardCategory: (...args: unknown[]) => mockCreateMenuBoardCategory(...args),
+  updateMenuBoardCategory: (...args: unknown[]) => mockUpdateMenuBoardCategory(...args),
+}));
+
+vi.mock('@/components/ui/forms/MediaInput', () => ({
+  default: ({ label }: { label: string }) => <div>{label}</div>,
+}));
+
+vi.mock('@/components/ui/modals/Modal');
+
+// -- Helpers --
+
+function renderAddModal(menuId: number | string = 1) {
+  const mockOnClose = vi.fn();
+  const mockOnSave = vi.fn();
+  renderWithProviders(
+    <AddAndEditMenuBoardCategoryModal
+      type="add"
+      menuId={menuId}
+      onClose={mockOnClose}
+      onSave={mockOnSave}
+    />,
+  );
+  return { mockOnClose, mockOnSave };
+}
+
+function renderEditModal(overrides = {}) {
+  const mockOnClose = vi.fn();
+  const mockOnSave = vi.fn();
+  const category = mockMenuBoardCategory(overrides);
+  renderWithProviders(
+    <AddAndEditMenuBoardCategoryModal
+      type="edit"
+      menuId={category.menuId}
+      data={category}
+      onClose={mockOnClose}
+      onSave={mockOnSave}
+    />,
+  );
+  return { mockOnClose, mockOnSave, category };
+}
+
+// -- Tests --
+
+describe('AddAndEditMenuBoardCategoryModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Scenarios 34, 35 — add with valid data
+  describe('Add mode', () => {
+    it('renders "Add Category" title with empty name and code fields', () => {
+      renderAddModal();
+
+      expect(screen.getByRole('dialog', { name: 'Add Category' })).toBeInTheDocument();
+      expect(screen.getByLabelText('Name')).toHaveValue('');
+      expect(screen.getByLabelText('Code', { exact: false })).toHaveValue('');
+      expect(screen.getByLabelText('Description', { exact: false })).toHaveValue('');
+    });
+
+    it('calls createMenuBoardCategory with all provided fields on save', async () => {
+      const user = userEvent.setup();
+      mockCreateMenuBoardCategory.mockResolvedValue(mockMenuBoardCategory());
+      const { mockOnSave } = renderAddModal(5);
+
+      await user.type(screen.getByLabelText('Name'), 'Starters');
+      await user.type(screen.getByLabelText('Code', { exact: false }), 'STR');
+      await user.type(screen.getByLabelText('Description', { exact: false }), 'Starter dishes');
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      await waitFor(() => {
+        expect(mockCreateMenuBoardCategory).toHaveBeenCalledWith(
+          5,
+          expect.objectContaining({
+            name: 'Starters',
+            code: 'STR',
+            description: 'Starter dishes',
+          }),
+        );
+        expect(mockOnSave).toHaveBeenCalled();
+      });
+    });
+
+    // Scenario 36 — empty name
+    it('shows validation error when name is empty on save', async () => {
+      const user = userEvent.setup();
+      renderAddModal();
+
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      expect(screen.getByText('Name is required')).toBeInTheDocument();
+      expect(mockCreateMenuBoardCategory).not.toHaveBeenCalled();
+    });
+
+    it('shows validation error when name is only whitespace', async () => {
+      const user = userEvent.setup();
+      renderAddModal();
+
+      await user.type(screen.getByLabelText('Name'), '   ');
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      expect(screen.getByText('Name is required')).toBeInTheDocument();
+      expect(mockCreateMenuBoardCategory).not.toHaveBeenCalled();
+    });
+
+    it('clears name error when user types a valid name', async () => {
+      const user = userEvent.setup();
+      renderAddModal();
+
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+      expect(screen.getByText('Name is required')).toBeInTheDocument();
+
+      await user.type(screen.getByLabelText('Name'), 'M');
+      expect(screen.queryByText('Name is required')).not.toBeInTheDocument();
+    });
+
+    it('displays API error message when createMenuBoardCategory rejects', async () => {
+      const user = userEvent.setup();
+      mockCreateMenuBoardCategory.mockRejectedValue({
+        response: { data: { message: 'Permission denied' } },
+      });
+      renderAddModal();
+
+      await user.type(screen.getByLabelText('Name'), 'New Category');
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Permission denied')).toBeInTheDocument();
+      });
+    });
+  });
+
+  // Scenarios 43, 44 — edit mode
+  describe('Edit mode', () => {
+    it('renders "Edit Category" title and pre-populates fields', () => {
+      renderEditModal({ name: 'Mains', description: 'Main dishes', code: 'MN' });
+
+      expect(screen.getByRole('dialog', { name: 'Edit Category' })).toBeInTheDocument();
+      expect(screen.getByLabelText('Name')).toHaveValue('Mains');
+      expect(screen.getByLabelText('Code', { exact: false })).toHaveValue('MN');
+      expect(screen.getByLabelText('Description', { exact: false })).toHaveValue('Main dishes');
+    });
+
+    it('calls updateMenuBoardCategory with changed name on save', async () => {
+      const user = userEvent.setup();
+      mockUpdateMenuBoardCategory.mockResolvedValue(mockMenuBoardCategory({ name: 'Desserts' }));
+      const { mockOnSave, category } = renderEditModal({ name: 'Old Name' });
+
+      await user.clear(screen.getByLabelText('Name'));
+      await user.type(screen.getByLabelText('Name'), 'Desserts');
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      await waitFor(() => {
+        expect(mockUpdateMenuBoardCategory).toHaveBeenCalledWith(
+          category.menuCategoryId,
+          expect.objectContaining({ name: 'Desserts' }),
+        );
+        expect(mockOnSave).toHaveBeenCalled();
+      });
+    });
+
+    // Scenario 45 — view-only user gets 403 at the API level; the modal shows the error
+    it('shows validation error when name is cleared during edit', async () => {
+      const user = userEvent.setup();
+      renderEditModal({ name: 'Drinks' });
+
+      await user.clear(screen.getByLabelText('Name'));
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      expect(screen.getByText('Name is required')).toBeInTheDocument();
+      expect(mockUpdateMenuBoardCategory).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Cancel button', () => {
+    it('calls onClose without calling the API', async () => {
+      const user = userEvent.setup();
+      const { mockOnClose } = renderAddModal();
+
+      await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      expect(mockOnClose).toHaveBeenCalled();
+      expect(mockCreateMenuBoardCategory).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/pages/Library/MenuBoard/subPages/Products/__tests__/AddAndEditMenuBoardProductModal.test.tsx
+++ b/frontend/src/pages/Library/MenuBoard/subPages/Products/__tests__/AddAndEditMenuBoardProductModal.test.tsx
@@ -326,8 +326,8 @@ describe('AddAndEditMenuBoardProductModal', () => {
       const [optionNameInput] = screen.getAllByPlaceholderText('Option Name');
       const [optionValueInput] = screen.getAllByPlaceholderText('Option Value');
 
-      await user.type(optionNameInput, 'Size');
-      await user.type(optionValueInput, '12');
+      await user.type(optionNameInput!, 'Size');
+      await user.type(optionValueInput!, '12');
 
       await user.click(screen.getByRole('button', { name: 'Save' }));
 

--- a/frontend/src/pages/Library/MenuBoard/subPages/Products/__tests__/AddAndEditMenuBoardProductModal.test.tsx
+++ b/frontend/src/pages/Library/MenuBoard/subPages/Products/__tests__/AddAndEditMenuBoardProductModal.test.tsx
@@ -1,0 +1,470 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import AddAndEditMenuBoardProductModal from '../components/AddAndEditMenuBoardProductModal';
+
+import {
+  renderWithProviders,
+  mockMenuBoardProduct,
+} from '../../../__tests__/MenuBoardSetup';
+
+// -- Module mocks --
+
+const mockCreateMenuBoardProduct = vi.fn();
+const mockUpdateMenuBoardProduct = vi.fn();
+
+vi.mock('@/services/menuBoardApi', () => ({
+  createMenuBoardProduct: (...args: unknown[]) => mockCreateMenuBoardProduct(...args),
+  updateMenuBoardProduct: (...args: unknown[]) => mockUpdateMenuBoardProduct(...args),
+}));
+
+vi.mock('@/components/ui/forms/MediaInput', () => ({
+  default: ({ label }: { label: string }) => <div>{label}</div>,
+}));
+
+vi.mock('@/components/ui/modals/Modal');
+
+// -- Helpers --
+
+function renderAddModal(menuCategoryId: number | string = 1) {
+  const mockOnClose = vi.fn();
+  const mockOnSave = vi.fn();
+  renderWithProviders(
+    <AddAndEditMenuBoardProductModal
+      type="add"
+      menuCategoryId={menuCategoryId}
+      onClose={mockOnClose}
+      onSave={mockOnSave}
+    />,
+  );
+  return { mockOnClose, mockOnSave };
+}
+
+function renderEditModal(overrides = {}) {
+  const mockOnClose = vi.fn();
+  const mockOnSave = vi.fn();
+  const product = mockMenuBoardProduct(overrides);
+  renderWithProviders(
+    <AddAndEditMenuBoardProductModal
+      type="edit"
+      menuCategoryId={product.menuCategoryId}
+      data={product}
+      onClose={mockOnClose}
+      onSave={mockOnSave}
+    />,
+  );
+  return { mockOnClose, mockOnSave, product };
+}
+
+// -- Tests --
+
+describe('AddAndEditMenuBoardProductModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Scenarios 49, 58, 59 — add with valid data
+  describe('Add mode — General tab', () => {
+    it('renders "Add Product" title with three navigation tabs', () => {
+      renderAddModal();
+
+      expect(screen.getByRole('dialog', { name: 'Add Product' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'General' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Details' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Product Options' })).toBeInTheDocument();
+    });
+
+    it('renders General tab fields with default empty values', () => {
+      renderAddModal();
+
+      expect(screen.getByLabelText('Name')).toHaveValue('');
+      expect(screen.getByLabelText('Code')).toHaveValue('');
+    });
+
+    // Scenario 50 — empty name
+    it('shows validation error when name is empty on save', async () => {
+      const user = userEvent.setup();
+      renderAddModal();
+
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      expect(screen.getByText('Name is required')).toBeInTheDocument();
+      expect(mockCreateMenuBoardProduct).not.toHaveBeenCalled();
+    });
+
+    it('auto-switches to General tab when a name validation error occurs on Details tab', async () => {
+      const user = userEvent.setup();
+      renderAddModal();
+
+      // Switch to Details tab without filling name
+      await user.click(screen.getByRole('button', { name: 'Details' }));
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      // Should switch back to General and show error
+      await waitFor(() => {
+        expect(screen.getByText('Name is required')).toBeInTheDocument();
+        expect(screen.getByLabelText('Name')).toBeInTheDocument();
+      });
+    });
+
+    it('calls createMenuBoardProduct with all scalar fields on save', async () => {
+      const user = userEvent.setup();
+      mockCreateMenuBoardProduct.mockResolvedValue(mockMenuBoardProduct());
+      const { mockOnSave } = renderAddModal(3);
+
+      await user.type(screen.getByLabelText('Name'), 'Burger');
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      await waitFor(() => {
+        expect(mockCreateMenuBoardProduct).toHaveBeenCalledWith(
+          3,
+          expect.objectContaining({ name: 'Burger' }),
+        );
+        expect(mockOnSave).toHaveBeenCalled();
+      });
+    });
+
+    it('sends availability=1 when switch is on (default)', async () => {
+      const user = userEvent.setup();
+      mockCreateMenuBoardProduct.mockResolvedValue(mockMenuBoardProduct());
+      renderAddModal();
+
+      await user.type(screen.getByLabelText('Name'), 'Product A');
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      await waitFor(() => {
+        expect(mockCreateMenuBoardProduct).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({ availability: 1 }),
+        );
+      });
+    });
+
+    // Scenario 59 — availability=0
+    it('sends availability=0 when Availability switch is toggled off', async () => {
+      const user = userEvent.setup();
+      mockCreateMenuBoardProduct.mockResolvedValue(mockMenuBoardProduct());
+      renderAddModal();
+
+      await user.type(screen.getByLabelText('Name'), 'Product B');
+      // Toggle Availability off
+      const availabilitySwitch = screen.getByRole('switch', { name: /Availability/i });
+      await user.click(availabilitySwitch);
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      await waitFor(() => {
+        expect(mockCreateMenuBoardProduct).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({ availability: 0 }),
+        );
+      });
+    });
+
+    it('displays API error message when createMenuBoardProduct rejects', async () => {
+      const user = userEvent.setup();
+      mockCreateMenuBoardProduct.mockRejectedValue({
+        response: { data: { message: 'Category not found' } },
+      });
+      renderAddModal();
+
+      await user.type(screen.getByLabelText('Name'), 'X');
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Category not found')).toBeInTheDocument();
+      });
+    });
+  });
+
+  // Scenarios 77, 78, 79, 80 — edit mode
+  describe('Edit mode', () => {
+    it('renders "Edit Product" title and pre-populates General tab fields', () => {
+      renderEditModal({
+        name: 'Fries',
+        price: 3.5,
+        code: 'FRS',
+        displayOrder: 2,
+        availability: 1,
+      });
+
+      expect(screen.getByRole('dialog', { name: 'Edit Product' })).toBeInTheDocument();
+      expect(screen.getByLabelText('Name')).toHaveValue('Fries');
+      expect(screen.getByLabelText('Code')).toHaveValue('FRS');
+    });
+
+    it('calls updateMenuBoardProduct with changed fields on save', async () => {
+      const user = userEvent.setup();
+      mockUpdateMenuBoardProduct.mockResolvedValue(mockMenuBoardProduct({ name: 'Large Fries' }));
+      const { product } = renderEditModal({ name: 'Fries' });
+
+      await user.clear(screen.getByLabelText('Name'));
+      await user.type(screen.getByLabelText('Name'), 'Large Fries');
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      await waitFor(() => {
+        expect(mockUpdateMenuBoardProduct).toHaveBeenCalledWith(
+          product.menuProductId,
+          expect.objectContaining({ name: 'Large Fries' }),
+        );
+      });
+    });
+
+    // Scenario 78 — toggle availability
+    it('sends availability=0 when toggled off during edit', async () => {
+      const user = userEvent.setup();
+      mockUpdateMenuBoardProduct.mockResolvedValue(mockMenuBoardProduct());
+      renderEditModal({ name: 'Pizza', availability: 1 });
+
+      const availabilitySwitch = screen.getByRole('switch', { name: /Availability/i });
+      await user.click(availabilitySwitch);
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      await waitFor(() => {
+        expect(mockUpdateMenuBoardProduct).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.objectContaining({ availability: 0 }),
+        );
+      });
+    });
+
+    // Scenario 80 — empty name on edit
+    it('shows validation error when name is cleared on edit', async () => {
+      const user = userEvent.setup();
+      renderEditModal({ name: 'Salad' });
+
+      await user.clear(screen.getByLabelText('Name'));
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      expect(screen.getByText('Name is required')).toBeInTheDocument();
+      expect(mockUpdateMenuBoardProduct).not.toHaveBeenCalled();
+    });
+  });
+
+  // Scenarios 61-68 — Product Options tab
+  describe('Product Options tab', () => {
+    it('starts with no options rows and a single "+" button', async () => {
+      const user = userEvent.setup();
+      renderAddModal();
+
+      await user.click(screen.getByRole('button', { name: 'Product Options' }));
+
+      const optionsTab = screen.getByRole('dialog');
+      const inputs = within(optionsTab).queryAllByPlaceholderText('Option Name');
+      expect(inputs).toHaveLength(0);
+    });
+
+    // Scenario 61 — add an option row
+    it('adds a new option row when the "+" button is clicked', async () => {
+      const user = userEvent.setup();
+      renderAddModal();
+
+      await user.click(screen.getByRole('button', { name: 'Product Options' }));
+      await user.click(screen.getByRole('button', { name: '' })); // Plus button (icon only)
+
+      expect(screen.getAllByPlaceholderText('Option Name')).toHaveLength(1);
+      expect(screen.getAllByPlaceholderText('Option Value')).toHaveLength(1);
+    });
+
+    it('removes an option row when the "−" button is clicked', async () => {
+      const user = userEvent.setup();
+      renderAddModal();
+
+      await user.click(screen.getByRole('button', { name: 'Product Options' }));
+      // Add one row
+      const addBtn = screen.getAllByRole('button').find(
+        (b) => !b.textContent?.trim() && !b.getAttribute('aria-label'),
+      );
+      await user.click(addBtn!);
+      expect(screen.getAllByPlaceholderText('Option Name')).toHaveLength(1);
+
+      // Remove it
+      const removeBtn = screen.getAllByRole('button').find(
+        (b) => !b.textContent?.trim() && !b.getAttribute('aria-label') && b !== addBtn,
+      );
+      if (removeBtn) {
+        await user.click(removeBtn);
+      }
+
+      expect(screen.queryAllByPlaceholderText('Option Name')).toHaveLength(0);
+    });
+
+    // Scenario 65 — options serialized correctly in payload
+    it('includes productOptions in payload when filled in', async () => {
+      const user = userEvent.setup();
+      mockCreateMenuBoardProduct.mockResolvedValue(mockMenuBoardProduct());
+      renderAddModal(1);
+
+      // Fill name on General tab
+      await user.type(screen.getByLabelText('Name'), 'Steak');
+
+      // Switch to Options tab and add one row
+      await user.click(screen.getByRole('button', { name: 'Product Options' }));
+      await user.click(screen.getByRole('button', { name: '' })); // Plus icon button
+
+      const [optionNameInput] = screen.getAllByPlaceholderText('Option Name');
+      const [optionValueInput] = screen.getAllByPlaceholderText('Option Value');
+
+      await user.type(optionNameInput, 'Size');
+      await user.type(optionValueInput, '12');
+
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      await waitFor(() => {
+        expect(mockCreateMenuBoardProduct).toHaveBeenCalledWith(
+          1,
+          expect.objectContaining({
+            productOptions: [{ option: 'Size', value: '12' }],
+          }),
+        );
+      });
+    });
+
+    // Scenario 67 — pre-existing options loaded in edit mode
+    it('pre-populates existing product options in edit mode', async () => {
+      const user = userEvent.setup();
+      const product = mockMenuBoardProduct({
+        name: 'Loaded Burger',
+        productOptions: [
+          { menuProductId: 1, option: 'Cheese', value: '1.00' },
+          { menuProductId: 1, option: 'Bacon', value: '1.50' },
+        ],
+      });
+      renderWithProviders(
+        <AddAndEditMenuBoardProductModal
+          type="edit"
+          menuCategoryId={1}
+          data={product}
+          onClose={vi.fn()}
+          onSave={vi.fn()}
+        />,
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Product Options' }));
+
+      const optionNames = screen.getAllByPlaceholderText('Option Name');
+      expect(optionNames).toHaveLength(2);
+      expect(optionNames[0]).toHaveValue('Cheese');
+      expect(optionNames[1]).toHaveValue('Bacon');
+    });
+
+    // Scenario 66 — updating removes old options and sends only new ones
+    it('sends empty productOptions array when all options are removed', async () => {
+      const user = userEvent.setup();
+      mockUpdateMenuBoardProduct.mockResolvedValue(mockMenuBoardProduct());
+      const product = mockMenuBoardProduct({
+        name: 'Wrap',
+        productOptions: [{ menuProductId: 1, option: 'Hot Sauce', value: '0.50' }],
+      });
+      renderWithProviders(
+        <AddAndEditMenuBoardProductModal
+          type="edit"
+          menuCategoryId={1}
+          data={product}
+          onClose={vi.fn()}
+          onSave={vi.fn()}
+        />,
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Product Options' }));
+
+      // Remove the single row using any remove button inside options area
+      const minusButtons = screen.getAllByRole('button');
+      // The minus button has no text content — find it by process of elimination
+      const removeBtn = minusButtons.find((b) => {
+        const txt = b.textContent?.trim();
+        return !txt && b !== minusButtons[minusButtons.length - 1];
+      });
+      if (removeBtn) {
+        await user.click(removeBtn);
+      }
+
+      // Switch back to General and save
+      await user.click(screen.getByRole('button', { name: 'General' }));
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      await waitFor(() => {
+        expect(mockUpdateMenuBoardProduct).toHaveBeenCalledWith(
+          product.menuProductId,
+          expect.objectContaining({ productOptions: [] }),
+        );
+      });
+    });
+  });
+
+  // Details tab — scenario 77 (description, allergyInfo, calories)
+  describe('Details tab', () => {
+    it('pre-populates description, allergyInfo, and calories in edit mode', async () => {
+      const user = userEvent.setup();
+      renderEditModal({
+        name: 'Soup',
+        description: 'Tomato soup',
+        allergyInfo: 'Contains celery',
+        calories: 150,
+      });
+
+      await user.click(screen.getByRole('button', { name: 'Details' }));
+
+      expect(screen.getByLabelText('Description')).toHaveValue('Tomato soup');
+      expect(screen.getByLabelText('Allergy Information')).toHaveValue('Contains celery');
+    });
+
+    it('sends description and allergyInfo in the payload', async () => {
+      const user = userEvent.setup();
+      mockCreateMenuBoardProduct.mockResolvedValue(mockMenuBoardProduct());
+      renderAddModal(2);
+
+      await user.type(screen.getByLabelText('Name'), 'Salad');
+
+      await user.click(screen.getByRole('button', { name: 'Details' }));
+      await user.type(screen.getByLabelText('Description'), 'Garden salad');
+      await user.type(screen.getByLabelText('Allergy Information'), 'Contains nuts');
+
+      await user.click(screen.getByRole('button', { name: 'General' }));
+      await user.click(screen.getByRole('button', { name: 'Save' }));
+
+      await waitFor(() => {
+        expect(mockCreateMenuBoardProduct).toHaveBeenCalledWith(
+          2,
+          expect.objectContaining({
+            description: 'Garden salad',
+            allergyInfo: 'Contains nuts',
+          }),
+        );
+      });
+    });
+  });
+
+  describe('Cancel button', () => {
+    it('calls onClose without calling the API', async () => {
+      const user = userEvent.setup();
+      const { mockOnClose } = renderAddModal();
+
+      await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      expect(mockOnClose).toHaveBeenCalled();
+      expect(mockCreateMenuBoardProduct).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
PLM ticket here: https://github.com/orgs/xibosignageltd/projects/22/views/14?filterQuery=assignee%3A%40me&pane=issue&itemId=185258906&issue=xibosignageltd%7Cxibo-private%7C1443

Test scenarios covered:
Menu Board CRUD
Menu Board Folder Management
Menu Board Categories CRUD
Menu Board Products CRUD
Menu Board Products Options
Menu Board Permission and Access Control
Menu Board Category and Menu Board Product Widget Integration; Active Status and Cache
Display Notifications
Data Integrity and Cascades
API response structure
w/ additional Edge cases