### PR TITLE
Displays: fix issue when assigning displays

### DIFF
--- a/lib/Entity/Display.php
+++ b/lib/Entity/Display.php
@@ -568,10 +568,10 @@ class Display implements \JsonSerializable
         $log,
         $dispatcher,
         private readonly ConfigServiceInterface $config,
-        private readonly DisplayGroupFactory $displayGroupFactory,
-        private readonly DisplayProfileFactory $displayProfileFactory,
-        private readonly DisplayFactory $displayFactory,
-        private readonly FolderFactory $folderFactory
+        private readonly ?DisplayGroupFactory $displayGroupFactory,
+        private readonly ?DisplayProfileFactory $displayProfileFactory,
+        private readonly ?DisplayFactory $displayFactory,
+        private readonly ?FolderFactory $folderFactory
     ) {
         $this->setCommonDependencies($store, $log, $dispatcher);
         $this->excludeProperty('mediaInventoryXml');


### PR DESCRIPTION
### Backend Changes
**Fixed** 
- Make the other parameters nullable when assigning displays

Relates to https://github.com/xibosignageltd/xibo-private/issues/1536, https://github.com/xibosignageltd/xibo-private/issues/1537, https://github.com/xibosignageltd/xibo-private/issues/1538