### PR TITLE
Lazy-load HLS.js and PDF.js vendor libraries per-module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ results.xml
 containers/
 web/dist
 modules/bundle*.js*
+modules/vendor-*.min.js*
 modules/assets/pdfjs
 
 # The OpenOOH specification

--- a/modules/hls.xml
+++ b/modules/hls.xml
@@ -122,4 +122,7 @@ video {
 }
         ]]></style>
     </stencil>
+    <assets>
+        <asset id="hlsLib" type="path" mimeType="text/javascript" isAutoInclude="true" path="/modules/vendor-hls.min.js"></asset>
+    </assets>
 </module>

--- a/modules/pdf.xml
+++ b/modules/pdf.xml
@@ -213,6 +213,7 @@ window.addEventListener('resize', function(event) {
 }, true);
     ]]></onInitialize>
     <assets>
+        <asset id="pdfjsLib" type="path" mimeType="text/javascript" isAutoInclude="true" path="/modules/vendor-pdfjs.min.js"></asset>
         <asset id="pdfWorkerSrc" type="path" mimeType="text/javascript" isAutoInclude="false" path="/modules/assets/pdfjs/pdf.worker.js"></asset>
     </assets>
 </module>

--- a/modules/src/player_bundle.js
+++ b/modules/src/player_bundle.js
@@ -52,11 +52,8 @@ require('moment-timezone');
 window.Handlebars = require('handlebars/dist/handlebars.min.js');
 require('./handlebars-helpers.js');
 
-// Include HLS.js
-window.Hls = require('hls.js');
-
-// Include PDFjs
-window.pdfjsLib = require('pdfjs-dist/es5/build/pdf.js');
+// HLS.js and PDFjs are shipped per-module via <assets> in hls.xml / pdf.xml,
+// so they only load on pages that actually need them.
 
 // Include common helpers/transformer
 window.transformer = require('../../ui/src/helpers/transformer.js');

--- a/modules/src/vendor-hls.js
+++ b/modules/src/vendor-hls.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+window.Hls = require('hls.js');

--- a/modules/src/vendor-pdfjs.js
+++ b/modules/src/vendor-pdfjs.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+window.pdfjsLib = require('pdfjs-dist/es5/build/pdf.js');

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -282,6 +282,8 @@ const moduleConfig = function(env) {
   return Object.assign({}, config, {
     entry: {
       bundle: './modules/src/player_bundle.js',
+      'vendor-hls': './modules/src/vendor-hls.js',
+      'vendor-pdfjs': './modules/src/vendor-pdfjs.js',
     },
     output: {
       path: path.resolve(__dirname, 'modules'),


### PR DESCRIPTION
## Summary

Refactor vendor library loading to lazy-load HLS.js and PDF.js only on modules that require them, rather than bundling them globally in the player bundle. This reduces the initial bundle size and improves load performance for displays that don't use HLS or PDF widgets.

## Changes

- **New vendor entry points**: Created `vendor-hls.js` and `vendor-pdfjs.js` as separate webpack entry points that expose `window.Hls` and `window.pdfjsLib` respectively
- **Updated webpack config**: Added `vendor-hls` and `vendor-pdfjs` entries to the module build configuration
- **Removed global includes**: Removed HLS.js and PDF.js requires from `player_bundle.js` with a comment explaining they now load per-module via `<assets>` declarations
- **Module asset declarations**: 
  - Added `hlsLib` asset to `hls.xml` pointing to `/modules/vendor-hls.min.js`
  - Added `pdfjsLib` asset to `pdf.xml` pointing to `/modules/vendor-pdfjs.min.js`
- **Build artifacts**: Updated `.gitignore` to exclude minified vendor files (`modules/vendor-*.min.js*`)

## Implementation Details

The vendor libraries are now conditionally loaded only when their respective modules are instantiated. Each module declares its vendor dependency via the `<assets>` section with `isAutoInclude="true"`, ensuring the library is available when needed without bloating the core player bundle.

https://claude.ai/code/session_01JEzQCz9p3KvpFPWnj1sQQb