### PR TITLE
Frontend: Fix silent save failures in modals due to Zod validation errors

### DIFF
--- a/frontend/src/pages/Design/Campaigns/components/AddCampaignModal.tsx
+++ b/frontend/src/pages/Design/Campaigns/components/AddCampaignModal.tsx
@@ -110,6 +110,7 @@ export default function AddCampaignModal({
         });
 
         setFormErrors(mappedErrors);
+        setApiError(t('Please fix the highlighted errors before saving.'));
         return;
       }
 

--- a/frontend/src/pages/Design/Layouts/components/EditLayout.tsx
+++ b/frontend/src/pages/Design/Layouts/components/EditLayout.tsx
@@ -106,7 +106,7 @@ export default function EditLayout({ isOpen = true, onClose, data, onSave }: Edi
         description: fieldErrors.description?.[0],
         code: fieldErrors.code?.[0],
       });
-
+      setApiError(t('Please fix the highlighted errors before saving.'));
       return;
     }
 

--- a/frontend/src/pages/Design/Layouts/components/SaveAsTemplateModal.tsx
+++ b/frontend/src/pages/Design/Layouts/components/SaveAsTemplateModal.tsx
@@ -87,7 +87,7 @@ export default function SaveAsTemplateModal({
       setFormErrors({
         name: fieldErrors.name?.[0],
       });
-
+      setApiError(t('Please fix the highlighted errors before saving.'));
       return;
     }
 

--- a/frontend/src/pages/Design/Resolutions/components/AddAndEditResolutionModal.tsx
+++ b/frontend/src/pages/Design/Resolutions/components/AddAndEditResolutionModal.tsx
@@ -72,8 +72,8 @@ export default function AddAndEditResolutionModal({
       return {
         ...DEFAULT_DRAFT,
         resolution: data.resolution,
-        width: data.width,
-        height: data.height,
+        width: Number(data.width),
+        height: Number(data.height),
         enabled: Boolean(data.enabled),
       };
     }
@@ -85,8 +85,8 @@ export default function AddAndEditResolutionModal({
       setDraft({
         ...DEFAULT_DRAFT,
         resolution: data.resolution,
-        width: data.width,
-        height: data.height,
+        width: Number(data.width),
+        height: Number(data.height),
         enabled: Boolean(data.enabled),
       });
     } else {

--- a/frontend/src/pages/Design/Templates/components/AddAndEditTemplate.tsx
+++ b/frontend/src/pages/Design/Templates/components/AddAndEditTemplate.tsx
@@ -142,7 +142,7 @@ export default function AddAndEditTemplateModal({
       const result = schema.safeParse(draft);
 
       if (!result.success) {
-        setApiError(undefined);
+        setApiError(t('Please fix the highlighted errors before saving.'));
         const fieldErrors = result.error.flatten().fieldErrors;
         const mappedErrors: TemplateFormErrors = {};
 

--- a/frontend/src/pages/Displays/DisplayGroup/components/AddAndEditDisplayGroupModal.tsx
+++ b/frontend/src/pages/Displays/DisplayGroup/components/AddAndEditDisplayGroupModal.tsx
@@ -169,7 +169,7 @@ export default function AddAndEditDisplayGroupModal({
       const result = schema.safeParse(draft);
 
       if (!result.success) {
-        setApiError(undefined);
+        setApiError(t('Please fix the highlighted errors before saving.'));
         const fieldErrors = result.error.flatten().fieldErrors;
         const mappedErrors: DisplayGroupFormErrors = {};
 

--- a/frontend/src/pages/Displays/DisplayProfile/components/AddDisplayProfileModal.tsx
+++ b/frontend/src/pages/Displays/DisplayProfile/components/AddDisplayProfileModal.tsx
@@ -76,7 +76,7 @@ export default function AddDisplayProfileModal({
       const result = schema.safeParse(draft);
 
       if (!result.success) {
-        setApiError(undefined);
+        setApiError(t('Please fix the highlighted errors before saving.'));
         const fieldErrors = result.error.flatten().fieldErrors;
         const mappedErrors: AddFormErrors = {};
         Object.entries(fieldErrors).forEach(([key, value]) => {

--- a/frontend/src/pages/Displays/DisplayProfile/components/EditDisplayProfileModal.tsx
+++ b/frontend/src/pages/Displays/DisplayProfile/components/EditDisplayProfileModal.tsx
@@ -340,7 +340,7 @@ export default function EditDisplayProfileModal({
       const result = schema.safeParse({ name: draft.name, isDefault: draft.isDefault });
 
       if (!result.success) {
-        setApiError(undefined);
+        setApiError(t('Please fix the highlighted errors before saving.'));
         setNameError(result.error.flatten().fieldErrors.name?.[0]);
         return;
       }

--- a/frontend/src/pages/Displays/Displays/components/EditDisplayModal.tsx
+++ b/frontend/src/pages/Displays/Displays/components/EditDisplayModal.tsx
@@ -429,7 +429,7 @@ export default function EditDisplayModal({
   ];
   const [activeTab, setActiveTab] = useState<ActiveTab>('general');
   const [apiError, setApiError] = useState<string | undefined>();
-  const [nameError, setNameError] = useState<string | undefined>();
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string | undefined>>({});
 
   const [draft, setDraft] = useState<EditDraft>({
     display: '',
@@ -509,7 +509,7 @@ export default function EditDisplayModal({
 
     setActiveTab('general');
     setApiError(undefined);
-    setNameError(undefined);
+    setFieldErrors({});
     setActiveProfile(null);
     setProfileFlat({});
     setProfileDefaults({});
@@ -524,8 +524,8 @@ export default function EditDisplayModal({
       tags: data.tags ?? [],
       licensed: data.licensed ?? 0,
       defaultLayoutId: data.defaultLayoutId ?? null,
-      latitude: data.latitude ?? null,
-      longitude: data.longitude ?? null,
+      latitude: data.latitude != null ? Number(data.latitude) : null,
+      longitude: data.longitude != null ? Number(data.longitude) : null,
       timeZone: data.timeZone ?? '',
       languages: data.languages
         ? data.languages
@@ -539,8 +539,8 @@ export default function EditDisplayModal({
       screenSize: data.screenSize ?? null,
       isMobile: data.isMobile ?? 0,
       isOutdoor: data.isOutdoor ?? 0,
-      costPerPlay: data.costPerPlay ?? null,
-      impressionsPerPlay: data.impressionsPerPlay ?? null,
+      costPerPlay: data.costPerPlay != null ? Number(data.costPerPlay) : null,
+      impressionsPerPlay: data.impressionsPerPlay != null ? Number(data.impressionsPerPlay) : null,
       ref1: data.ref1 ?? '',
       ref2: data.ref2 ?? '',
       ref3: data.ref3 ?? '',
@@ -723,12 +723,14 @@ export default function EditDisplayModal({
       });
 
       if (!result.success) {
-        setApiError(undefined);
-        setNameError(result.error.flatten().fieldErrors.display?.[0]);
+        const flat = result.error.flatten().fieldErrors;
+        setFieldErrors(Object.fromEntries(Object.entries(flat).map(([k, v]) => [k, v?.[0]])));
+        setApiError(t('Please fix the highlighted errors before saving.'));
         return;
       }
 
-      setNameError(undefined);
+      setFieldErrors({});
+      setApiError(undefined);
 
       const tagString =
         draft.tags.length > 0
@@ -983,7 +985,7 @@ export default function EditDisplayModal({
                 placeholder={t('Enter name')}
                 value={draft.display}
                 onChange={(v) => set('display', v)}
-                error={nameError}
+                error={fieldErrors.display}
               />
               <TextInput
                 name="license"
@@ -1045,6 +1047,7 @@ export default function EditDisplayModal({
                 placeholder=" "
                 value={draft.latitude ?? undefined}
                 onChange={(v) => set('latitude', v || null)}
+                error={fieldErrors.latitude}
               />
               <NumberInput
                 name="longitude"
@@ -1053,6 +1056,7 @@ export default function EditDisplayModal({
                 placeholder=" "
                 value={draft.longitude ?? undefined}
                 onChange={(v) => set('longitude', v || null)}
+                error={fieldErrors.longitude}
               />
               <TimezoneSelect
                 value={draft.timeZone}
@@ -1134,6 +1138,7 @@ export default function EditDisplayModal({
                 placeholder=" "
                 value={draft.costPerPlay ?? undefined}
                 onChange={(v) => set('costPerPlay', v || null)}
+                error={fieldErrors.costPerPlay}
               />
               <NumberInput
                 name="impressionsPerPlay"
@@ -1142,6 +1147,7 @@ export default function EditDisplayModal({
                 placeholder=" "
                 value={draft.impressionsPerPlay ?? undefined}
                 onChange={(v) => set('impressionsPerPlay', v || null)}
+                error={fieldErrors.impressionsPerPlay}
               />
             </>
           )}

--- a/frontend/src/pages/Displays/SyncGroups/components/AddAndEditSyncGroupModal.tsx
+++ b/frontend/src/pages/Displays/SyncGroups/components/AddAndEditSyncGroupModal.tsx
@@ -83,9 +83,9 @@ export default function AddAndEditSyncGroupModal({
       if (isEdit && syncGroup) {
         setDraft({
           name: syncGroup.name,
-          syncPublisherPort: syncGroup.syncPublisherPort,
-          syncSwitchDelay: syncGroup.syncSwitchDelay,
-          syncVideoPauseDelay: syncGroup.syncVideoPauseDelay,
+          syncPublisherPort: Number(syncGroup.syncPublisherPort),
+          syncSwitchDelay: Number(syncGroup.syncSwitchDelay),
+          syncVideoPauseDelay: Number(syncGroup.syncVideoPauseDelay),
           leadDisplayId: syncGroup.leadDisplayId || null,
           folderId: syncGroup.folderId || null,
         });
@@ -110,7 +110,7 @@ export default function AddAndEditSyncGroupModal({
       const result = schema.safeParse(draft);
 
       if (!result.success) {
-        setApiError(undefined);
+        setApiError(t('Please fix the highlighted errors before saving.'));
         const fieldErrors = result.error.flatten().fieldErrors;
         const mappedErrors: FormErrors = {};
         Object.entries(fieldErrors).forEach(([key, value]) => {

--- a/frontend/src/pages/Library/Dataset/components/AddAndEditDatasetModal.tsx
+++ b/frontend/src/pages/Library/Dataset/components/AddAndEditDatasetModal.tsx
@@ -109,7 +109,7 @@ const createDraftFromData = (
     dataSet: data.dataSet ?? '',
     description: data.description ?? '',
     code: data.code ?? '',
-    folderId: data.folderId ?? null,
+    folderId: data.folderId != null ? Number(data.folderId) : null,
     isRemote: Boolean(data.isRemote),
     isRealTime: Boolean(data.isRealTime),
     ignoreFirstRow: Boolean(data.ignoreFirstRow),
@@ -129,10 +129,10 @@ const createDraftFromData = (
     summarize: (data.summarize || 'none') as DatasetSummarize,
     summarizeField: data.summarizeField ?? '',
     limitPolicy: (data.limitPolicy || 'stop') as DatasetLimitPolicy,
-    refreshRate: data.refreshRate ?? 0,
-    clearRate: data.clearRate ?? 1,
-    runsAfter: data.runsAfter ?? 0,
-    rowLimit: data.rowLimit ?? 0,
+    refreshRate: data.refreshRate != null ? Number(data.refreshRate) : 0,
+    clearRate: data.clearRate != null ? Number(data.clearRate) : 1,
+    runsAfter: data.runsAfter != null ? Number(data.runsAfter) : 0,
+    rowLimit: data.rowLimit != null ? Number(data.rowLimit) : 0,
   };
 };
 
@@ -238,7 +238,7 @@ export default function AddAndEditDatasetModal({
       } else if (draft.isRemote && (fieldErrors.uri || fieldErrors.username)) {
         setActiveTab(fieldErrors.uri ? 'remote' : 'auth');
       }
-
+      setApiError(t('Please fix the highlighted errors before saving.'));
       return;
     }
 

--- a/frontend/src/pages/Library/Dataset/subPages/Columns/components/AddAndEditDatasetColumnModal.tsx
+++ b/frontend/src/pages/Library/Dataset/subPages/Columns/components/AddAndEditDatasetColumnModal.tsx
@@ -144,6 +144,7 @@ export function AddAndEditDatasetColumnModal({
       setFormErrors({
         heading: fieldErrors.heading?.[0],
       });
+      setApiError(t('Please fix the highlighted errors before saving.'));
       return;
     }
 

--- a/frontend/src/pages/Library/Dataset/subPages/Rss/components/AddAndEditDatasetRssModal.tsx
+++ b/frontend/src/pages/Library/Dataset/subPages/Rss/components/AddAndEditDatasetRssModal.tsx
@@ -249,6 +249,7 @@ export function AddAndEditDatasetRssModal({
 
       setFormErrors(errors);
       setActiveTab('general');
+      setApiError(t('Please fix the highlighted errors before saving.'));
       return;
     }
 

--- a/frontend/src/pages/Library/Media/components/EditMediaModal.tsx
+++ b/frontend/src/pages/Library/Media/components/EditMediaModal.tsx
@@ -131,6 +131,7 @@ export default function EditMediaModal({
       });
 
       setFormErrors(fieldErrors);
+      setApiError(t('Please fix the highlighted errors before saving.'));
       return;
     }
 

--- a/frontend/src/pages/Library/MenuBoard/__tests__/AddAndEditMenuBoardModal.test.tsx
+++ b/frontend/src/pages/Library/MenuBoard/__tests__/AddAndEditMenuBoardModal.test.tsx
@@ -60,12 +60,7 @@ function renderEditModal(dataOverrides = {}) {
   const mockOnSave = vi.fn();
   const board = mockMenuBoard(dataOverrides);
   renderWithProviders(
-    <AddAndEditMenuBoardModal
-      type="edit"
-      data={board}
-      onClose={mockOnClose}
-      onSave={mockOnSave}
-    />,
+    <AddAndEditMenuBoardModal type="edit" data={board} onClose={mockOnClose} onSave={mockOnSave} />,
   );
   return { mockOnClose, mockOnSave, board };
 }
@@ -100,7 +95,11 @@ describe('AddAndEditMenuBoardModal', () => {
 
       await waitFor(() => {
         expect(mockCreateMenuBoard).toHaveBeenCalledWith(
-          expect.objectContaining({ name: 'New Board', code: 'NB_01', description: 'A description' }),
+          expect.objectContaining({
+            name: 'New Board',
+            code: 'NB_01',
+            description: 'A description',
+          }),
         );
         expect(mockOnSave).toHaveBeenCalled();
         expect(mockOnClose).toHaveBeenCalled();

--- a/frontend/src/pages/Library/MenuBoard/__tests__/DeleteMenuBoardModal.test.tsx
+++ b/frontend/src/pages/Library/MenuBoard/__tests__/DeleteMenuBoardModal.test.tsx
@@ -55,11 +55,7 @@ describe('DeleteMenuBoardModal', () => {
   // Scenario 27 — bulk delete confirmation
   it('shows plural confirmation message with count when deleting multiple boards', () => {
     renderWithProviders(
-      <DeleteMenuBoardModal
-        onClose={mockOnClose}
-        onDelete={mockOnDelete}
-        itemCount={3}
-      />,
+      <DeleteMenuBoardModal onClose={mockOnClose} onDelete={mockOnDelete} itemCount={3} />,
     );
 
     expect(screen.getByText('Delete Menu Boards?')).toBeInTheDocument();
@@ -86,11 +82,7 @@ describe('DeleteMenuBoardModal', () => {
   it('calls onClose when Cancel is clicked', async () => {
     const user = userEvent.setup();
     renderWithProviders(
-      <DeleteMenuBoardModal
-        onClose={mockOnClose}
-        onDelete={mockOnDelete}
-        itemCount={1}
-      />,
+      <DeleteMenuBoardModal onClose={mockOnClose} onDelete={mockOnDelete} itemCount={1} />,
     );
 
     await user.click(screen.getByRole('button', { name: 'Cancel' }));

--- a/frontend/src/pages/Library/MenuBoard/__tests__/useMenuBoardActions.test.tsx
+++ b/frontend/src/pages/Library/MenuBoard/__tests__/useMenuBoardActions.test.tsx
@@ -156,12 +156,7 @@ describe('useMenuBoardActions', () => {
       const { result } = renderActions();
 
       await act(async () => {
-        await result.current.handleConfirmClone(
-          mockMenuBoard({ menuId: 5 }),
-          'Copy',
-          'desc',
-          'CP',
-        );
+        await result.current.handleConfirmClone(mockMenuBoard({ menuId: 5 }), 'Copy', 'desc', 'CP');
       });
 
       expect(mockCopyMenuBoard).toHaveBeenCalledWith({

--- a/frontend/src/pages/Library/MenuBoard/components/AddAndEditMenuBoardModal.tsx
+++ b/frontend/src/pages/Library/MenuBoard/components/AddAndEditMenuBoardModal.tsx
@@ -116,6 +116,7 @@ export default function AddAndEditMenuBoardModal({
         description: fieldErrors.description?.[0],
         code: fieldErrors.code?.[0],
       });
+      setApiError(t('Please fix the highlighted errors before saving.'));
       return;
     }
 

--- a/frontend/src/pages/Library/MenuBoard/subPages/Categories/__tests__/AddAndEditMenuBoardCategoryModal.test.tsx
+++ b/frontend/src/pages/Library/MenuBoard/subPages/Categories/__tests__/AddAndEditMenuBoardCategoryModal.test.tsx
@@ -23,12 +23,8 @@ import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+import { renderWithProviders, mockMenuBoardCategory } from '../../../__tests__/MenuBoardSetup';
 import AddAndEditMenuBoardCategoryModal from '../components/AddAndEditMenuBoardCategoryModal';
-
-import {
-  renderWithProviders,
-  mockMenuBoardCategory,
-} from '../../../__tests__/MenuBoardSetup';
 
 // -- Module mocks --
 

--- a/frontend/src/pages/Library/MenuBoard/subPages/Categories/components/AddAndEditMenuBoardCategoryModal.tsx
+++ b/frontend/src/pages/Library/MenuBoard/subPages/Categories/components/AddAndEditMenuBoardCategoryModal.tsx
@@ -66,7 +66,7 @@ const createDraftFromData = (data?: MenuBoardCategory | null): CategoryDraft => 
     name: data.name ?? '',
     description: data.description ?? '',
     code: data.code ?? '',
-    mediaId: data.mediaId ?? null,
+    mediaId: data.mediaId != null ? Number(data.mediaId) : null,
   };
 };
 
@@ -112,6 +112,7 @@ export default function AddAndEditMenuBoardCategoryModal({
         description: fieldErrors.description?.[0],
         code: fieldErrors.code?.[0],
       });
+      setApiError(t('Please fix the highlighted errors before saving.'));
       return;
     }
 

--- a/frontend/src/pages/Library/MenuBoard/subPages/Products/__tests__/AddAndEditMenuBoardProductModal.test.tsx
+++ b/frontend/src/pages/Library/MenuBoard/subPages/Products/__tests__/AddAndEditMenuBoardProductModal.test.tsx
@@ -23,12 +23,8 @@ import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+import { renderWithProviders, mockMenuBoardProduct } from '../../../__tests__/MenuBoardSetup';
 import AddAndEditMenuBoardProductModal from '../components/AddAndEditMenuBoardProductModal';
-
-import {
-  renderWithProviders,
-  mockMenuBoardProduct,
-} from '../../../__tests__/MenuBoardSetup';
 
 // -- Module mocks --
 
@@ -293,16 +289,16 @@ describe('AddAndEditMenuBoardProductModal', () => {
 
       await user.click(screen.getByRole('button', { name: 'Product Options' }));
       // Add one row
-      const addBtn = screen.getAllByRole('button').find(
-        (b) => !b.textContent?.trim() && !b.getAttribute('aria-label'),
-      );
+      const addBtn = screen
+        .getAllByRole('button')
+        .find((b) => !b.textContent?.trim() && !b.getAttribute('aria-label'));
       await user.click(addBtn!);
       expect(screen.getAllByPlaceholderText('Option Name')).toHaveLength(1);
 
       // Remove it
-      const removeBtn = screen.getAllByRole('button').find(
-        (b) => !b.textContent?.trim() && !b.getAttribute('aria-label') && b !== addBtn,
-      );
+      const removeBtn = screen
+        .getAllByRole('button')
+        .find((b) => !b.textContent?.trim() && !b.getAttribute('aria-label') && b !== addBtn);
       if (removeBtn) {
         await user.click(removeBtn);
       }

--- a/frontend/src/pages/Library/MenuBoard/subPages/Products/components/AddAndEditMenuBoardProductModal.tsx
+++ b/frontend/src/pages/Library/MenuBoard/subPages/Products/components/AddAndEditMenuBoardProductModal.tsx
@@ -90,13 +90,13 @@ const createDraftFromData = (data?: MenuBoardProduct | null): ProductDraft => {
   }
   return {
     name: data.name ?? '',
-    price: data.price ?? null,
+    price: data.price != null ? Number(data.price) : null,
     description: data.description ?? '',
     code: data.code ?? '',
-    displayOrder: data.displayOrder ?? null,
+    displayOrder: data.displayOrder != null ? Number(data.displayOrder) : null,
     availability: (data.availability ?? 1) === 1,
     allergyInfo: data.allergyInfo ?? '',
-    calories: data.calories ?? null,
+    calories: data.calories != null ? Number(data.calories) : null,
     mediaId: data.mediaId || null,
     productOptions: (data.productOptions ?? []).map((o, i) => ({
       id: i,
@@ -198,6 +198,7 @@ export default function AddAndEditMenuBoardProductModal({
       } else if (errors.description || errors.allergyInfo) {
         setActiveTab('details');
       }
+      setApiError(t('Please fix the highlighted errors before saving.'));
       return;
     }
 

--- a/frontend/src/pages/Library/Playlists/components/AddAndEditPlaylistModal.tsx
+++ b/frontend/src/pages/Library/Playlists/components/AddAndEditPlaylistModal.tsx
@@ -107,7 +107,7 @@ export default function AddAndEditPlaylistModal({
       return {
         ...DEFAULT_DRAFT,
         name: data.name,
-        folderId: data.folderId ?? null,
+        folderId: data.folderId != null ? Number(data.folderId) : null,
         tags: data.tags.map((t) => ({ ...t })),
         enableStat: data.enableStat,
         isDynamic: data.isDynamic,
@@ -116,8 +116,8 @@ export default function AddAndEditPlaylistModal({
         filterMediaTag: data.filterMediaTag ? data.filterMediaTag.map((t) => ({ ...t })) : [],
         exactTags: data.exactTags || false,
         logicalOperator: data.logicalOperator || 'OR',
-        filterFolderId: data.filterFolderId ?? null,
-        maxNumberOfItems: data.maxNumberOfItems || 0,
+        filterFolderId: data.filterFolderId != null ? Number(data.filterFolderId) : null,
+        maxNumberOfItems: Number(data.maxNumberOfItems) || 0,
       };
     }
     return { ...DEFAULT_DRAFT, folderId: defaultFolderId ?? null };
@@ -156,7 +156,7 @@ export default function AddAndEditPlaylistModal({
       setDraft({
         ...DEFAULT_DRAFT,
         name: data.name,
-        folderId: data.folderId ?? null,
+        folderId: data.folderId != null ? Number(data.folderId) : null,
         tags: data.tags.map((t) => ({ ...t })),
         enableStat: data.enableStat,
         isDynamic: data.isDynamic,
@@ -165,8 +165,8 @@ export default function AddAndEditPlaylistModal({
         filterMediaTag: data.filterMediaTag ? data.filterMediaTag.map((t) => ({ ...t })) : [],
         exactTags: data.exactTags || false,
         logicalOperator: data.logicalOperator || 'OR',
-        filterFolderId: data.filterFolderId || null,
-        maxNumberOfItems: data.maxNumberOfItems || 0,
+        filterFolderId: data.filterFolderId != null ? Number(data.filterFolderId) : null,
+        maxNumberOfItems: Number(data.maxNumberOfItems) || 0,
       });
     } else {
       setDraft({ ...DEFAULT_DRAFT, folderId: defaultFolderId ?? null });
@@ -182,7 +182,7 @@ export default function AddAndEditPlaylistModal({
       const result = schema.safeParse(draft);
 
       if (!result.success) {
-        setApiError(undefined);
+        setApiError(t('Please fix the highlighted errors before saving.'));
         const fieldErrors = result.error.flatten().fieldErrors;
         const mappedErrors: PlaylistFormErrors = {};
 


### PR DESCRIPTION
- All modals now show a fallback error banner when validation fails.
- Numeric fields from the API are coerced to Number() on draft init to prevent silent "Expected number, received string" failures.
- Linter fixes for test files