### PR TITLE
Logs: fixed message overflow in logs page

### DIFF
--- a/frontend/src/components/ui/table/cells/TextCell.tsx
+++ b/frontend/src/components/ui/table/cells/TextCell.tsx
@@ -26,6 +26,7 @@ interface TextProps extends React.HTMLAttributes<HTMLDivElement> {
   subtext?: string;
   weight?: 'normal' | 'bold';
   truncate?: boolean;
+  wrap?: boolean;
   className?: string;
 }
 
@@ -35,12 +36,13 @@ export function TextCell({
   className = '',
   weight = 'normal',
   truncate = false,
+  wrap = false,
   ...props
 }: TextProps) {
   return (
     <div className={`flex items-center w-full min-w-0 gap-2 ${className}`} {...props}>
       <span
-        className={`text-gray-800 text-sm ${truncate ? 'truncate' : ''} ${weight === 'bold' ? 'font-semibold' : ''}`}
+        className={`text-gray-800 text-sm ${truncate ? 'truncate' : ''} ${wrap ? 'min-w-0 break-words whitespace-normal' : ''} ${weight === 'bold' ? 'font-semibold' : ''}`}
       >
         {children}
       </span>

--- a/frontend/src/pages/Advanced/Logs/LogsConfig.tsx
+++ b/frontend/src/pages/Advanced/Logs/LogsConfig.tsx
@@ -219,6 +219,6 @@ export const getLogsColumns = (t: TFunction): ColumnDef<LogEntry>[] => [
     accessorKey: 'message',
     header: t('Message'),
     size: 300,
-    cell: (info) => <TextCell>{decodeHtmlEntities(info.getValue<string>())}</TextCell>,
+    cell: (info) => <TextCell wrap>{decodeHtmlEntities(info.getValue<string>())}</TextCell>,
   },
 ];


### PR DESCRIPTION
### Frontend Changes

- Added text-wrapping class for the text cell and logs message column 

-------
Relates to https://github.com/xibosignageltd/xibo-private/issues/1585