### PR TITLE
Module Templates: various fixes

### DIFF
--- a/frontend/src/components/ui/table/DataTableBulkActions.tsx
+++ b/frontend/src/components/ui/table/DataTableBulkActions.tsx
@@ -8,6 +8,7 @@ export interface DataTableBulkAction<TData> {
   icon?: LucideIcon;
   onClick: (selectedRows: TData[]) => void;
   variant?: 'default' | 'danger';
+  disabled?: boolean;
 }
 
 interface DataTableBulkActionsProps<TData> {
@@ -50,6 +51,7 @@ export function DataTableBulkActions<TData>({
             <button
               key={idx}
               onClick={() => action.onClick(selectedRows)}
+              disabled={action.disabled}
               className={twMerge(
                 'cursor-pointer flex justify-center size-6 items-center text-sm font-medium rounded-lg border border-transparent focus:outline-hidden disabled:opacity-50 disabled:pointer-events-none',
                 action.variant === 'danger'

--- a/frontend/src/pages/Developer/ModuleTemplates/ModuleTemplates.tsx
+++ b/frontend/src/pages/Developer/ModuleTemplates/ModuleTemplates.tsx
@@ -21,6 +21,7 @@
 
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import type { RowSelectionState } from '@tanstack/react-table';
+import { isAxiosError } from 'axios';
 import { Filter, FilterX, Plus, Search, Upload } from 'lucide-react';
 import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -28,6 +29,7 @@ import { useNavigate } from 'react-router-dom';
 
 import type { ModalType, ModuleTemplateFilterInput } from './ModuleTemplatesConfig';
 import {
+  getBulkActions,
   getFilterKeys,
   getModuleTemplateColumns,
   INITIAL_FILTER_STATE,
@@ -41,16 +43,23 @@ import { notify } from '@/components/ui/Notification';
 import TabNav from '@/components/ui/TabNav';
 import ShareModal from '@/components/ui/modals/ShareModal';
 import { DataTable } from '@/components/ui/table/DataTable';
+import { useUserContext } from '@/context/UserContext';
 import { useFilteredTabs } from '@/hooks/useFilteredTabs';
 import { useTableState } from '@/hooks/useTableState';
 import { fetchDataTypes, importModuleTemplateXml } from '@/services/moduleTemplatesApi';
 import type { ModuleTemplate } from '@/types/moduleTemplates';
+import { UserType } from '@/types/user';
+import { hasFeature } from '@/utils/permissions';
 
 export default function ModuleTemplates() {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const navigate = useNavigate();
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const { user } = useUserContext();
+  const isSuperAdmin = user?.userTypeId === UserType.SuperAdmin;
+  const canManageTemplates = hasFeature(user, 'developer.edit');
+  const canDeleteTemplates = hasFeature(user, 'developer.delete');
 
   const {
     pagination,
@@ -84,8 +93,9 @@ export default function ModuleTemplates() {
   const [openFilter, setOpenFilter] = useState(false);
   const [activeModal, setActiveModal] = useState<ModalType>(null);
   const [selectedTemplate, setSelectedTemplate] = useState<ModuleTemplate | null>(null);
-  const [shareEntityId, setShareEntityId] = useState<number | null>(null);
+  const [shareEntityId, setShareEntityId] = useState<number | number[] | null>(null);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const [selectionCache, setSelectionCache] = useState<Record<string, ModuleTemplate>>({});
 
   const openModal = (name: ModalType) => setActiveModal(name);
   const closeModal = () => {
@@ -122,6 +132,31 @@ export default function ModuleTemplates() {
 
   const developerTabs = useFilteredTabs('developer');
 
+  const getRowId = (row: ModuleTemplate) => String(row.id);
+
+  const handleRowSelectionChange: typeof setRowSelection = (updaterOrValue) => {
+    const newSelection =
+      typeof updaterOrValue === 'function' ? updaterOrValue(rowSelection) : updaterOrValue;
+
+    setRowSelection(newSelection);
+
+    setSelectionCache((prev) => {
+      const next = { ...prev };
+      templateList.forEach((item) => {
+        const id = getRowId(item);
+        if (newSelection[id]) {
+          next[id] = item;
+        }
+      });
+      return next;
+    });
+  };
+
+  const getAllSelectedItems = (): ModuleTemplate[] =>
+    Object.keys(rowSelection)
+      .map((id) => selectionCache[id])
+      .filter((item): item is ModuleTemplate => !!item);
+
   const handleRefresh = () => {
     queryClient.invalidateQueries({ queryKey: moduleTemplateQueryKeys.all });
   };
@@ -149,6 +184,35 @@ export default function ModuleTemplates() {
     openModal('share');
   };
 
+  const handleBulkDelete = () => {
+    openModal('bulkDelete');
+  };
+
+  const handleBulkShare = () => {
+    setShareEntityId(getAllSelectedItems().map((item) => item.id));
+    openModal('share');
+  };
+
+  const handleBulkSuccess = () => {
+    setRowSelection({});
+    closeModal();
+    handleRefresh();
+  };
+
+  // A bulk delete batch can partially succeed: keep the modal open (it still shows the
+  // error for the templates that failed) but drop the already-deleted ids from the
+  // selection and refresh the table so they don't linger as if nothing happened.
+  const handleBulkPartialSuccess = (deletedIds: number[]) => {
+    setRowSelection((prev) => {
+      const next = { ...prev };
+      deletedIds.forEach((id) => {
+        delete next[String(id)];
+      });
+      return next;
+    });
+    handleRefresh();
+  };
+
   const handleImportXml = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (!file) return;
@@ -156,8 +220,12 @@ export default function ModuleTemplates() {
       await importModuleTemplateXml(file);
       notify.success(t('Template imported successfully'));
       handleRefresh();
-    } catch {
-      notify.error(t('Failed to import template'));
+    } catch (err: unknown) {
+      const message =
+        (isAxiosError(err) && err.response?.data?.message) ||
+        (err instanceof Error && err.message) ||
+        t('Failed to import template');
+      notify.error(message);
     } finally {
       if (fileInputRef.current) fileInputRef.current.value = '';
     }
@@ -174,6 +242,18 @@ export default function ModuleTemplates() {
     onCopy: handleCopy,
     onDelete: handleDelete,
     onShare: handleShare,
+    currentUserId: user?.userId ?? 0,
+    isSuperAdmin,
+    canManageTemplates,
+    canDeleteTemplates,
+  });
+
+  const bulkActions = getBulkActions({
+    t,
+    onBulkDelete: handleBulkDelete,
+    onBulkShare: handleBulkShare,
+    isSuperAdmin,
+    canDeleteTemplates,
   });
 
   const filterOptions = getFilterKeys(t, dataTypeOptions);
@@ -275,13 +355,14 @@ export default function ModuleTemplates() {
               onGlobalFilterChange={setGlobalFilter}
               loading={isFetching}
               rowSelection={rowSelection}
-              onRowSelectionChange={setRowSelection}
+              onRowSelectionChange={handleRowSelectionChange}
+              bulkActions={bulkActions}
               onRefresh={handleRefresh}
               columnPinning={{ left: [], right: ['tableActions'] }}
               columnVisibility={columnVisibility}
               onColumnVisibilityChange={setColumnVisibility}
               viewMode={null}
-              getRowId={(row: ModuleTemplate) => String(row.id)}
+              getRowId={getRowId}
             />
           )}
         </div>
@@ -292,20 +373,16 @@ export default function ModuleTemplates() {
         entityType="ModuleTemplate"
         entityId={shareEntityId}
         isOpen={activeModal === 'share'}
-        onClose={() => {
-          closeModal();
-          handleRefresh();
-        }}
+        onClose={handleBulkSuccess}
       />
 
       <ModuleTemplateModals
         activeModal={activeModal}
         selectedTemplate={selectedTemplate}
+        selectedTemplates={getAllSelectedItems()}
         onClose={closeModal}
-        onSuccess={() => {
-          closeModal();
-          handleRefresh();
-        }}
+        onSuccess={handleBulkSuccess}
+        onPartialSuccess={handleBulkPartialSuccess}
       />
     </section>
   );

--- a/frontend/src/pages/Developer/ModuleTemplates/ModuleTemplatesConfig.tsx
+++ b/frontend/src/pages/Developer/ModuleTemplates/ModuleTemplatesConfig.tsx
@@ -26,6 +26,7 @@ import type { ComponentProps } from 'react';
 
 import type { FilterConfigItem } from '@/components/ui/FilterInputs';
 import type { SelectOption } from '@/components/ui/forms/SelectDropdown';
+import type { DataTableBulkAction } from '@/components/ui/table/DataTableBulkActions';
 import { ActionsCell, TextCell } from '@/components/ui/table/cells';
 import type { ModuleTemplate } from '@/types/moduleTemplates';
 import type { ActionItem } from '@/types/table';
@@ -43,7 +44,7 @@ export interface ModuleTemplateFilterInput {
   dataType?: string | null;
 }
 
-export type ModalType = 'add' | 'copy' | 'delete' | 'share' | null;
+export type ModalType = 'add' | 'copy' | 'delete' | 'bulkDelete' | 'share' | null;
 
 export const INITIAL_FILTER_STATE: ModuleTemplateFilterInput = {
   id: null,
@@ -82,6 +83,12 @@ export interface ModuleTemplateActionsProps {
   onCopy: (template: ModuleTemplate) => void;
   onDelete: (template: ModuleTemplate) => void;
   onShare: (template: ModuleTemplate) => void;
+  currentUserId: number;
+  isSuperAdmin: boolean;
+  /** "Add/Edit custom modules and templates" global feature. */
+  canManageTemplates: boolean;
+  /** "Delete custom modules and templates" global feature — distinct from canManageTemplates. */
+  canDeleteTemplates: boolean;
 }
 
 export const getModuleTemplateItemActions = ({
@@ -90,11 +97,25 @@ export const getModuleTemplateItemActions = ({
   onCopy,
   onDelete,
   onShare,
+  currentUserId,
+  isSuperAdmin,
+  canManageTemplates,
+  canDeleteTemplates,
 }: ModuleTemplateActionsProps): ((template: ModuleTemplate) => ActionItem[]) => {
   return (template: ModuleTemplate) => {
     const actions: ActionItem[] = [];
+    const isUserTemplate = template.ownership === 'user';
+    const isOwner = template.ownerId === currentUserId;
+    // Edit/Copy/Export require BOTH the global "manage templates" feature and the
+    // per-template share permission — a share grant alone is not enough.
+    const canEdit = isUserTemplate && canManageTemplates && !!(template.userPermissions?.edit ?? 1);
+    // Delete has its own distinct global feature, separate from edit/manage.
+    const canDelete =
+      isUserTemplate && canDeleteTemplates && !!(template.userPermissions?.delete ?? 1);
+    // Share is never granted via a share permission — only the owner or a Super Admin may share.
+    const canShare = isOwner || isSuperAdmin;
 
-    if (template.ownership === 'user') {
+    if (canEdit) {
       actions.push(
         {
           label: t('Edit'),
@@ -112,7 +133,7 @@ export const getModuleTemplateItemActions = ({
           label: t('Export XML'),
           icon: Download,
           onClick: () => {
-            window.location.href = `/developer/template/${template.id}/export`;
+            window.location.href = `/json/developer/template/${template.id}/export`;
           },
         },
         {
@@ -123,15 +144,21 @@ export const getModuleTemplateItemActions = ({
       );
     }
 
-    actions.push({ isSeparator: true });
-    actions.push({
-      label: t('Share'),
-      icon: Share2,
-      onClick: () => onShare(template),
-    });
+    if (canShare) {
+      if (actions.length > 0) {
+        actions.push({ isSeparator: true });
+      }
+      actions.push({
+        label: t('Share'),
+        icon: Share2,
+        onClick: () => onShare(template),
+      });
+    }
 
-    if (template.ownership === 'user') {
-      actions.push({ isSeparator: true });
+    if (canDelete) {
+      if (actions.length > 0) {
+        actions.push({ isSeparator: true });
+      }
       actions.push({
         label: t('Delete'),
         icon: Trash2,
@@ -143,6 +170,40 @@ export const getModuleTemplateItemActions = ({
     return actions;
   };
 };
+
+interface GetBulkActionsProps {
+  t: TFunction;
+  onBulkDelete: () => void;
+  onBulkShare: () => void;
+  isSuperAdmin: boolean;
+  canDeleteTemplates: boolean;
+}
+
+export const getBulkActions = ({
+  t,
+  onBulkDelete,
+  onBulkShare,
+  isSuperAdmin,
+  canDeleteTemplates,
+}: GetBulkActionsProps): DataTableBulkAction<ModuleTemplate>[] => [
+  {
+    // Bulk selections can span templates the current user doesn't own, so — same as the
+    // per-row action — Share is only enabled here for Super Admins. Shown but disabled
+    // (rather than omitted) so a view-only user can see the action exists without being
+    // able to use it.
+    label: t('Share'),
+    icon: Share2,
+    onClick: onBulkShare,
+    disabled: !isSuperAdmin,
+  },
+  {
+    label: t('Delete Selected'),
+    icon: Trash2,
+    onClick: onBulkDelete,
+    variant: 'danger',
+    disabled: !canDeleteTemplates,
+  },
+];
 
 export const getModuleTemplateColumns = (
   props: ModuleTemplateActionsProps,

--- a/frontend/src/pages/Developer/ModuleTemplates/components/ModuleTemplateModals.tsx
+++ b/frontend/src/pages/Developer/ModuleTemplates/components/ModuleTemplateModals.tsx
@@ -44,8 +44,11 @@ import type { ModuleTemplate } from '@/types/moduleTemplates';
 interface ModuleTemplateModalsProps {
   activeModal: ModalType;
   selectedTemplate: ModuleTemplate | null;
+  selectedTemplates?: ModuleTemplate[];
   onClose: () => void;
   onSuccess: () => void;
+  /** Called with the ids that were deleted when a bulk delete only partially succeeds. */
+  onPartialSuccess?: (deletedIds: number[]) => void;
 }
 
 // ── Add Modal ────────────────────────────────────────────────────────────────
@@ -250,13 +253,15 @@ function CopyModal({
 // ── Delete Modal ─────────────────────────────────────────────────────────────
 
 function DeleteModal({
-  template,
+  templates,
   onClose,
   onSuccess,
+  onPartialSuccess,
 }: {
-  template: ModuleTemplate;
+  templates: ModuleTemplate[];
   onClose: () => void;
   onSuccess: () => void;
+  onPartialSuccess?: (deletedIds: number[]) => void;
 }) {
   const { t } = useTranslation();
   const [isPending, setIsPending] = useState(false);
@@ -266,14 +271,31 @@ function DeleteModal({
     setError(null);
     setIsPending(true);
     try {
-      await deleteModuleTemplate(template.id);
-      onSuccess();
-    } catch (err: unknown) {
-      setError(
-        (isAxiosError(err) && err.response?.data?.message) ||
-          (err instanceof Error && err.message) ||
-          t('Failed to delete template'),
+      const results = await Promise.allSettled(
+        templates.map((template) => deleteModuleTemplate(template.id)),
       );
+      const failed = results.filter((r) => r.status === 'rejected');
+      if (failed.length > 0) {
+        // Deleted templates are already gone server-side even though the batch as a
+        // whole "failed" — reflect that in the table/selection now, rather than only
+        // on the next full onSuccess (which never fires until every item succeeds).
+        const deletedIds = templates
+          .filter((_, i) => results[i]?.status === 'fulfilled')
+          .map((template) => template.id);
+        if (deletedIds.length > 0) {
+          onPartialSuccess?.(deletedIds);
+        }
+
+        const firstRejected = failed[0] as PromiseRejectedResult;
+        const reason = firstRejected.reason;
+        setError(
+          (isAxiosError(reason) && reason.response?.data?.message) ||
+            (reason instanceof Error && reason.message) ||
+            t('{{count}} template(s) could not be deleted.', { count: failed.length }),
+        );
+        return;
+      }
+      onSuccess();
     } finally {
       setIsPending(false);
     }
@@ -303,16 +325,24 @@ function DeleteModal({
             </div>
           </div>
           <h2 className="text-center text-lg font-semibold mb-2 text-red-800">
-            {t('Delete Template?')}
+            {templates.length === 1 ? t('Delete Template?') : t('Delete Templates?')}
           </h2>
         </div>
 
         <p className="text-center text-gray-500">
-          <Trans
-            i18nKey='Are you sure you want to delete "<strong>{{name}}</strong>"?'
-            values={{ name: template.templateId }}
-            components={{ strong: <strong /> }}
-          />
+          {templates.length === 1 ? (
+            <Trans
+              i18nKey='Are you sure you want to delete "<strong>{{name}}</strong>"?'
+              values={{ name: templates[0]?.templateId }}
+              components={{ strong: <strong /> }}
+            />
+          ) : (
+            <Trans
+              i18nKey="Are you sure you want to delete <strong>{{count}}</strong> templates?"
+              values={{ count: templates.length }}
+              components={{ strong: <strong /> }}
+            />
+          )}
         </p>
 
         <span className="flex justify-center gap-px rounded-md bg-gray-50 p-1.5">
@@ -337,11 +367,24 @@ function DeleteModal({
 export function ModuleTemplateModals({
   activeModal,
   selectedTemplate,
+  selectedTemplates,
   onClose,
   onSuccess,
+  onPartialSuccess,
 }: ModuleTemplateModalsProps) {
   if (activeModal === 'add') {
     return <AddModal onClose={onClose} onSuccess={onSuccess} />;
+  }
+
+  if (activeModal === 'bulkDelete' && selectedTemplates && selectedTemplates.length > 0) {
+    return (
+      <DeleteModal
+        templates={selectedTemplates}
+        onClose={onClose}
+        onSuccess={onSuccess}
+        onPartialSuccess={onPartialSuccess}
+      />
+    );
   }
 
   if (!selectedTemplate) return null;
@@ -351,7 +394,7 @@ export function ModuleTemplateModals({
   }
 
   if (activeModal === 'delete') {
-    return <DeleteModal template={selectedTemplate} onClose={onClose} onSuccess={onSuccess} />;
+    return <DeleteModal templates={[selectedTemplate]} onClose={onClose} onSuccess={onSuccess} />;
   }
 
   return null;

--- a/frontend/src/pages/Developer/ModuleTemplates/components/tabs/PropertiesTab.tsx
+++ b/frontend/src/pages/Developer/ModuleTemplates/components/tabs/PropertiesTab.tsx
@@ -605,6 +605,8 @@ interface PropertyCardProps {
   dragHandleNode?: React.ReactNode;
   /** Visual-only overlay clone while dragging. */
   isOverlay?: boolean;
+  /** Briefly highlights the card right after it's added. */
+  isNew?: boolean;
 }
 
 function PropertyCard({
@@ -614,6 +616,7 @@ function PropertyCard({
   onDelete,
   dragHandleNode,
   isOverlay,
+  isNew,
 }: PropertyCardProps) {
   const { t } = useTranslation();
 
@@ -623,8 +626,12 @@ function PropertyCard({
 
   return (
     <div
-      className={`w-[360px] shrink-0 border rounded-lg bg-white flex flex-col ${
-        isOverlay ? 'border-xibo-blue-400 shadow-xl rotate-1' : 'border-gray-200'
+      className={`w-[360px] shrink-0 border rounded-lg bg-white flex flex-col transition-[box-shadow,border-color] duration-1000 ${
+        isOverlay
+          ? 'border-xibo-blue-400 shadow-xl rotate-1'
+          : isNew
+            ? 'border-xibo-blue-400 ring-2 ring-xibo-blue-300'
+            : 'border-gray-200'
       }`}
     >
       {/* Sticky header */}
@@ -833,6 +840,8 @@ export default function PropertiesTab({ properties, onChange }: PropertiesTabPro
   const counterRef = useRef(properties.length);
   const [activeId, setActiveId] = useState<string | null>(null);
   const lastSetPropertiesRef = useRef<ModuleTemplateProperty[]>(properties);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const [justAddedId, setJustAddedId] = useState<string | null>(null);
 
   // Re-sync sortIds when properties changes externally (e.g. form reset via Cancel).
   // Uses referential equality: if the incoming prop is not the array we last passed
@@ -854,7 +863,21 @@ export default function PropertiesTab({ properties, onChange }: PropertiesTabPro
     const newId = `prop-${counterRef.current++}`;
     setSortIds((prev) => [...prev, newId]);
     callOnChange([...properties, { type: 'text', id: '' }]);
+    setJustAddedId(newId);
   };
+
+  // Scroll the newly added card into view and briefly highlight it, since the
+  // list scrolls horizontally and an appended card otherwise renders off-screen
+  // with no visible sign anything happened.
+  useEffect(() => {
+    if (!justAddedId) return;
+    scrollContainerRef.current?.scrollTo({
+      left: scrollContainerRef.current.scrollWidth,
+      behavior: 'smooth',
+    });
+    const timer = setTimeout(() => setJustAddedId(null), 1500);
+    return () => clearTimeout(timer);
+  }, [justAddedId]);
 
   const updateProperty = (index: number, updated: ModuleTemplateProperty) =>
     callOnChange(properties.map((p, i) => (i === index ? updated : p)));
@@ -906,7 +929,10 @@ export default function PropertiesTab({ properties, onChange }: PropertiesTabPro
           onDragEnd={handleDragEnd}
         >
           <SortableContext items={sortIds} strategy={horizontalListSortingStrategy}>
-            <div className="flex flex-row items-start gap-4 overflow-x-auto overflow-y-auto max-h-[calc(100vh-300px)] pb-2">
+            <div
+              ref={scrollContainerRef}
+              className="flex flex-row items-start gap-4 overflow-x-auto overflow-y-auto max-h-[calc(100vh-300px)] pb-2"
+            >
               {properties.map((prop, idx) => (
                 <SortablePropertyCard
                   key={sortIds[idx]}
@@ -915,6 +941,7 @@ export default function PropertiesTab({ properties, onChange }: PropertiesTabPro
                   index={idx}
                   onChange={updateProperty}
                   onDelete={deleteProperty}
+                  isNew={sortIds[idx] === justAddedId}
                 />
               ))}
             </div>

--- a/frontend/src/pages/Reporting/SavedReports/SavedReportsConfig.tsx
+++ b/frontend/src/pages/Reporting/SavedReports/SavedReportsConfig.tsx
@@ -104,7 +104,7 @@ export const getSavedReportItemActions = (
 ): ((report: SavedReport) => ActionItem[]) => {
   const { t, onDelete, onGoToSchedule, onOpen, onBackToReports } = props;
   return (report: SavedReport) => {
-    const exportUrl = `/report/savedreport/${report.savedReportId}/report/${report.reportName}/export`;
+    const exportUrl = `/json/report/savedreport/${report.savedReportId}/report/${report.reportName}/export`;
     return [
       {
         label: t('Open'),

--- a/frontend/src/services/moduleTemplatesApi.ts
+++ b/frontend/src/services/moduleTemplatesApi.ts
@@ -155,10 +155,20 @@ export async function copyModuleTemplate(
   return response.data.data;
 }
 
+interface UploadHandlerFile {
+  name?: string;
+  error?: string;
+}
+
 export async function importModuleTemplateXml(file: File): Promise<void> {
   const formData = new FormData();
   formData.append('files[]', file);
-  await http.post('/developer/template/import', formData, {
+  const response = await http.post('/developer/template/import', formData, {
     headers: { 'Content-Type': 'multipart/form-data' },
   });
+
+  const uploadedFile: UploadHandlerFile | undefined = response.data?.files?.[0];
+  if (uploadedFile?.error) {
+    throw new Error(uploadedFile.error);
+  }
 }

--- a/frontend/src/types/moduleTemplates.ts
+++ b/frontend/src/types/moduleTemplates.ts
@@ -67,6 +67,13 @@ export interface ModuleTemplateProperty {
   };
 }
 
+export interface ModuleTemplatePermissions {
+  view?: number;
+  edit?: number;
+  delete?: number;
+  modifyPermissions?: number;
+}
+
 export interface ModuleTemplate {
   id: number;
   templateId: string;
@@ -84,6 +91,7 @@ export interface ModuleTemplate {
   onTemplateVisible: string | null;
   stencil: ModuleTemplateStencil | null;
   properties: ModuleTemplateProperty[] | null;
+  userPermissions?: ModuleTemplatePermissions;
 }
 
 export interface DataType {

--- a/lib/Controller/Developer.php
+++ b/lib/Controller/Developer.php
@@ -396,6 +396,9 @@ class Developer extends Base
             'libraryQuotaFull' => false,
         ];
 
+        // Output handled by UploadHandler
+        $this->setNoOutput(true);
+
         $this->getLog()->debug('Hand off to Upload Handler with options: ' . json_encode($options));
 
         // Hand off to the Upload Handler provided by jquery-file-upload
@@ -438,7 +441,7 @@ class Developer extends Base
 
         $uploadHandler->post();
 
-        return $response->withStatus(200)->withJson(['success' => true]);
+        return $response->withHeader('Content-Type', 'application/json');
     }
 
     /**

--- a/lib/Controller/Developer.php
+++ b/lib/Controller/Developer.php
@@ -542,8 +542,7 @@ class Developer extends Base
             'id' => $params->getInt('id'),
             'templateId' => $params->getString('templateId'),
             'dataType' => $params->getString('dataType'),
-            'keyword' => $params->getString('keyword')
-            ], $params
-        );
+            'keyword' => $params->getString('keyword'),
+        ], $params);
     }
 }

--- a/lib/Widget/Definition/Stencil.php
+++ b/lib/Widget/Definition/Stencil.php
@@ -77,6 +77,7 @@ class Stencil implements \JsonSerializable
     public function jsonSerialize(): array
     {
         return [
+            'twig' => $this->twig,
             'hbsId' => $this->hbsId,
             'hbs' => $this->hbs,
             'head' => $this->head,

--- a/lib/routes-react.php
+++ b/lib/routes-react.php
@@ -140,10 +140,15 @@ $app->get('/report/available', ['\Xibo\Controller\Stats', 'availableReports'])
 //
 // Saved reports
 //
-$app->group('', function(\Slim\Routing\RouteCollectorProxy $group) {
-    $group->get('/report/savedreport/{id}/report/{name}/open', ['\Xibo\Controller\SavedReport','savedReportOpen'])->setName('savedreport.open');
-    $group->get('/report/savedreport/{id}/report/{name}/export', ['\Xibo\Controller\SavedReport','savedReportExport'])->setName('savedreport.export');
-    $group->get('/report/savedreport/{id}/report/{name}/convert', ['\Xibo\Controller\SavedReport','savedReportConvert'])->setName('savedreport.convert');
+$app->group('', function (\Slim\Routing\RouteCollectorProxy $group) {
+    $group->get('/report/savedreport/{id}/report/{name}/open', ['\Xibo\Controller\SavedReport', 'savedReportOpen'])
+        ->setName('savedreport.open');
+    $group->get('/report/savedreport/{id}/report/{name}/export', ['\Xibo\Controller\SavedReport', 'savedReportExport'])
+        ->setName('savedreport.export');
+    $group->get(
+        '/report/savedreport/{id}/report/{name}/convert',
+        ['\Xibo\Controller\SavedReport', 'savedReportConvert']
+    )->setName('savedreport.convert');
 })->addMiddleware(new FeatureAuth($app->getContainer(), ['report.saving']));
 
 $app->get('/stats/export/count', ['\Xibo\Controller\Stats', 'exportStatsCount'])

--- a/lib/routes-react.php
+++ b/lib/routes-react.php
@@ -153,6 +153,10 @@ $app->get('/stats/export/count', ['\Xibo\Controller\Stats', 'exportStatsCount'])
 //
 // Developer
 //
+$app->delete('/developer/template/{id}', ['\Xibo\Controller\Developer', 'templateDelete'])
+    ->setName('developer.templates.delete')
+    ->addMiddleware(new FeatureAuth($app->getContainer(), ['developer.delete']));
+
 $app->group('', function (\Slim\Routing\RouteCollectorProxy $group) {
     $group->get('/developer/template/datatypes', ['\Xibo\Controller\Developer', 'getAvailableDataTypes'])
         ->setName('developer.templates.datatypes.search');
@@ -164,8 +168,6 @@ $app->group('', function (\Slim\Routing\RouteCollectorProxy $group) {
         ->setName('developer.templates.add');
     $group->put('/developer/template/{id}', ['\Xibo\Controller\Developer', 'templateEdit'])
         ->setName('developer.templates.edit');
-    $group->delete('/developer/template/{id}', ['\Xibo\Controller\Developer', 'templateDelete'])
-        ->setName('developer.templates.delete');
     $group->get('/developer/template/{id}/export', ['\Xibo\Controller\Developer', 'templateExport'])
         ->setName('developer.templates.export');
     $group->post('/developer/template/import', ['\Xibo\Controller\Developer', 'templateImport'])


### PR DESCRIPTION
### Frontend Changes

- Added scrolling for the newly added property
- Fixed module export link
- Added bulk `Share` and `Delete` actions
- Added error handling
- Fixed user permissions

Note: I had to update the bulk action component to handle the bulk actions for users who may have view permission 
but not have certain permissions (i.e. delete).

### Backend Changes
- Added twig file in the stencil
- Updated module template delete middleware

-------
Relates to https://github.com/xibosignageltd/xibo-private/issues/1597