### PR TITLE
Adjust Media thumbnail size for Gallery view.

### DIFF
--- a/frontend/src/pages/Library/Media/components/MediaCard.tsx
+++ b/frontend/src/pages/Library/Media/components/MediaCard.tsx
@@ -55,9 +55,11 @@ export default function MediaCard({
   actions,
 }: MediaCardProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [hasThumbnailError, setHasThumbnailError] = useState(false);
 
   const isPlayable = media.mediaType === 'video' || media.mediaType === 'audio';
   const IconComponent = getMediaIcon(media.mediaType);
+  const showThumbnail = media.thumbnail && !hasThumbnailError;
 
   const { refs, floatingStyles, context } = useFloating({
     open: isMenuOpen,
@@ -105,12 +107,14 @@ export default function MediaCard({
         className="aspect-video w-full bg-gray-400 rounded-t-lg overflow-hidden cursor-pointer relative flex items-center justify-center"
         onClick={() => onPreview(media)}
       >
-        {media.thumbnail ? (
+        {showThumbnail ? (
           <div className="flex h-full justify-center items-center">
             <img
               src={media.thumbnail}
               alt={media.name}
+              loading="lazy"
               className="w-full h-full object-cover transition-transform group-hover:scale-105"
+              onError={() => setHasThumbnailError(true)}
             />
             {isPlayable && (
               <div className="absolute flex items-center justify-center rounded-full bg-white/10 size-9.5">

--- a/lib/Widget/Render/WidgetDownloader.php
+++ b/lib/Widget/Render/WidgetDownloader.php
@@ -176,9 +176,11 @@ class WidgetDownloader
         // and then thumbnails in tn_{mediaId}_{mediaType}cover.png
         // unless we are an image module, which is its own image, and would then have a thumbnail in
         // tn_{mediaId}_{mediaType}cover.png
+        // This single cached thumbnail is shared by the library table view (shown small) and the
+        // gallery view (shown larger) - sized for the gallery, downscaled by the browser for the table.
         try {
-            $width = 120;
-            $height = 120;
+            $width = 320;
+            $height = 320;
 
             if ($media->mediaType === 'image') {
                 $filePath = $this->libraryLocation . $media->storedAs;


### PR DESCRIPTION
fixes https://github.com/xibosignageltd/xibo-private/issues/1574

New thumbnails will be generated with the bigger size from the start
Existing thumbnails will be replaced by the bigger size thumbnail in place on request on the media table/gallery view ( due to dimensions mismatch, which will trigger the thumbnail image regeneration ) 