### PR TITLE
Display: fixed unable to move displays in a different folder

### DIFF
--- a/frontend/src/pages/Displays/Displays/hooks/useDisplaysActions.ts
+++ b/frontend/src/pages/Displays/Displays/hooks/useDisplaysActions.ts
@@ -109,7 +109,7 @@ export function useDisplaysActions({
       const movePromises = itemsToMove.map((item) =>
         selectFolder({
           folderId: newFolderId,
-          targetId: item.displayId,
+          targetId: item.displayGroupId,
           targetType: 'displaygroup',
         }),
       );


### PR DESCRIPTION
### Frontend Changes

- Use `displayGroupId` (based on the previous implementation) when moving displays instead of the `displayId` 

-------
Relates to https://github.com/xibosignageltd/xibo-private/issues/1468