### PR TITLE
Test Suite : ESLint should only run on develop.

### DIFF
--- a/.github/workflows/test-suite.yaml
+++ b/.github/workflows/test-suite.yaml
@@ -95,7 +95,8 @@ jobs:
 
   lint:
     name: Run ESLint
-    if: github.event.issue.pull_request && contains(github.event.comment.body, 'TEST:')
+    needs: check-base-branch
+    if: needs.check-base-branch.outputs.base_ref == 'develop'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
As the ESLint is configured to run on the `/frontend` folder, therefore it likely should only run on develop.

- Israt review request more so like a CC for awareness ;)