### PR TITLE
Fix clipped tag dropdown in filter form

### DIFF
--- a/web/theme/default/css/xibo.css
+++ b/web/theme/default/css/xibo.css
@@ -992,7 +992,7 @@ ul li.active.tab-design:hover a {
 }
 
 .XiboFilter .form-inline {
-    overflow: auto;
+    overflow: visible;
 }
 
 .XiboFilter .form-inline .form-group, .XiboFilterCustom .form-inline .form-group {


### PR DESCRIPTION
Fixes part of the tag filtering UI clipping issue reported in the Xibo Community forum:
https://community.xibo.org.uk/t/tag-input-and-dropdown-ui-elements-become-visually-clipped-in-cms-filtering-interface/37952 

This change updates the filter form overflow behavior so tag dropdown suggestions remain visible instead of being clipped by the filter container.

Tested locally using the Docker CMS setup by comparing the behavior before and after the CSS change.

Before: The dropdown menu was clipped, with no way for the user to see or access it:
<img width="866" height="410" alt="image" src="https://github.com/user-attachments/assets/db948489-a82e-451b-8545-198a084c81c5" />

After: The dropdown menu is easy to see now:
<img width="1040" height="376" alt="image" src="https://github.com/user-attachments/assets/be3cdac3-4e94-40b1-8a57-f4ae88d19be5" />

