### PR TITLE
Frontend: Remove dead catch blocks, debug logs, and unsafe error casts

### DIFF
--- a/frontend/src/pages/Advanced/Sessions/hooks/useSessionActions.ts
+++ b/frontend/src/pages/Advanced/Sessions/hooks/useSessionActions.ts
@@ -72,13 +72,6 @@ export function useSessionActions({
       setRowSelection({});
       handleRefresh();
       closeModal();
-    } catch (error) {
-      console.error(error);
-      const message =
-        isAxiosError(error) && error.response?.data?.message
-          ? error.response.data.message
-          : t('Session could not be logged out.');
-      setLogoutError(message);
     } finally {
       setIsLoggingOut(false);
     }

--- a/frontend/src/pages/Design/Campaigns/components/AddCampaignModal.tsx
+++ b/frontend/src/pages/Design/Campaigns/components/AddCampaignModal.tsx
@@ -19,6 +19,7 @@
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { isAxiosError } from 'axios';
 import { useEffect, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -147,10 +148,8 @@ export default function AddCampaignModal({
       } catch (err: unknown) {
         console.error('Failed to create campaign:', err);
 
-        const apiErr = err as { response?: { data?: { message?: string } } };
-
-        if (apiErr.response?.data?.message) {
-          setApiError(apiErr.response.data.message);
+        if (isAxiosError(err) && err.response?.data?.message) {
+          setApiError(err.response.data.message);
         } else if (err instanceof Error) {
           setApiError(err.message);
         } else {

--- a/frontend/src/pages/Design/Campaigns/components/EditCampaignModal.tsx
+++ b/frontend/src/pages/Design/Campaigns/components/EditCampaignModal.tsx
@@ -21,6 +21,7 @@
 
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import type { ColumnDef, PaginationState, SortingState } from '@tanstack/react-table';
+import { isAxiosError } from 'axios';
 import { useEffect, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -216,9 +217,8 @@ export default function EditCampaignModal({
         onSuccess();
         onClose();
       } catch (err: unknown) {
-        const apiErr = err as { response?: { data?: { message?: string } } };
-        if (apiErr.response?.data?.message) {
-          setApiError(apiErr.response.data.message);
+        if (isAxiosError(err) && err.response?.data?.message) {
+          setApiError(err.response.data.message);
         } else if (err instanceof Error) {
           setApiError(err.message);
         } else {

--- a/frontend/src/pages/Design/Campaigns/hooks/useCampaignActions.ts
+++ b/frontend/src/pages/Design/Campaigns/hooks/useCampaignActions.ts
@@ -88,15 +88,6 @@ export function useCampaignActions({
       setRowSelection({});
       handleRefresh();
       closeModal();
-    } catch (error) {
-      console.error(error);
-
-      const message =
-        isAxiosError(error) && error.response?.data?.message
-          ? error.response.data.message
-          : t('Some campaigns could not be deleted.');
-
-      setDeleteError(message);
     } finally {
       setIsDeleting(false);
     }

--- a/frontend/src/pages/Design/Layouts/__tests__/Layouts.edit.form.test.tsx
+++ b/frontend/src/pages/Design/Layouts/__tests__/Layouts.edit.form.test.tsx
@@ -202,6 +202,7 @@ describe('Layouts page - edit form fields', () => {
   // ---------------------------------------------------------------------------
   test('Failed save keeps the modal open', async () => {
     vi.mocked(updateLayout).mockRejectedValueOnce({
+      isAxiosError: true,
       response: { data: { message: 'Layout name already exists' } },
     });
 

--- a/frontend/src/pages/Design/Layouts/components/EditLayout.tsx
+++ b/frontend/src/pages/Design/Layouts/components/EditLayout.tsx
@@ -19,6 +19,7 @@
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { isAxiosError } from 'axios';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -133,10 +134,8 @@ export default function EditLayout({ isOpen = true, onClose, data, onSave }: Edi
       onClose();
     } catch (err) {
       console.error('Failed to update layout', err);
-      const apiError = err as { response?: { data?: { message?: string } } };
-
-      if (apiError.response?.data?.message) {
-        setApiError(apiError.response.data.message);
+      if (isAxiosError(err) && err.response?.data?.message) {
+        setApiError(err.response.data.message);
       } else if (err instanceof Error) {
         setApiError(err.message);
       } else {

--- a/frontend/src/pages/Design/Layouts/components/SaveAsTemplateModal.tsx
+++ b/frontend/src/pages/Design/Layouts/components/SaveAsTemplateModal.tsx
@@ -19,6 +19,7 @@
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { isAxiosError } from 'axios';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -111,10 +112,8 @@ export default function SaveAsTemplateModal({
     } catch (err) {
       console.error(err);
 
-      const apiErr = err as { response?: { data?: { message?: string } } };
-
-      if (apiErr.response?.data?.message) {
-        setApiError(apiErr.response.data.message);
+      if (isAxiosError(err) && err.response?.data?.message) {
+        setApiError(err.response.data.message);
       } else if (err instanceof Error) {
         setApiError(err.message);
       } else {

--- a/frontend/src/pages/Design/Layouts/hooks/useLayoutActions.ts
+++ b/frontend/src/pages/Design/Layouts/hooks/useLayoutActions.ts
@@ -94,13 +94,6 @@ export function useLayoutActions({
       setRowSelection({});
       handleRefresh();
       closeModal();
-    } catch (error) {
-      console.error(error);
-      const message =
-        isAxiosError(error) && error.response?.data?.message
-          ? error.response.data.message
-          : t('Some selected items could not be deleted.');
-      setDeleteError(message);
     } finally {
       setIsDeleting(false);
     }
@@ -249,8 +242,8 @@ export function useLayoutActions({
       closeModal();
     } catch (error) {
       console.error(error);
-      const apiErr = error as { response?: { data?: { message?: string } } };
-      const message = apiErr.response?.data?.message ?? t('Failed to publish layout');
+      const message =
+        (isAxiosError(error) && error.response?.data?.message) || t('Failed to publish layout');
       notify.error(message);
     } finally {
       setIsPublishing(false);
@@ -304,9 +297,6 @@ export function useLayoutActions({
       a.click();
 
       window.URL.revokeObjectURL(url);
-
-      const text = await blob.text();
-      console.log('TEXT RESPONSE:', text);
 
       notify.success(t('Layout exported successfully'));
       closeModal();

--- a/frontend/src/pages/Design/Resolutions/components/AddAndEditResolutionModal.tsx
+++ b/frontend/src/pages/Design/Resolutions/components/AddAndEditResolutionModal.tsx
@@ -19,6 +19,7 @@
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { isAxiosError } from 'axios';
 import { useEffect, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -146,10 +147,8 @@ export default function AddAndEditResolutionModal({
       } catch (err: unknown) {
         console.error('Failed to save resolution:', err);
 
-        const apiError = err as { response?: { data?: { message?: string } } };
-
-        if (apiError.response?.data?.message) {
-          setApiError(apiError.response.data.message);
+        if (isAxiosError(err) && err.response?.data?.message) {
+          setApiError(err.response.data.message);
         } else if (err instanceof Error) {
           setApiError(err.message);
         } else {

--- a/frontend/src/pages/Design/Resolutions/hooks/useResolutionActions.ts
+++ b/frontend/src/pages/Design/Resolutions/hooks/useResolutionActions.ts
@@ -72,13 +72,6 @@ export function useResolutionActions({
       setRowSelection({});
       handleRefresh();
       closeModal();
-    } catch (error) {
-      console.error(error);
-      const message =
-        isAxiosError(error) && error.response?.data?.message
-          ? error.response.data.message
-          : t('Some selected items cannot be deleted.');
-      setDeleteError(message);
     } finally {
       setIsDeleting(false);
     }

--- a/frontend/src/pages/Design/Templates/__tests__/Templates.edit.form.test.tsx
+++ b/frontend/src/pages/Design/Templates/__tests__/Templates.edit.form.test.tsx
@@ -173,6 +173,7 @@ describe('Templates page - edit form fields', () => {
   // ---------------------------------------------------------------------------
   test('Failed save keeps the modal open', async () => {
     vi.mocked(updateTemplate).mockRejectedValueOnce({
+      isAxiosError: true,
       response: { data: { message: 'Template name already exists' } },
     });
 

--- a/frontend/src/pages/Design/Templates/components/AddAndEditTemplate.tsx
+++ b/frontend/src/pages/Design/Templates/components/AddAndEditTemplate.tsx
@@ -19,6 +19,7 @@
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { isAxiosError } from 'axios';
 import { useEffect, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -191,10 +192,8 @@ export default function AddAndEditTemplateModal({
       } catch (err: unknown) {
         console.error('Failed to save playlist:', err);
 
-        const apiError = err as { response?: { data?: { message?: string } } };
-
-        if (apiError.response?.data?.message) {
-          setApiError(apiError.response.data.message);
+        if (isAxiosError(err) && err.response?.data?.message) {
+          setApiError(err.response.data.message);
         } else if (err instanceof Error) {
           setApiError(err.message);
         } else {

--- a/frontend/src/pages/Design/Templates/hooks/useTemplateActions.ts
+++ b/frontend/src/pages/Design/Templates/hooks/useTemplateActions.ts
@@ -84,15 +84,6 @@ export function useTemplateActions({
       setRowSelection({});
       handleRefresh();
       closeModal();
-    } catch (error) {
-      console.error(error);
-
-      const message =
-        isAxiosError(error) && error.response?.data?.message
-          ? error.response.data.message
-          : t('Some selected items are in use and cannot be deleted.');
-
-      setDeleteError(message);
     } finally {
       setIsDeleting(false);
     }
@@ -119,7 +110,6 @@ export function useTemplateActions({
       notify.success(t('Template copied successfully'));
       handleRefresh();
       closeModal();
-      console.log('copy template', selectedTemplate, newName, description, copyMediaFiles);
     } catch (error) {
       console.error('Copy template failed', error);
       notify.error(t('Failed to copy template'));

--- a/frontend/src/pages/Displays/DisplayGroup/__tests__/DisplayGroup.edit.form.test.tsx
+++ b/frontend/src/pages/Displays/DisplayGroup/__tests__/DisplayGroup.edit.form.test.tsx
@@ -254,6 +254,7 @@ describe('DisplayGroup - edit form fields', () => {
   test('Failed save keeps the modal open and shows the error', async () => {
     const user = userEvent.setup();
     vi.mocked(updateDisplayGroup).mockRejectedValueOnce({
+      isAxiosError: true,
       message: 'Request failed with status code 422',
       response: { data: { message: 'Display group name already exists' } },
     });

--- a/frontend/src/pages/Displays/DisplayGroup/components/AddAndEditDisplayGroupModal.tsx
+++ b/frontend/src/pages/Displays/DisplayGroup/components/AddAndEditDisplayGroupModal.tsx
@@ -21,6 +21,7 @@
 
 import { useQuery } from '@tanstack/react-query';
 import type { ColumnDef, PaginationState, SortingState } from '@tanstack/react-table';
+import { isAxiosError } from 'axios';
 import { useEffect, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -233,9 +234,8 @@ export default function AddAndEditDisplayGroupModal({
         }
         onClose();
       } catch (err: unknown) {
-        const apiErr = err as { response?: { data?: { message?: string } } };
-        if (apiErr.response?.data?.message) {
-          setApiError(apiErr.response.data.message);
+        if (isAxiosError(err) && err.response?.data?.message) {
+          setApiError(err.response.data.message);
         } else if (err instanceof Error) {
           setApiError(err.message);
         } else {

--- a/frontend/src/pages/Displays/DisplayGroup/hooks/useDisplayGroupActions.ts
+++ b/frontend/src/pages/Displays/DisplayGroup/hooks/useDisplayGroupActions.ts
@@ -107,13 +107,6 @@ export function useDisplayGroupActions({
       setRowSelection({});
       handleRefresh();
       closeModal();
-    } catch (error) {
-      console.error(error);
-      const message =
-        isAxiosError(error) && error.response?.data?.message
-          ? error.response.data.message
-          : t('Some selected items cannot be deleted.');
-      setDeleteError(message);
     } finally {
       setIsDeleting(false);
     }
@@ -200,13 +193,6 @@ export function useDisplayGroupActions({
         handleRefresh();
         closeModal();
       }
-    } catch (error) {
-      console.error(error);
-      const message =
-        isAxiosError(error) && error.response?.data?.message
-          ? error.response.data.message
-          : errorMessage;
-      setActionError(message);
     } finally {
       setIsActionPending(false);
     }

--- a/frontend/src/pages/Displays/DisplayProfile/__tests__/DisplayProfile.edit.form.test.tsx
+++ b/frontend/src/pages/Displays/DisplayProfile/__tests__/DisplayProfile.edit.form.test.tsx
@@ -161,6 +161,7 @@ describe('DisplayProfile - edit form fields', () => {
   // ---------------------------------------------------------------------------
   test('Failed save keeps the modal open and shows the error', async () => {
     vi.mocked(updateDisplayProfile).mockRejectedValueOnce({
+      isAxiosError: true,
       response: { data: { message: 'Display profile name already exists' } },
     });
 

--- a/frontend/src/pages/Displays/DisplayProfile/__tests__/DisplayProfileBaseForm.test-helper.tsx
+++ b/frontend/src/pages/Displays/DisplayProfile/__tests__/DisplayProfileBaseForm.test-helper.tsx
@@ -37,6 +37,7 @@
 // It is NOT used anywhere in the production app.
 // ---------------------------------------------------------------------------
 
+import { isAxiosError } from 'axios';
 import { useEffect, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -53,8 +54,10 @@ type ConfigValue = string | number | null;
 type FlatConfig = Record<string, ConfigValue>;
 
 function getApiErrorMessage(err: unknown, fallback: string): string {
-  const e = err as { response?: { data?: { message?: string } } };
-  return e.response?.data?.message ?? (err instanceof Error ? err.message : fallback);
+  return (
+    (isAxiosError(err) && err.response?.data?.message) ||
+    (err instanceof Error ? err.message : fallback)
+  );
 }
 
 // The API returns config as an array of { name, value } pairs.

--- a/frontend/src/pages/Displays/DisplayProfile/components/AddDisplayProfileModal.tsx
+++ b/frontend/src/pages/Displays/DisplayProfile/components/AddDisplayProfileModal.tsx
@@ -19,6 +19,7 @@
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { isAxiosError } from 'axios';
 import { useEffect, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -96,9 +97,8 @@ export default function AddDisplayProfileModal({
         onSave(created);
         onClose();
       } catch (err: unknown) {
-        const apiErr = err as { response?: { data?: { message?: string } } };
-        if (apiErr.response?.data?.message) {
-          setApiError(apiErr.response.data.message);
+        if (isAxiosError(err) && err.response?.data?.message) {
+          setApiError(err.response.data.message);
         } else if (err instanceof Error) {
           setApiError(err.message);
         } else {

--- a/frontend/src/pages/Displays/DisplayProfile/components/EditDisplayProfileModal.tsx
+++ b/frontend/src/pages/Displays/DisplayProfile/components/EditDisplayProfileModal.tsx
@@ -19,6 +19,7 @@
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { isAxiosError } from 'axios';
 import { useEffect, useRef, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -47,8 +48,10 @@ type ConfigValue = string | number | null;
 type FlatConfig = Record<string, ConfigValue>;
 
 function getApiErrorMessage(err: unknown, fallback: string): string {
-  const e = err as { response?: { data?: { message?: string } } };
-  return e.response?.data?.message ?? (err instanceof Error ? err.message : fallback);
+  return (
+    (isAxiosError(err) && err.response?.data?.message) ||
+    (err instanceof Error ? err.message : fallback)
+  );
 }
 
 interface EditDraft {

--- a/frontend/src/pages/Displays/DisplayProfile/hooks/useDisplayProfileActions.ts
+++ b/frontend/src/pages/Displays/DisplayProfile/hooks/useDisplayProfileActions.ts
@@ -73,13 +73,6 @@ export function useDisplayProfileActions({
       setRowSelection({});
       handleRefresh();
       closeModal();
-    } catch (error) {
-      console.error(error);
-      const message =
-        isAxiosError(error) && error.response?.data?.message
-          ? error.response.data.message
-          : t('Some selected items cannot be deleted.');
-      setDeleteError(message);
     } finally {
       setIsDeleting(false);
     }

--- a/frontend/src/pages/Displays/Displays/__tests__/Displays.add.test.tsx
+++ b/frontend/src/pages/Displays/Displays/__tests__/Displays.add.test.tsx
@@ -168,6 +168,7 @@ describe('Displays page - add display', () => {
   test('wrong code keeps the modal open and shows the server error message', async () => {
     const user = userEvent.setup();
     vi.mocked(addDisplayViaCode).mockRejectedValueOnce({
+      isAxiosError: true,
       response: {
         data: {
           message:

--- a/frontend/src/pages/Displays/Displays/__tests__/edit/edit.form.test.tsx
+++ b/frontend/src/pages/Displays/Displays/__tests__/edit/edit.form.test.tsx
@@ -182,6 +182,7 @@ describe('Display - edit form fields', () => {
   test('Failed save keeps the modal open and shows the error', async () => {
     const user = userEvent.setup();
     vi.mocked(updateDisplay).mockRejectedValueOnce({
+      isAxiosError: true,
       message: 'Request failed with status code 422',
       response: { data: { message: 'Display name already exists' } },
     });

--- a/frontend/src/pages/Displays/Displays/__tests__/modals/edit/edit.form.test.tsx
+++ b/frontend/src/pages/Displays/Displays/__tests__/modals/edit/edit.form.test.tsx
@@ -182,6 +182,7 @@ describe('Display - edit form fields', () => {
   test('Failed save keeps the modal open and shows the error', async () => {
     const user = userEvent.setup();
     vi.mocked(updateDisplay).mockRejectedValueOnce({
+      isAxiosError: true,
       message: 'Request failed with status code 422',
       response: { data: { message: 'Display name already exists' } },
     });

--- a/frontend/src/pages/Displays/Displays/__tests__/page/actions.add.test.tsx
+++ b/frontend/src/pages/Displays/Displays/__tests__/page/actions.add.test.tsx
@@ -168,6 +168,7 @@ describe('Displays page - add display', () => {
   test('wrong code keeps the modal open and shows the server error message', async () => {
     const user = userEvent.setup();
     vi.mocked(addDisplayViaCode).mockRejectedValueOnce({
+      isAxiosError: true,
       response: {
         data: {
           message:

--- a/frontend/src/pages/Displays/Displays/components/AddDisplayModal.tsx
+++ b/frontend/src/pages/Displays/Displays/components/AddDisplayModal.tsx
@@ -19,6 +19,7 @@
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { isAxiosError } from 'axios';
 import { useEffect, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -53,9 +54,8 @@ export default function AddDisplayModal({ isOpen = true, onClose }: AddDisplayMo
         notify.success(t('CMS Credentials Added'));
         onClose();
       } catch (err: unknown) {
-        const apiErr = err as { response?: { data?: { message?: string } } };
-        if (apiErr.response?.data?.message) {
-          setApiError(apiErr.response.data.message);
+        if (isAxiosError(err) && err.response?.data?.message) {
+          setApiError(err.response.data.message);
         } else if (err instanceof Error) {
           setApiError(err.message);
         } else {

--- a/frontend/src/pages/Displays/Displays/components/EditDisplayModal.tsx
+++ b/frontend/src/pages/Displays/Displays/components/EditDisplayModal.tsx
@@ -29,6 +29,7 @@ import {
   useFloating,
   useInteractions,
 } from '@floating-ui/react';
+import { isAxiosError } from 'axios';
 import type { TFunction } from 'i18next';
 import { useEffect, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -95,8 +96,10 @@ function formatSettingName(name: string): string {
 }
 
 function getApiErrorMessage(err: unknown, fallback: string): string {
-  const e = err as { response?: { data?: { message?: string } } };
-  return e.response?.data?.message ?? (err instanceof Error ? err.message : fallback);
+  return (
+    (isAxiosError(err) && err.response?.data?.message) ||
+    (err instanceof Error ? err.message : fallback)
+  );
 }
 
 function configArrayToFlat(

--- a/frontend/src/pages/Displays/Displays/hooks/useDisplaysActions.ts
+++ b/frontend/src/pages/Displays/Displays/hooks/useDisplaysActions.ts
@@ -95,13 +95,6 @@ export function useDisplaysActions({
       setRowSelection({});
       handleRefresh();
       closeModal();
-    } catch (error) {
-      console.error(error);
-      const message =
-        isAxiosError(error) && error.response?.data?.message
-          ? error.response.data.message
-          : t('Some selected items cannot be deleted.');
-      setDeleteError(message);
     } finally {
       setIsDeleting(false);
     }
@@ -206,13 +199,6 @@ export function useDisplaysActions({
         handleRefresh();
         closeModal();
       }
-    } catch (error) {
-      console.error(error);
-      const message =
-        isAxiosError(error) && error.response?.data?.message
-          ? error.response.data.message
-          : errorMessage;
-      setActionError(message);
     } finally {
       setIsActionPending(false);
     }

--- a/frontend/src/pages/Displays/SyncGroups/components/AddAndEditSyncGroupModal.tsx
+++ b/frontend/src/pages/Displays/SyncGroups/components/AddAndEditSyncGroupModal.tsx
@@ -19,6 +19,7 @@
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { isAxiosError } from 'axios';
 import { useEffect, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -140,9 +141,8 @@ export default function AddAndEditSyncGroupModal({
           onClose();
         }
       } catch (err: unknown) {
-        const apiErr = err as { response?: { data?: { message?: string } } };
-        if (apiErr.response?.data?.message) {
-          setApiError(apiErr.response.data.message);
+        if (isAxiosError(err) && err.response?.data?.message) {
+          setApiError(err.response.data.message);
         } else if (err instanceof Error) {
           setApiError(err.message);
         } else {

--- a/frontend/src/pages/Displays/SyncGroups/hooks/useSyncGroupActions.ts
+++ b/frontend/src/pages/Displays/SyncGroups/hooks/useSyncGroupActions.ts
@@ -72,13 +72,6 @@ export function useSyncGroupActions({
       setRowSelection({});
       handleRefresh();
       closeModal();
-    } catch (error) {
-      console.error(error);
-      const message =
-        isAxiosError(error) && error.response?.data?.message
-          ? error.response.data.message
-          : t('Some selected items cannot be deleted.');
-      setDeleteError(message);
     } finally {
       setIsDeleting(false);
     }

--- a/frontend/src/pages/Library/Dataset/components/AddAndEditDatasetModal.tsx
+++ b/frontend/src/pages/Library/Dataset/components/AddAndEditDatasetModal.tsx
@@ -19,6 +19,7 @@
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { isAxiosError } from 'axios';
 import { Check, Copy } from 'lucide-react';
 import { useEffect, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -260,8 +261,9 @@ export default function AddAndEditDatasetModal({
         onClose();
       } catch (err: unknown) {
         console.error('Failed to save Dataset:', err);
-        const apiError = err as { response?: { data?: { message?: string } } };
-        setApiError(apiError.response?.data?.message || t('An unexpected error occurred.'));
+        setApiError(
+          (isAxiosError(err) && err.response?.data?.message) || t('An unexpected error occurred.'),
+        );
       }
     });
   };

--- a/frontend/src/pages/Library/Dataset/hooks/useDatasetActions.ts
+++ b/frontend/src/pages/Library/Dataset/hooks/useDatasetActions.ts
@@ -82,13 +82,6 @@ export function useDatasetActions({
       setRowSelection({});
       handleRefresh();
       closeModal();
-    } catch (error) {
-      console.error(error);
-      const message =
-        isAxiosError(error) && error.response?.data?.message
-          ? error.response.data.message
-          : t('Some selected items could not be deleted.');
-      setDeleteError(message);
     } finally {
       setIsDeleting(false);
     }

--- a/frontend/src/pages/Library/Dataset/subPages/Columns/DatasetColumns.tsx
+++ b/frontend/src/pages/Library/Dataset/subPages/Columns/DatasetColumns.tsx
@@ -21,6 +21,7 @@
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import type { RowSelectionState } from '@tanstack/react-table';
+import { isAxiosError } from 'axios';
 import { Eye, Plus, Search, Slash, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -177,8 +178,9 @@ export default function DatasetColumns() {
       handleRefresh();
     },
     onError: (err: unknown) => {
-      const apiError = err as { response?: { data?: { message?: string } } };
-      setDeleteError(apiError.response?.data?.message || t('Failed to delete columns.'));
+      setDeleteError(
+        (isAxiosError(err) && err.response?.data?.message) || t('Failed to delete columns.'),
+      );
     },
   });
 

--- a/frontend/src/pages/Library/Dataset/subPages/Columns/components/AddAndEditDatasetColumnModal.tsx
+++ b/frontend/src/pages/Library/Dataset/subPages/Columns/components/AddAndEditDatasetColumnModal.tsx
@@ -19,6 +19,7 @@
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { isAxiosError } from 'axios';
 import { useEffect, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -162,8 +163,9 @@ export function AddAndEditDatasetColumnModal({
         onSave();
         onClose();
       } catch (err: unknown) {
-        const apiError = err as { response?: { data?: { message?: string } } };
-        setApiError(apiError.response?.data?.message || t('An unexpected error occurred.'));
+        setApiError(
+          (isAxiosError(err) && err.response?.data?.message) || t('An unexpected error occurred.'),
+        );
       }
     });
   };

--- a/frontend/src/pages/Library/Dataset/subPages/Data/DatasetData.tsx
+++ b/frontend/src/pages/Library/Dataset/subPages/Data/DatasetData.tsx
@@ -21,6 +21,7 @@
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import type { RowSelectionState } from '@tanstack/react-table';
+import { isAxiosError } from 'axios';
 import { Plus, Search, Slash, Table, Filter, FilterX } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -226,8 +227,9 @@ export default function DatasetData() {
       handleRefresh();
     },
     onError: (err: unknown) => {
-      const apiError = err as { response?: { data?: { message?: string } } };
-      setDeleteError(apiError.response?.data?.message || t('Failed to delete rows.'));
+      setDeleteError(
+        (isAxiosError(err) && err.response?.data?.message) || t('Failed to delete rows.'),
+      );
     },
   });
 

--- a/frontend/src/pages/Library/Dataset/subPages/Data/components/AddAndEditDatasetDataModal.tsx
+++ b/frontend/src/pages/Library/Dataset/subPages/Data/components/AddAndEditDatasetDataModal.tsx
@@ -19,6 +19,7 @@
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { isAxiosError } from 'axios';
 import { useEffect, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -136,9 +137,10 @@ export function AddAndEditDataModal({
         onSave();
         onClose();
       } catch (err: unknown) {
-        const error = err as { response?: { data?: { message?: string } }; message?: string };
         setApiError(
-          error.response?.data?.message || error.message || t('An unexpected error occurred.'),
+          (isAxiosError(err) && err.response?.data?.message) ||
+            (err instanceof Error && err.message) ||
+            t('An unexpected error occurred.'),
         );
       }
     });

--- a/frontend/src/pages/Library/Dataset/subPages/Rss/DatasetRss.tsx
+++ b/frontend/src/pages/Library/Dataset/subPages/Rss/DatasetRss.tsx
@@ -21,6 +21,7 @@
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import type { RowSelectionState } from '@tanstack/react-table';
+import { isAxiosError } from 'axios';
 import { Eye, Plus, Search, Slash, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -172,8 +173,9 @@ export default function DatasetRss() {
       handleRefresh();
     },
     onError: (err: unknown) => {
-      const apiError = err as { response?: { data?: { message?: string } } };
-      setDeleteError(apiError.response?.data?.message || t('Failed to delete RSS.'));
+      setDeleteError(
+        (isAxiosError(err) && err.response?.data?.message) || t('Failed to delete RSS.'),
+      );
     },
   });
 

--- a/frontend/src/pages/Library/Dataset/subPages/Rss/components/AddAndEditDatasetRssModal.tsx
+++ b/frontend/src/pages/Library/Dataset/subPages/Rss/components/AddAndEditDatasetRssModal.tsx
@@ -20,6 +20,7 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
+import { isAxiosError } from 'axios';
 import { Minus, Plus } from 'lucide-react';
 import { useEffect, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -265,8 +266,9 @@ export function AddAndEditDatasetRssModal({
         onSave();
         onClose();
       } catch (err: unknown) {
-        const apiErr = err as { response?: { data?: { message?: string } } };
-        setApiError(apiErr.response?.data?.message || t('An unexpected error occurred.'));
+        setApiError(
+          (isAxiosError(err) && err.response?.data?.message) || t('An unexpected error occurred.'),
+        );
       }
     });
   };

--- a/frontend/src/pages/Library/Media/components/EditMediaModal.tsx
+++ b/frontend/src/pages/Library/Media/components/EditMediaModal.tsx
@@ -19,6 +19,7 @@
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { isAxiosError } from 'axios';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -164,10 +165,8 @@ export default function EditMediaModal({
       onClose();
     } catch (err) {
       console.error('Failed to update media', err);
-      const apiError = err as { response?: { data?: { message?: string } } };
-
-      if (apiError.response?.data?.message) {
-        setApiError(apiError.response.data.message);
+      if (isAxiosError(err) && err.response?.data?.message) {
+        setApiError(err.response.data.message);
       } else if (err instanceof Error) {
         setApiError(err.message);
       } else {

--- a/frontend/src/pages/Library/Media/hooks/useMediaActions.ts
+++ b/frontend/src/pages/Library/Media/hooks/useMediaActions.ts
@@ -88,13 +88,6 @@ export function useMediaActions({
       setRowSelection({});
       handleRefresh();
       closeModal();
-    } catch (error) {
-      console.error(error);
-      const message =
-        isAxiosError(error) && error.response?.data?.message
-          ? error.response.data.message
-          : t('Some selected items could not be deleted.');
-      setDeleteError(message);
     } finally {
       setIsDeleting(false);
     }

--- a/frontend/src/pages/Library/MenuBoard/__tests__/AddAndEditMenuBoardModal.test.tsx
+++ b/frontend/src/pages/Library/MenuBoard/__tests__/AddAndEditMenuBoardModal.test.tsx
@@ -143,6 +143,7 @@ describe('AddAndEditMenuBoardModal', () => {
     it('displays API error message when createMenuBoard rejects', async () => {
       const user = userEvent.setup();
       mockCreateMenuBoard.mockRejectedValue({
+        isAxiosError: true,
         response: { data: { message: 'Server error from API' } },
       });
       renderAddModal();

--- a/frontend/src/pages/Library/MenuBoard/components/AddAndEditMenuBoardModal.tsx
+++ b/frontend/src/pages/Library/MenuBoard/components/AddAndEditMenuBoardModal.tsx
@@ -19,6 +19,7 @@
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { isAxiosError } from 'axios';
 import { useEffect, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -136,8 +137,9 @@ export default function AddAndEditMenuBoardModal({
         onSave();
         onClose();
       } catch (err: unknown) {
-        const axiosError = err as { response?: { data?: { message?: string } } };
-        setApiError(axiosError.response?.data?.message ?? t('An unexpected error occurred.'));
+        setApiError(
+          (isAxiosError(err) && err.response?.data?.message) || t('An unexpected error occurred.'),
+        );
       }
     });
   };

--- a/frontend/src/pages/Library/MenuBoard/hooks/useMenuBoardActions.ts
+++ b/frontend/src/pages/Library/MenuBoard/hooks/useMenuBoardActions.ts
@@ -78,13 +78,6 @@ export function useMenuBoardActions({
       setRowSelection({});
       handleRefresh();
       closeModal();
-    } catch (error) {
-      console.error(error);
-      const message =
-        isAxiosError(error) && error.response?.data?.message
-          ? error.response.data.message
-          : t('Some selected items could not be deleted.');
-      setDeleteError(message);
     } finally {
       setIsDeleting(false);
     }

--- a/frontend/src/pages/Library/MenuBoard/subPages/Categories/__tests__/AddAndEditMenuBoardCategoryModal.test.tsx
+++ b/frontend/src/pages/Library/MenuBoard/subPages/Categories/__tests__/AddAndEditMenuBoardCategoryModal.test.tsx
@@ -151,6 +151,7 @@ describe('AddAndEditMenuBoardCategoryModal', () => {
     it('displays API error message when createMenuBoardCategory rejects', async () => {
       const user = userEvent.setup();
       mockCreateMenuBoardCategory.mockRejectedValue({
+        isAxiosError: true,
         response: { data: { message: 'Permission denied' } },
       });
       renderAddModal();

--- a/frontend/src/pages/Library/MenuBoard/subPages/Categories/components/AddAndEditMenuBoardCategoryModal.tsx
+++ b/frontend/src/pages/Library/MenuBoard/subPages/Categories/components/AddAndEditMenuBoardCategoryModal.tsx
@@ -19,6 +19,7 @@
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { isAxiosError } from 'axios';
 import { useEffect, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -132,8 +133,9 @@ export default function AddAndEditMenuBoardCategoryModal({
         onSave();
         onClose();
       } catch (err: unknown) {
-        const axiosError = err as { response?: { data?: { message?: string } } };
-        setApiError(axiosError.response?.data?.message ?? t('An unexpected error occurred.'));
+        setApiError(
+          (isAxiosError(err) && err.response?.data?.message) || t('An unexpected error occurred.'),
+        );
       }
     });
   };

--- a/frontend/src/pages/Library/MenuBoard/subPages/Products/__tests__/AddAndEditMenuBoardProductModal.test.tsx
+++ b/frontend/src/pages/Library/MenuBoard/subPages/Products/__tests__/AddAndEditMenuBoardProductModal.test.tsx
@@ -181,6 +181,7 @@ describe('AddAndEditMenuBoardProductModal', () => {
     it('displays API error message when createMenuBoardProduct rejects', async () => {
       const user = userEvent.setup();
       mockCreateMenuBoardProduct.mockRejectedValue({
+        isAxiosError: true,
         response: { data: { message: 'Category not found' } },
       });
       renderAddModal();

--- a/frontend/src/pages/Library/MenuBoard/subPages/Products/components/AddAndEditMenuBoardProductModal.tsx
+++ b/frontend/src/pages/Library/MenuBoard/subPages/Products/components/AddAndEditMenuBoardProductModal.tsx
@@ -19,6 +19,7 @@
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { isAxiosError } from 'axios';
 import { Minus, Plus } from 'lucide-react';
 import { useEffect, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -218,8 +219,9 @@ export default function AddAndEditMenuBoardProductModal({
         onSave();
         onClose();
       } catch (err: unknown) {
-        const axiosError = err as { response?: { data?: { message?: string } } };
-        setApiError(axiosError.response?.data?.message ?? t('An unexpected error occurred.'));
+        setApiError(
+          (isAxiosError(err) && err.response?.data?.message) || t('An unexpected error occurred.'),
+        );
       }
     });
   };

--- a/frontend/src/pages/Library/Playlists/__tests__/Playlists.edit.form.test.tsx
+++ b/frontend/src/pages/Library/Playlists/__tests__/Playlists.edit.form.test.tsx
@@ -159,6 +159,7 @@ describe('Playlists page - edit form fields', () => {
   // ---------------------------------------------------------------------------
   test('Failed save keeps the modal open', async () => {
     vi.mocked(updatePlaylist).mockRejectedValueOnce({
+      isAxiosError: true,
       response: { data: { message: 'Playlist name already exists' } },
     });
 

--- a/frontend/src/pages/Library/Playlists/components/AddAndEditPlaylistModal.tsx
+++ b/frontend/src/pages/Library/Playlists/components/AddAndEditPlaylistModal.tsx
@@ -20,6 +20,7 @@
  */
 
 import type { ColumnDef, PaginationState, SortingState } from '@tanstack/react-table';
+import { isAxiosError } from 'axios';
 import { useEffect, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -237,10 +238,8 @@ export default function AddAndEditPlaylistModal({
       } catch (err: unknown) {
         console.error('Failed to save playlist:', err);
 
-        const apiError = err as { response?: { data?: { message?: string } } };
-
-        if (apiError.response?.data?.message) {
-          setApiError(apiError.response.data.message);
+        if (isAxiosError(err) && err.response?.data?.message) {
+          setApiError(err.response.data.message);
         } else if (err instanceof Error) {
           setApiError(err.message);
         } else {

--- a/frontend/src/pages/Library/Playlists/hooks/usePlaylistActions.ts
+++ b/frontend/src/pages/Library/Playlists/hooks/usePlaylistActions.ts
@@ -77,13 +77,6 @@ export function usePlaylistActions({
       setRowSelection({});
       handleRefresh();
       closeModal();
-    } catch (error) {
-      console.error(error);
-      const message =
-        isAxiosError(error) && error.response?.data?.message
-          ? error.response.data.message
-          : t('Some selected items could not be deleted.');
-      setDeleteError(message);
     } finally {
       setIsDeleting(false);
     }

--- a/frontend/src/pages/Schedule/Daypart/components/AddAndEditDaypartModal.tsx
+++ b/frontend/src/pages/Schedule/Daypart/components/AddAndEditDaypartModal.tsx
@@ -19,6 +19,7 @@
  * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { isAxiosError } from 'axios';
 import { Plus, Trash2 } from 'lucide-react';
 import { useEffect, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -192,10 +193,8 @@ export default function AddAndEditDaypartModal({
       } catch (err: unknown) {
         console.error('Failed to save daypart:', err);
 
-        const apiError = err as { response?: { data?: { message?: string } } };
-
-        if (apiError.response?.data?.message) {
-          setApiError(apiError.response.data.message);
+        if (isAxiosError(err) && err.response?.data?.message) {
+          setApiError(err.response.data.message);
         } else if (err instanceof Error) {
           setApiError(err.message);
         } else {

--- a/frontend/src/pages/Schedule/Daypart/hooks/useDaypartActions.ts
+++ b/frontend/src/pages/Schedule/Daypart/hooks/useDaypartActions.ts
@@ -72,13 +72,6 @@ export function useDaypartActions({
       setRowSelection({});
       handleRefresh();
       closeModal();
-    } catch (error) {
-      console.error(error);
-      const message =
-        isAxiosError(error) && error.response?.data?.message
-          ? error.response.data.message
-          : t('Some selected items could not be deleted.');
-      setDeleteError(message);
     } finally {
       setIsDeleting(false);
     }

--- a/frontend/src/pages/Schedule/Schedule/hooks/useEventActions.ts
+++ b/frontend/src/pages/Schedule/Schedule/hooks/useEventActions.ts
@@ -74,13 +74,6 @@ export function useEventActions({
       setRowSelection({});
       handleRefresh();
       closeModal();
-    } catch (error) {
-      console.error(error);
-      const message =
-        isAxiosError(error) && error.response?.data?.message
-          ? error.response.data.message
-          : t('Some selected items could not be deleted.');
-      setDeleteError(message);
     } finally {
       setIsDeleting(false);
     }


### PR DESCRIPTION
- Promise.allSettled never rejects, so catch blocks in confirmDelete/confirmLogout were dead code. Removed across all 15 action hooks

- Replaced unsafe `as { response?... }` error casts with `isAxiosError()` in 26 locations across modals and components.

- Removed two stray console.log statements from useLayoutActions and useTemplateActions.

- Updated 12 test files to mock Axios errors with isAxiosError: true so they  match the type guard.