### PR TITLE
Fix: update Developer link to target first child in Sidebar menu

### DIFF
--- a/frontend/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/frontend/src/components/layout/__tests__/Sidebar.test.tsx
@@ -158,10 +158,10 @@ describe('Sidebar Menu (The Navigation Bar)', () => {
       expect(link).toBeVisible();
     });
 
-    // Developer is a top-level external link (no subLinks) — always visible, not expandable.
+    // Developer is now a submenu parent; its link targets the first child (Module Templates).
     expect(screen.getByRole('link', { name: /developer/i })).toHaveAttribute(
       'href',
-      '/developer/template/view',
+      '/developer/template',
     );
 
     // Displays > Display Settings and Administration > Settings are both React Router links.

--- a/frontend/src/pages/Library/Media/__tests__/Media.filters.test.tsx
+++ b/frontend/src/pages/Library/Media/__tests__/Media.filters.test.tsx
@@ -360,7 +360,10 @@ describe('Reset Behavior', () => {
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Reset' })).toBeInTheDocument();
     });
-  });
+    // Bumped from the 5s default: this test passes in ~3s in isolation but races on
+    // JSDOM under the full parallel suite and intermittently exceeds 5s. See the
+    // frontend-testing notes on JSDOM contention before removing this.
+  }, 20_000);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fix for outdated sidebar link