### PR TITLE
Editor: wrap and migrate to React

### DIFF
--- a/frontend/src/components/editor/EditorHost.tsx
+++ b/frontend/src/components/editor/EditorHost.tsx
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Loader2 } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import type { NavigateFunction } from 'react-router-dom';
+
+interface EditorHostProps {
+  id: string;
+  editorBasePath: string;
+  stayPathPrefix: string;
+  returnPath?: string;
+  onExit?: () => void;
+  title: string;
+  forwardQuery?: string;
+  readySelector?: string;
+}
+
+const READY_TIMEOUT_MS = 8000;
+const READY_POLL_MS = 80;
+
+function leaveEditor(
+  navigate: NavigateFunction,
+  returnPath: string | undefined,
+  onExit: (() => void) | undefined,
+) {
+  if (onExit) {
+    onExit();
+    return;
+  }
+
+  if (returnPath) {
+    navigate(returnPath);
+  }
+}
+
+export default function EditorHost({
+  id,
+  editorBasePath,
+  stayPathPrefix,
+  returnPath,
+  onExit,
+  title,
+  forwardQuery,
+  readySelector,
+}: EditorHostProps) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  const pollRef = useRef<number | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const exit = () => leaveEditor(navigate, returnPath, onExit);
+
+  useEffect(() => {
+    const onMessage = (event: MessageEvent) => {
+      if (event.origin !== window.location.origin) {
+        return;
+      }
+
+      if (event.data?.type === 'xibo:editor-exit') {
+        leaveEditor(navigate, returnPath, onExit);
+      }
+    };
+
+    window.addEventListener('message', onMessage);
+    return () => window.removeEventListener('message', onMessage);
+  }, [navigate, returnPath, onExit]);
+
+  useEffect(() => {
+    return () => {
+      if (pollRef.current !== null) {
+        window.clearInterval(pollRef.current);
+      }
+    };
+  }, []);
+
+  const handleLoad = () => {
+    const frame = iframeRef.current;
+    if (!frame) {
+      return;
+    }
+
+    try {
+      const path = frame.contentWindow?.location.pathname ?? '';
+      if (path && !path.startsWith(stayPathPrefix)) {
+        exit();
+        return;
+      }
+    } catch {
+      // Ignore
+    }
+
+    frame.focus();
+
+    if (!readySelector) {
+      setLoading(false);
+      return;
+    }
+
+    let elapsed = 0;
+    if (pollRef.current !== null) {
+      window.clearInterval(pollRef.current);
+    }
+    pollRef.current = window.setInterval(() => {
+      elapsed += READY_POLL_MS;
+      let ready = elapsed >= READY_TIMEOUT_MS;
+      try {
+        const root = frame.contentWindow?.document.querySelector(readySelector);
+        ready = ready || !root || root.childElementCount > 0;
+      } catch {
+        ready = true;
+      }
+
+      if (ready) {
+        if (pollRef.current !== null) {
+          window.clearInterval(pollRef.current);
+          pollRef.current = null;
+        }
+        setLoading(false);
+      }
+    }, READY_POLL_MS);
+  };
+
+  const src = `${editorBasePath}/${id}?embed=1${forwardQuery ? `&${forwardQuery}` : ''}`;
+
+  return (
+    <div className="relative h-screen w-full">
+      {loading && (
+        <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-3 bg-white/80">
+          <Loader2 className="h-10 w-10 animate-spin text-gray-400" />
+          <span className="text-sm font-medium text-gray-500">{t('Loading editor…')}</span>
+        </div>
+      )}
+
+      <iframe
+        ref={iframeRef}
+        src={src}
+        title={title}
+        className="h-full w-full border-0"
+        onLoad={handleLoad}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/ui/modals/UsageReportModal.tsx
+++ b/frontend/src/components/ui/modals/UsageReportModal.tsx
@@ -24,6 +24,8 @@ import type { TFunction } from 'i18next';
 import { Palette, Eye } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useLocation, useNavigate } from 'react-router-dom';
+import type { NavigateFunction } from 'react-router-dom';
 
 import DatePickerInput from '@/components/ui/forms/DatePickerInput';
 import Modal from '@/components/ui/modals/Modal';
@@ -74,7 +76,11 @@ const getDisplaysColumns = (t: TFunction): ColumnDef<Display>[] => [
   },
 ];
 
-const getLayoutsColumns = (t: TFunction): ColumnDef<Layout>[] => [
+const getLayoutsColumns = (
+  t: TFunction,
+  navigate: NavigateFunction,
+  from: string,
+): ColumnDef<Layout>[] => [
   {
     accessorKey: 'layoutId',
     header: t('ID'),
@@ -117,7 +123,8 @@ const getLayoutsColumns = (t: TFunction): ColumnDef<Layout>[] => [
                     label: t('Design'),
                     icon: Palette,
                     isQuickAction: true,
-                    onClick: () => window.open(`/layout/designer/${row.layoutId}`, '_blank'),
+                    onClick: () =>
+                      navigate(`/design/layout/${row.layoutId}/editor`, { state: { from } }),
                   } as const,
                 ]
               : []),
@@ -147,6 +154,8 @@ export default function UsageReportModal({
   onClose,
 }: UsageReportModalProps) {
   const { t } = useTranslation();
+  const navigate = useNavigate();
+  const location = useLocation();
 
   const [activeTab, setActiveTab] = useState<Tab>('displays');
 
@@ -236,7 +245,7 @@ export default function UsageReportModal({
   }, [entityId, entityType, activeTab]);
 
   const displaysColumns = getDisplaysColumns(t);
-  const layoutsColumns = getLayoutsColumns(t);
+  const layoutsColumns = getLayoutsColumns(t, navigate, `${location.pathname}${location.search}`);
 
   const tabs: { key: Tab; label: string }[] = [
     { key: 'displays', label: t('Displays') },

--- a/frontend/src/pages/Design/Layouts/LayoutEditorHost.tsx
+++ b/frontend/src/pages/Design/Layouts/LayoutEditorHost.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useTranslation } from 'react-i18next';
+import { Navigate, useLocation, useParams, useSearchParams } from 'react-router-dom';
+
+import EditorHost from '@/components/editor/EditorHost';
+
+export default function LayoutEditorHost() {
+  const { t } = useTranslation();
+  const { id } = useParams<{ id: string }>();
+  const [searchParams] = useSearchParams();
+  const location = useLocation();
+  const isTemplateEditor = searchParams.get('isTemplateEditor') === '1';
+
+  const from = (location.state as { from?: string } | null)?.from;
+  const returnPath = from ?? (isTemplateEditor ? '/design/templates' : '/design/layout');
+
+  if (!id) {
+    return <Navigate to="/design/layout" replace />;
+  }
+
+  return (
+    <EditorHost
+      id={id}
+      editorBasePath="/layout/designer"
+      stayPathPrefix="/layout/designer"
+      returnPath={returnPath}
+      forwardQuery={isTemplateEditor ? 'isTemplateEditor=1' : undefined}
+      title={isTemplateEditor ? t('Template Editor') : t('Layout Editor')}
+      readySelector="#layout-editor"
+    />
+  );
+}

--- a/frontend/src/pages/Design/Layouts/hooks/useLayoutActions.ts
+++ b/frontend/src/pages/Design/Layouts/hooks/useLayoutActions.ts
@@ -179,7 +179,7 @@ export function useLayoutActions({
         throw new Error('Invalid layout response');
       }
 
-      window.open(`/layout/designer/${newLayout.layoutId}`, '_blank', 'noopener,noreferrer');
+      navigate(`/design/layout/${newLayout.layoutId}/editor`);
     } catch (error) {
       console.error(error);
       notify.error(t('Failed to create layout'));
@@ -187,7 +187,7 @@ export function useLayoutActions({
   };
 
   const handleOpenLayout = (layoutId: number) => {
-    window.open(`/layout/designer/${layoutId}`, '_blank');
+    navigate(`/design/layout/${layoutId}/editor`);
   };
 
   const handleCheckoutLayout = async (layoutId: number) => {
@@ -196,9 +196,9 @@ export function useLayoutActions({
     try {
       await checkoutLayout(layoutId);
 
-      window.open(`/layout/designer/${layoutId}`, '_blank');
-
       notify.success(t('Layout checked out successfully'));
+
+      navigate(`/design/layout/${layoutId}/editor`);
     } catch (error) {
       console.error(error);
       notify.error(t('Failed to checkout layout'));

--- a/frontend/src/pages/Design/Templates/hooks/useTemplateActions.ts
+++ b/frontend/src/pages/Design/Templates/hooks/useTemplateActions.ts
@@ -24,6 +24,7 @@ import { isAxiosError } from 'axios';
 import type { TFunction } from 'i18next';
 import type { Dispatch, SetStateAction } from 'react';
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import { notify } from '@/components/ui/Notification';
 import type { PublishValue } from '@/components/ui/forms/PublishDateSelect';
@@ -61,6 +62,7 @@ export function useTemplateActions({
   const [isPublishing, setIsPublishing] = useState(false);
   const [isDiscarding, setIsDiscarding] = useState(false);
   const [isExporting, setIsExporting] = useState(false);
+  const navigate = useNavigate();
 
   const confirmDelete = async (itemsToDelete: Template[]) => {
     if (itemsToDelete.length === 0 || isDeleting) {
@@ -263,7 +265,7 @@ export function useTemplateActions({
   };
 
   const handleAlterTemplate = (layoutId: number) => {
-    window.open(`/layout/designer/${layoutId}?isTemplateEditor=1`, '_blank');
+    navigate(`/design/layout/${layoutId}/editor?isTemplateEditor=1`);
   };
 
   return {

--- a/frontend/src/pages/Library/Playlists/Playlists.tsx
+++ b/frontend/src/pages/Library/Playlists/Playlists.tsx
@@ -33,6 +33,7 @@ import {
   INITIAL_FILTER_STATE,
   type PlaylistFilterInput,
 } from './PlaylistsConfig';
+import PlaylistEditorOverlay from './components/PlaylistEditorOverlay';
 import { PlaylistModals } from './components/PlaylistModals';
 import { usePlaylistActions } from './hooks/usePlaylistActions';
 import { usePlaylistData } from './hooks/usePlaylistData';
@@ -126,6 +127,7 @@ export default function Playlist() {
   const [itemsToMove, setItemsToMove] = useState<Playlist[]>([]);
   const [shareEntityIds, setShareEntityIds] = useState<number | number[] | null>(null);
   const [selectedPlaylistId, setSelectedPlaylistId] = useState<number | null>(null);
+  const [timelinePlaylistId, setTimelinePlaylistId] = useState<number | null>(null);
 
   const openModal = (name: ModalType) => setActiveModal(name);
   const closeModal = () => setActiveModal(null);
@@ -244,7 +246,7 @@ export default function Playlist() {
   };
 
   const handleOpenTimeline = (playlistId: number) => {
-    window.open(`/playlist/designer/${playlistId}`, '_blank');
+    setTimelinePlaylistId(playlistId);
   };
 
   const handleResetFilters = () => {
@@ -467,8 +469,19 @@ export default function Playlist() {
           handleConfirmEnableStats: (value) =>
             selectedPlaylist && handleConfirmEnableStats(selectedPlaylist, value),
         }}
+        openTimeline={handleOpenTimeline}
         folderActions={folderActions}
       />
+
+      {timelinePlaylistId != null && (
+        <PlaylistEditorOverlay
+          playlistId={timelinePlaylistId}
+          onClose={() => {
+            setTimelinePlaylistId(null);
+            handleRefresh();
+          }}
+        />
+      )}
     </section>
   );
 }

--- a/frontend/src/pages/Library/Playlists/__tests__/Playlists.timeline.test.tsx
+++ b/frontend/src/pages/Library/Playlists/__tests__/Playlists.timeline.test.tsx
@@ -41,6 +41,12 @@ import type { Playlist } from '@/types/playlist';
 // Module mocks
 // =============================================================================
 
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...(actual as object), useNavigate: () => mockNavigate };
+});
+
 vi.mock('@/services/folderApi');
 vi.mock('@/services/playlistApi');
 vi.mock('@/services/userApi', () => ({
@@ -115,7 +121,6 @@ describe('Playlists page - Timeline action', () => {
     vi.clearAllMocks();
     vi.mocked(usePlaylistActions).mockReturnValue(defaultPlaylistActions());
     mockFetchPlaylists(SINGLE_PLAYLIST);
-    vi.spyOn(window, 'open').mockImplementation(() => null);
   });
 
   // ---------------------------------------------------------------------------
@@ -130,14 +135,14 @@ describe('Playlists page - Timeline action', () => {
     expect(screen.getByTitle('Timeline')).toBeInTheDocument();
   });
 
-  test('Clicking the quick action Timeline button calls window.open with the designer URL and _blank target', async () => {
+  test('Clicking the quick action Timeline button opens the playlist editor overlay', async () => {
     renderPlaylistsPage();
 
     await screen.findByText(mockPlaylist.name);
     fireEvent.click(screen.getByTitle('Timeline'));
 
-    expect(window.open).toHaveBeenCalledOnce();
-    expect(window.open).toHaveBeenCalledWith('/playlist/designer/101', '_blank');
+    const frame = await screen.findByTitle('Playlist Editor');
+    expect(frame.getAttribute('src')).toContain('/playlist/designer/101');
   });
 
   test('Clicking the quick action Timeline button does not open any modal dialog', async () => {
@@ -164,13 +169,13 @@ describe('Playlists page - Timeline action', () => {
     expect(timelineButtons.length).toBeGreaterThanOrEqual(2);
   });
 
-  test('Clicking the dropdown Timeline item calls window.open with the designer URL', async () => {
+  test('Clicking the dropdown Timeline item opens the playlist editor overlay', async () => {
     renderPlaylistsPage();
 
     await openDropdownTimeline();
 
-    expect(window.open).toHaveBeenCalledOnce();
-    expect(window.open).toHaveBeenCalledWith('/playlist/designer/101', '_blank');
+    const frame = await screen.findByTitle('Playlist Editor');
+    expect(frame.getAttribute('src')).toContain('/playlist/designer/101');
   });
 
   test('Clicking the dropdown Timeline item does not open any modal dialog', async () => {
@@ -182,22 +187,20 @@ describe('Playlists page - Timeline action', () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Section 3 — URL Construction
+  // Section 3 — Editor target
   // ---------------------------------------------------------------------------
 
-  test('Timeline URL includes the correct playlistId from the row', async () => {
+  test('Timeline overlay targets the correct playlistId from the row', async () => {
     renderPlaylistsPage();
 
     await screen.findByText(mockPlaylist.name);
     fireEvent.click(screen.getByTitle('Timeline'));
 
-    expect(window.open).toHaveBeenCalledWith(
-      `/playlist/designer/${mockPlaylist.playlistId}`,
-      '_blank',
-    );
+    const frame = await screen.findByTitle('Playlist Editor');
+    expect(frame.getAttribute('src')).toContain(`/playlist/designer/${mockPlaylist.playlistId}`);
   });
 
-  test('Different playlists produce different timeline URLs', async () => {
+  test('Different playlists produce different timeline targets', async () => {
     mockFetchPlaylists(TWO_PLAYLISTS);
     renderPlaylistsPage();
 
@@ -205,7 +208,8 @@ describe('Playlists page - Timeline action', () => {
     const secondRow = screen.getByText('Second Playlist').closest('tr') as HTMLElement;
     fireEvent.click(within(secondRow).getByTitle('Timeline'));
 
-    expect(window.open).toHaveBeenCalledWith('/playlist/designer/202', '_blank');
+    const frame = await screen.findByTitle('Playlist Editor');
+    expect(frame.getAttribute('src')).toContain('/playlist/designer/202');
   });
 
   // ---------------------------------------------------------------------------

--- a/frontend/src/pages/Library/Playlists/components/PlaylistEditorOverlay.tsx
+++ b/frontend/src/pages/Library/Playlists/components/PlaylistEditorOverlay.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { useTranslation } from 'react-i18next';
+
+import EditorHost from '@/components/editor/EditorHost';
+
+interface PlaylistEditorOverlayProps {
+  playlistId: number;
+  onClose: () => void;
+}
+
+export default function PlaylistEditorOverlay({ playlistId, onClose }: PlaylistEditorOverlayProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="fixed inset-0 z-50 bg-white/10">
+      <EditorHost
+        id={String(playlistId)}
+        editorBasePath="/playlist/designer"
+        stayPathPrefix="/playlist/designer"
+        title={t('Playlist Editor')}
+        onExit={onClose}
+        readySelector="#playlist-editor"
+      />
+    </div>
+  );
+}

--- a/frontend/src/pages/Library/Playlists/components/PlaylistModals.tsx
+++ b/frontend/src/pages/Library/Playlists/components/PlaylistModals.tsx
@@ -61,6 +61,7 @@ interface PlaylistModalsProps {
     handleConfirmMove: (folderId: number) => void;
     handleConfirmEnableStats: (value: string) => void;
   };
+  openTimeline: (playlistId: number) => void;
   folderActions: ReturnType<typeof useFolderActions>;
 }
 
@@ -68,6 +69,7 @@ export function PlaylistModals({
   actions,
   selection,
   handlers,
+  openTimeline,
   folderActions,
 }: PlaylistModalsProps) {
   const { t } = useTranslation();
@@ -83,8 +85,12 @@ export function PlaylistModals({
             actions.closeModal();
           }}
           data={selection.selectedPlaylist}
-          onSave={() => {
+          onSave={(saved) => {
             actions.handleRefresh();
+            // After creating a new (non-dynamic) playlist, jump to the Timeline editor
+            if (!selection.selectedPlaylistId && !saved.isDynamic) {
+              openTimeline(saved.playlistId);
+            }
           }}
         />
       )}

--- a/frontend/src/pages/Schedule/Schedule/components/AgendaModal.tsx
+++ b/frontend/src/pages/Schedule/Schedule/components/AgendaModal.tsx
@@ -46,6 +46,7 @@ import { useEffect, useId, useRef, useState } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { useTranslation } from 'react-i18next';
 import { MapContainer, Marker, TileLayer, useMap, useMapEvents } from 'react-leaflet';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { twMerge } from 'tailwind-merge';
 
 import { agendaQueryKeys, useAgendaData } from '../hooks/useAgendaData';
@@ -519,6 +520,8 @@ interface BreadcrumbPanelProps {
 
 function BreadcrumbPanel({ row, data, selectedGroupId, onEdit }: BreadcrumbPanelProps) {
   const { t } = useTranslation();
+  const navigate = useNavigate();
+  const location = useLocation();
   const event = data.events.find(
     (ev) => ev.layoutId === row.layoutId && ev.eventId === row.eventId,
   );
@@ -556,14 +559,17 @@ function BreadcrumbPanel({ row, data, selectedGroupId, onEdit }: BreadcrumbPanel
   return (
     <div className="rounded-lg px-4 py-3 text-sm text-gray-500 font-semibold flex flex-wrap items-center gap-y-1">
       {showLayoutLink ? (
-        <a
-          href={`/layout/designer/${layout.layoutId}`}
+        <button
+          type="button"
+          onClick={() =>
+            navigate(`/design/layout/${layout.layoutId}/editor`, {
+              state: { from: `${location.pathname}${location.search}` },
+            })
+          }
           className="px-3 py-2 text-xibo-blue-600 cursor-pointer hover:underline"
-          target="_blank"
-          rel="noreferrer"
         >
           {layoutName}
-        </a>
+        </button>
       ) : (
         <span className="px-3 py-2">{layoutName}</span>
       )}

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -81,6 +81,15 @@ export const router = createBrowserRouter(
       ],
     },
     {
+      path: 'design/layout/:id/editor',
+      loader: requireAuthLoader,
+      hydrateFallbackElement: <></>,
+      lazy: () =>
+        import('@/pages/Design/Layouts/LayoutEditorHost').then((m) => ({
+          Component: m.default,
+        })),
+    },
+    {
       path: 'login',
       loader: () => {
         // Force to go to server login page

--- a/lib/Controller/User.php
+++ b/lib/Controller/User.php
@@ -1696,7 +1696,7 @@ class User extends Base
         $permissions = $this->permissionFactory->getAllByObjectId($this->getUser(), $object->permissionsClass(), $id);
 
         // Get the provided permissions
-        $groupIds = $sanitizedParams->getArray('groupIds');
+        $groupIds = $sanitizedParams->getArray('groupIds', ['default' => []]);
 
         // Run the update
         $this->updatePermissions($permissions, $groupIds);

--- a/ui/src/editor-core/common.js
+++ b/ui/src/editor-core/common.js
@@ -12,17 +12,16 @@ module.exports = {
      * @param {string} cloneName - Screen tag
      */
   showLoadingScreen: function() {
-    let bumpVal = $('.loading-overlay.loading').data('bump') || 0;
-    bumpVal++;
+    const $overlay = $('.loading-overlay');
+    const bumpVal = ($overlay.data('bump') || 0) + 1;
+    $overlay.data('bump', bumpVal);
 
-    if (bumpVal <= 1) {
-      $('.loading-overlay').addClass('loading').fadeIn(400);
+    if (bumpVal === 1) {
+      $overlay.addClass('loading').stop(true).fadeIn(400);
       // TODO: Alert message disabled for now
       // it clashes with the user timeout
       // window.onbeforeunload = () => editorsTrans.onbeforeunload;
     }
-
-    $('.loading-overlay').data('bump', bumpVal++);
   },
 
   /**
@@ -30,19 +29,18 @@ module.exports = {
      * @param {string} cloneName - Screen tag
      */
   hideLoadingScreen: function() {
-    let bumpVal = $('.loading-overlay.loading').data('bump') || 1;
-    bumpVal--;
+    const $overlay = $('.loading-overlay');
+    const bumpVal = Math.max(0, ($overlay.data('bump') || 1) - 1);
+    $overlay.data('bump', bumpVal);
 
-    if (bumpVal <= 0) {
-      $('.loading-overlay.loading').fadeOut(400, function(el) {
-        $(el).removeClass('loading');
+    if (bumpVal === 0) {
+      $overlay.stop(true).fadeOut(400, function() {
+        $('.loading-overlay').removeClass('loading');
         // TODO: Alert message disabled for now
         // it clashes with the user timeout
         // window.onbeforeunload = null;
       });
     }
-
-    $('.loading-overlay').data('bump', bumpVal);
   },
 
   /**

--- a/ui/src/editor-core/history-manager.js
+++ b/ui/src/editor-core/history-manager.js
@@ -237,7 +237,7 @@ HistoryManager.prototype.uploadChange = function(
       type: linkToAPI.type,
       data: change.newState,
     }).done(function(data) {
-      if (data.success) {
+      if (!data || data.success) {
         change.uploaded = true;
         change.uploading = false;
 

--- a/ui/src/layout-editor/main.js
+++ b/ui/src/layout-editor/main.js
@@ -5975,6 +5975,9 @@ lD.handleInputs = function() {
         handler.metaKey
       );
 
+      const typingInField = $(handler.target).is(
+        'input, textarea, select, [contenteditable="true"]');
+
       if ($(handler.target).is($('body'))) {
         // Delete ( Del or Backspace )
         if (
@@ -5995,15 +5998,6 @@ lD.handleInputs = function() {
           }, 500);
         }
 
-        // Undo ( Ctrl + Z )
-        if (
-          handler.code == 'KeyZ' &&
-          controlOrCommandPressed &&
-          allowInputs
-        ) {
-          lD.undoLastAction();
-        }
-
         // Duplicate selected object ( Shift + D )
         if (
           handler.code == 'KeyD' &&
@@ -6012,6 +6006,16 @@ lD.handleInputs = function() {
         ) {
           lD.duplicateSelectedObject();
         }
+      }
+
+      if (
+        handler.code == 'KeyZ' &&
+        controlOrCommandPressed &&
+        allowInputs &&
+        !typingInField
+      ) {
+        handler.preventDefault();
+        lD.undoLastAction();
       }
     });
 };

--- a/ui/src/playlist-editor/main.js
+++ b/ui/src/playlist-editor/main.js
@@ -1411,6 +1411,9 @@ pE.handleKeyInputs = function() {
         handler.metaKey
       );
 
+      const typingInField = $(handler.target).is(
+        'input, textarea, select, [contenteditable="true"]');
+
       if ($(handler.target).is($('body'))) {
         // Delete
         if (
@@ -1421,15 +1424,16 @@ pE.handleKeyInputs = function() {
         ) {
           pE.deleteSelectedObject();
         }
+      }
 
-        // Undo
-        if (
-          handler.code == 'KeyZ' &&
-          controlOrCommandPressed &&
-          allowInputs
-        ) {
-          pE.undoLastAction();
-        }
+      if (
+        handler.code == 'KeyZ' &&
+        controlOrCommandPressed &&
+        allowInputs &&
+        !typingInField
+      ) {
+        handler.preventDefault();
+        pE.undoLastAction();
       }
     });
 };

--- a/ui/src/style/topbar.scss
+++ b/ui/src/style/topbar.scss
@@ -133,11 +133,9 @@
     .layout-action-menu {
         margin: 0;
         padding: 0;
-        // Fix position for now
         position: fixed;
         top: 0;
-        right: 114px;
-        // Fix position for now
+        right: 12px;
 
         #layoutJumpListContainer {
             min-width: 120px;

--- a/ui/src/style/variables.scss
+++ b/ui/src/style/variables.scss
@@ -1,35 +1,37 @@
 // Global SASS variables 
 
 // COLOURS
-$xibo-color-primary: #1775F6;
+// Primary aligned to the React app palette (--brand-primary #0e70f6 ⇒ xibo-blue-600).
+// Variant hexes are the oklch-derived xibo-blue scale used in frontend/src/styles/global.css.
+$xibo-color-primary: #0e70f6;       // xibo-blue-600
 $xibo-color-secondary: #121A5E;
 $xibo-color-tertiary: #15D5CB;
-$xibo-color-accent: #EB7857;
+$xibo-color-accent: #EB7857;        // matches React --brand-accent
 
-//  Variants
-$xibo-color-primary-d60: #0E4694;
-$xibo-color-primary-d40: #125ABF;
-$xibo-color-primary-l60: #74ACFA;
-$xibo-color-primary-l30: #B9D6FC;
-$xibo-color-primary-l20: #dcedff;
-$xibo-color-primary-l10: #E8F1FE;
-$xibo-color-primary-l5: #F3F8FF;
+//  Variants (light → dark, mapped to the xibo-blue scale)
+$xibo-color-primary-d60: #00378e;   // xibo-blue-800
+$xibo-color-primary-d40: #0059d3;   // xibo-blue-700
+$xibo-color-primary-l60: #77acfe;   // xibo-blue-300
+$xibo-color-primary-l30: #99c1fe;   // xibo-blue-200
+$xibo-color-primary-l20: #d5e6ff;   // light tint (≈ original brightness, new hue)
+$xibo-color-primary-l10: #e4efff;   // xibo-blue-50
+$xibo-color-primary-l5: #f0f6ff;    // slightly lighter than xibo-blue-50
 
-//  Neutral
+//  Neutral (retuned toward the React/Tailwind grey scale)
 $xibo-color-neutral-0: #fff;
-$xibo-color-neutral-100: #FCFCFC;
-$xibo-color-neutral-300: #E9E9E9;
-$xibo-color-neutral-500: #CECECE;
-$xibo-color-neutral-600: #CCC;
-$xibo-color-neutral-700: #898989;
-$xibo-color-neutral-900: #333333;
+$xibo-color-neutral-100: #f9fafb;   // gray-50
+$xibo-color-neutral-300: #e5e7eb;   // gray-200
+$xibo-color-neutral-500: #d1d5db;   // gray-300
+$xibo-color-neutral-600: #d1d5db;   // gray-300
+$xibo-color-neutral-700: #828998;   // cool grey, lightness-matched to original #898989
+$xibo-color-neutral-900: #1f2937;   // gray-800
 $xibo-color-neutral-1000: #000000;
 
-// Semantic
-$xibo-color-semantic-error: #BF5555;
-$xibo-color-semantic-success: #3E9A42;
-$xibo-color-semantic-warning: #D4D74E;
-$xibo-color-semantic-info: #5593BF;
+// Semantic (React/Tailwind equivalents)
+$xibo-color-semantic-error: #dc2626;    // red-600
+$xibo-color-semantic-success: #0d9488;  // teal-600
+$xibo-color-semantic-warning: #fdc533;  // amber, lightness-matched to original #D4D74E
+$xibo-color-semantic-info: #4087fc;     // blue, lightness-matched to original #5593BF
 
 // Overlay
 $xibo-color-overlay: rgba(0, 0, 0, 0.6);

--- a/views/layout-designer-page.twig
+++ b/views/layout-designer-page.twig
@@ -27,6 +27,7 @@
 {% block title %}{{ "Layout Editor"|trans }} | {% endblock %}
 
 {% set hideNavigation = "1" %}
+{% set forceHide = true %}
 
 {% block pageContent %}
 

--- a/views/playlist-designer-page.twig
+++ b/views/playlist-designer-page.twig
@@ -27,17 +27,10 @@
 {% block title %}{{ "Playlist Editor"|trans }} | {% endblock %}
 
 {% set hideNavigation = "1" %}
+{% set forceHide = true %}
 
 {% block pageContent %}
 
-    {# Mirrors the DOM structure that playlist-form-timeline.twig provides when
-       loaded into a Bootstrap modal, which pE.loadEditor() depends on:
-       - #editor-container  (close-button lookup + external playlist message)
-       - .editor-modal      (help-pane reparenting + close-button lookup)
-       - .editor-modal-header .modal-header--left  (help-pane anchor)
-       - .container-designer  (toolbar, properties-panel, topbar lookups)
-       - .editor-top-bar      (populated by topbar template in pE.loadEditor)
-    #}
     <div id="editor-container">
         <div class="modal editor-modal">
             <div class="modal-dialog editor-modal-dialog">
@@ -83,7 +76,14 @@
                 const _originalClose = pE.close.bind(pE);
                 pE.close = function() {
                     _originalClose();
-                    window.close();
+                    if (window.parent !== window) {
+                        window.parent.postMessage(
+                            {type: 'xibo:editor-exit'},
+                            window.location.origin
+                        );
+                    } else {
+                        window.close();
+                    }
                 };
             });
         </script>


### PR DESCRIPTION
relates to xibosignageltd/xibo-private#1569
relates to xibosignageltd/xibo-private#1570

- Fix stuck loading overlay: history-manager now treats 204 No Content as success
- Rework common.js loading counter: stable selector, fix post-increment bug, use .stop(true)
- Fix Ctrl+Z undo in both editors: fires from canvas, skips input fields, preventDefault
- Fix 500 on saving empty permissions: default groupIds to []
- Post xibo:editor-exit to parent on playlist close when framed, else window.close()
- forceHide legacy user-menu/notification chrome while embedded
- Realign legacy editor SASS palette to React app (primary, neutrals, semantics)
- Reposition .layout-action-menu (right 114px → 12px) for hidden topbar chrome