### PR TITLE
Bugfix: Multiple Fix for Display Profile

### DIFF
--- a/frontend/src/pages/Displays/DisplayProfile/__tests__/DisplayProfile.edit.form.test.tsx
+++ b/frontend/src/pages/Displays/DisplayProfile/__tests__/DisplayProfile.edit.form.test.tsx
@@ -148,6 +148,7 @@ describe('DisplayProfile - edit form fields', () => {
       name: mockDisplayProfile.name,
       isDefault: mockDisplayProfile.isDefault,
       config: {},
+      commandOverrides: [],
     });
   });
 

--- a/frontend/src/pages/Displays/DisplayProfile/__tests__/DisplayProfileBaseForm.test-helper.tsx
+++ b/frontend/src/pages/Displays/DisplayProfile/__tests__/DisplayProfileBaseForm.test-helper.tsx
@@ -166,6 +166,7 @@ export default function DisplayProfileBaseForm({
           name: draft.name,
           isDefault: draft.isDefault,
           config: configPayload,
+          commandOverrides: [],
         });
         onSave({ ...data, ...updated });
         onClose();

--- a/frontend/src/pages/Displays/DisplayProfile/__tests__/fixtures/displayProfile.ts
+++ b/frontend/src/pages/Displays/DisplayProfile/__tests__/fixtures/displayProfile.ts
@@ -20,7 +20,7 @@
  */
 
 import type { FetchDisplayProfileResponse } from '@/services/displayProfileApi';
-import type { DisplayProfile } from '@/types/displayProfile';
+import type { DisplayProfile, DisplayProfileCommand } from '@/types/displayProfile';
 import type { User } from '@/types/user';
 
 export const buildDisplayProfile = (overrides: Partial<DisplayProfile> = {}): DisplayProfile => ({
@@ -71,6 +71,31 @@ export const mockUser: User = {
     TIME_FORMAT_JS: 'HH:mm',
   },
 };
+
+export const mockCommands: DisplayProfileCommand[] = [
+  {
+    commandId: 1,
+    command: 'Reboot',
+    code: 'reboot',
+    commandString: 'reboot',
+    validationString: '',
+    createAlertOn: 'never',
+    commandStringDisplayProfile: null,
+    validationStringDisplayProfile: null,
+    createAlertOnDisplayProfile: null,
+  },
+  {
+    commandId: 2,
+    command: 'Shell Command',
+    code: 'shell',
+    commandString: 'shell|',
+    validationString: '',
+    createAlertOn: 'never',
+    commandStringDisplayProfile: 'shell|custom-cmd',
+    validationStringDisplayProfile: 'OK',
+    createAlertOnDisplayProfile: 'failure',
+  },
+];
 
 export const queryKeys = {
   displayProfilePage: ['userPref', 'displayProfile_page'] as const,

--- a/frontend/src/pages/Displays/DisplayProfile/__tests__/fixtures/displayProfile.ts
+++ b/frontend/src/pages/Displays/DisplayProfile/__tests__/fixtures/displayProfile.ts
@@ -20,7 +20,7 @@
  */
 
 import type { FetchDisplayProfileResponse } from '@/services/displayProfileApi';
-import type { DisplayProfile, DisplayProfileCommand } from '@/types/displayProfile';
+import type { DisplayProfile } from '@/types/displayProfile';
 import type { User } from '@/types/user';
 
 export const buildDisplayProfile = (overrides: Partial<DisplayProfile> = {}): DisplayProfile => ({
@@ -71,31 +71,6 @@ export const mockUser: User = {
     TIME_FORMAT_JS: 'HH:mm',
   },
 };
-
-export const mockCommands: DisplayProfileCommand[] = [
-  {
-    commandId: 1,
-    command: 'Reboot',
-    code: 'reboot',
-    commandString: 'reboot',
-    validationString: '',
-    createAlertOn: 'never',
-    commandStringDisplayProfile: null,
-    validationStringDisplayProfile: null,
-    createAlertOnDisplayProfile: null,
-  },
-  {
-    commandId: 2,
-    command: 'Shell Command',
-    code: 'shell',
-    commandString: 'shell|',
-    validationString: '',
-    createAlertOn: 'never',
-    commandStringDisplayProfile: 'shell|custom-cmd',
-    validationStringDisplayProfile: 'OK',
-    createAlertOnDisplayProfile: 'failure',
-  },
-];
 
 export const queryKeys = {
   displayProfilePage: ['userPref', 'displayProfile_page'] as const,

--- a/frontend/src/pages/Displays/DisplayProfile/components/CommandsTab.tsx
+++ b/frontend/src/pages/Displays/DisplayProfile/components/CommandsTab.tsx
@@ -28,11 +28,13 @@ import TextInput from '@/components/ui/forms/TextInput';
 import CommandBuilder from '@/pages/Displays/Commands/components/CommandBuilder/CommandBuilder';
 import type { DisplayProfileCommand } from '@/types/displayProfile';
 
+type CommandOverrideMutableField = 'commandString' | 'validationString' | 'createAlertOn';
+
 export interface CommandOverrideDraft {
   commandId: number;
   command: string;
   code: string;
-  description: string;
+  description: string | null;
   baseCommandString: string;
   baseValidationString: string;
   baseCreateAlertOn: string;
@@ -49,7 +51,7 @@ export function buildCommandDrafts(commands: DisplayProfileCommand[]): {
     commandId: cmd.commandId,
     command: cmd.command,
     code: cmd.code ?? '',
-    description: cmd.description ?? '',
+    description: cmd.description ?? null,
     baseCommandString: cmd.commandString ?? '',
     baseValidationString: cmd.validationString ?? '',
     baseCreateAlertOn: cmd.createAlertOn ?? 'never',
@@ -89,10 +91,18 @@ export default function CommandsTab({
     });
   };
 
-  const updateDraft = (commandId: number, field: string, value: string) => {
-    onCommandDraftsChange(
-      commandDrafts.map((c) => (c.commandId === commandId ? { ...c, [field]: value } : c)),
-    );
+  const updateDraft = (commandId: number, field: CommandOverrideMutableField, value: string) => {
+    const updated = commandDrafts.map((c) => {
+      if (c.commandId !== commandId) return c;
+      const draft = { ...c, [field]: value };
+      // Reset dependent fields when the command string is cleared
+      if (field === 'commandString' && !value) {
+        draft.validationString = '';
+        draft.createAlertOn = '';
+      }
+      return draft;
+    });
+    onCommandDraftsChange(updated);
   };
 
   return (
@@ -105,6 +115,7 @@ export default function CommandsTab({
             <button
               type="button"
               className="flex w-full items-center gap-2 px-4 py-3 text-left hover:bg-gray-50 transition-colors"
+              aria-expanded={isExpanded}
               onClick={() => toggleExpanded(cmd.commandId)}
             >
               {isExpanded ? (

--- a/frontend/src/pages/Displays/DisplayProfile/components/CommandsTab.tsx
+++ b/frontend/src/pages/Displays/DisplayProfile/components/CommandsTab.tsx
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import SelectDropdown from '@/components/ui/forms/SelectDropdown';
+import TextInput from '@/components/ui/forms/TextInput';
+import CommandBuilder from '@/pages/Displays/Commands/components/CommandBuilder/CommandBuilder';
+import type { DisplayProfileCommand } from '@/types/displayProfile';
+
+export interface CommandOverrideDraft {
+  commandId: number;
+  command: string;
+  code: string;
+  description: string;
+  baseCommandString: string;
+  baseValidationString: string;
+  baseCreateAlertOn: string;
+  commandString: string;
+  validationString: string;
+  createAlertOn: string;
+}
+
+export function buildCommandDrafts(commands: DisplayProfileCommand[]): {
+  drafts: CommandOverrideDraft[];
+  expandedIds: Set<number>;
+} {
+  const drafts = commands.map((cmd) => ({
+    commandId: cmd.commandId,
+    command: cmd.command,
+    code: cmd.code ?? '',
+    description: cmd.description ?? '',
+    baseCommandString: cmd.commandString ?? '',
+    baseValidationString: cmd.validationString ?? '',
+    baseCreateAlertOn: cmd.createAlertOn ?? 'never',
+    commandString: cmd.commandStringDisplayProfile ?? '',
+    validationString: cmd.validationStringDisplayProfile ?? '',
+    createAlertOn: cmd.createAlertOnDisplayProfile ?? '',
+  }));
+  const expandedIds = new Set(drafts.filter((c) => c.commandString).map((c) => c.commandId));
+  return { drafts, expandedIds };
+}
+
+interface CommandsTabProps {
+  commandDrafts: CommandOverrideDraft[];
+  onCommandDraftsChange: (drafts: CommandOverrideDraft[]) => void;
+  initialExpandedIds?: Set<number>;
+}
+
+export default function CommandsTab({
+  commandDrafts,
+  onCommandDraftsChange,
+  initialExpandedIds,
+}: CommandsTabProps) {
+  const { t } = useTranslation();
+  const [expandedCommands, setExpandedCommands] = useState<Set<number>>(
+    () => initialExpandedIds ?? new Set(),
+  );
+
+  const toggleExpanded = (commandId: number) => {
+    setExpandedCommands((prev) => {
+      const next = new Set(prev);
+      if (next.has(commandId)) {
+        next.delete(commandId);
+      } else {
+        next.add(commandId);
+      }
+      return next;
+    });
+  };
+
+  const updateDraft = (commandId: number, field: string, value: string) => {
+    onCommandDraftsChange(
+      commandDrafts.map((c) => (c.commandId === commandId ? { ...c, [field]: value } : c)),
+    );
+  };
+
+  return (
+    <div className="space-y-2">
+      {commandDrafts.map((cmd) => {
+        const isExpanded = expandedCommands.has(cmd.commandId);
+        const hasOverride = !!cmd.commandString;
+        return (
+          <div key={cmd.commandId} className="rounded-lg border overflow-hidden border-gray-200">
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 px-4 py-3 text-left hover:bg-gray-50 transition-colors"
+              onClick={() => toggleExpanded(cmd.commandId)}
+            >
+              {isExpanded ? (
+                <ChevronDown size={16} className="shrink-0 text-gray-500" />
+              ) : (
+                <ChevronRight size={16} className="shrink-0 text-gray-500" />
+              )}
+              <span className="font-medium">{cmd.command}</span>
+              <span className="text-sm text-gray-500">({cmd.code})</span>
+              {hasOverride && (
+                <span className="ml-auto rounded-full bg-blue-100 px-2 py-0.5 text-xs text-blue-700">
+                  {t('Overridden')}
+                </span>
+              )}
+            </button>
+            {isExpanded && (
+              <div className="border-t border-gray-200 px-4 py-3 space-y-3">
+                {cmd.description && <p className="text-sm text-gray-400">{cmd.description}</p>}
+                <CommandBuilder
+                  value={cmd.commandString}
+                  onChange={(val) => updateDraft(cmd.commandId, 'commandString', val)}
+                />
+                <TextInput
+                  name={`validationString_${cmd.commandId}`}
+                  label={t('Validation String')}
+                  helpText={t('A regular expression to validate the output of the command.')}
+                  placeholder={cmd.baseValidationString || undefined}
+                  value={cmd.validationString}
+                  onChange={(val) => updateDraft(cmd.commandId, 'validationString', val)}
+                />
+                <SelectDropdown
+                  label={t('Create Alert On')}
+                  value={cmd.createAlertOn || cmd.baseCreateAlertOn || 'never'}
+                  options={[
+                    { value: 'never', label: t('Never') },
+                    { value: 'success', label: t('Success') },
+                    { value: 'failure', label: t('Failure') },
+                    { value: 'always', label: t('Always') },
+                  ]}
+                  onSelect={(val) => updateDraft(cmd.commandId, 'createAlertOn', val || 'never')}
+                />
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/pages/Displays/DisplayProfile/components/EditDisplayProfileModal.tsx
+++ b/frontend/src/pages/Displays/DisplayProfile/components/EditDisplayProfileModal.tsx
@@ -23,6 +23,9 @@ import { isAxiosError } from 'axios';
 import { useEffect, useRef, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import type { CommandOverrideDraft } from './CommandsTab';
+import CommandsTab from './CommandsTab';
+import { buildCommandDrafts } from './CommandsTab';
 import { AndroidFields } from './fields/AndroidFields';
 import { ChromeOsFields } from './fields/ChromeOsFields';
 import {
@@ -75,7 +78,8 @@ type ActiveTab =
   | 'advanced'
   | 'timers'
   | 'pictureOptions'
-  | 'lockSettings';
+  | 'lockSettings'
+  | 'commands';
 
 function tabClass(activeTab: ActiveTab, tab: ActiveTab): string {
   const isActive = activeTab === tab;
@@ -138,6 +142,9 @@ export default function EditDisplayProfileModal({
     { id: 0, property: '', value: 0 },
   ]);
 
+  const [commandDrafts, setCommandDrafts] = useState<CommandOverrideDraft[]>([]);
+  const [expandedCommandIds, setExpandedCommandIds] = useState<Set<number>>(new Set());
+
   const [dayparts, setDayparts] = useState<Daypart[]>([]);
   const [daypartsTotalCount, setDaypartsTotalCount] = useState(0);
   const [isLoadingMoreDayparts, setIsLoadingMoreDayparts] = useState(false);
@@ -185,6 +192,8 @@ export default function EditDisplayProfileModal({
     });
     setHisenseTimerRules([]);
     setHisensePictureRows([{ id: 0, property: '', value: 0 }]);
+    setCommandDrafts([]);
+    setExpandedCommandIds(new Set());
 
     const isLgSsspType = data.type === 'lg' || data.type === 'sssp';
     const isHisenseType = data.type === 'hisense';
@@ -305,6 +314,13 @@ export default function EditDisplayProfileModal({
         setHisensePictureRows(
           parsedPicRows.length > 0 ? parsedPicRows : [{ id: 0, property: '', value: 0 }],
         );
+      }
+
+      // Populate command overrides
+      if (full.commands) {
+        const { drafts, expandedIds } = buildCommandDrafts(full.commands);
+        setCommandDrafts(drafts);
+        setExpandedCommandIds(expandedIds);
       }
     });
 
@@ -536,6 +552,12 @@ export default function EditDisplayProfileModal({
               }));
             })(),
           }),
+          commandOverrides: commandDrafts.map((cmd) => ({
+            commandId: cmd.commandId,
+            commandString: cmd.commandString,
+            validationString: cmd.commandString ? cmd.validationString : '',
+            createAlertOn: cmd.commandString ? cmd.createAlertOn : 'never',
+          })),
         });
         onSave({ ...data, ...updated });
         onClose();
@@ -554,7 +576,11 @@ export default function EditDisplayProfileModal({
   const hasLocationTab =
     data?.type === 'android' || data?.type === 'windows' || data?.type === 'linux' || isHisense;
   const hasTroubleshootingTab =
-    data?.type === 'android' || data?.type === 'windows' || data?.type === 'linux' || isHisense;
+    data?.type === 'android' ||
+    data?.type === 'windows' ||
+    data?.type === 'linux' ||
+    isLgSssp ||
+    isHisense;
   const hasTimersTab = isLgSssp || isHisense;
   const hasPictureOptionsTab = isLgSssp || isHisense;
   const hasLockSettingsTab = isLgSssp;
@@ -642,7 +668,7 @@ export default function EditDisplayProfileModal({
           disabled: isPending || isLoading,
         },
       ]}
-      size={isHisense ? 'lg' : 'md'}
+      size="lg"
     >
       <div className="flex flex-col h-full overflow-y-hidden overflow-x-visible px-4">
         <nav className="flex px-4 overflow-x-auto shrink-0" aria-label="Tabs">
@@ -708,6 +734,13 @@ export default function EditDisplayProfileModal({
               {t('Advanced')}
             </button>
           )}
+          <button
+            type="button"
+            className={tab('commands')}
+            onClick={() => setActiveTab('commands')}
+          >
+            {t('Commands')}
+          </button>
         </nav>
 
         <div className="flex-1 overflow-y-auto py-4 px-8 space-y-4">
@@ -745,6 +778,15 @@ export default function EditDisplayProfileModal({
 
               {/* Type-specific fields */}
               {renderTypeFields()}
+
+              {/* Commands tab */}
+              {activeTab === 'commands' && (
+                <CommandsTab
+                  commandDrafts={commandDrafts}
+                  onCommandDraftsChange={setCommandDrafts}
+                  initialExpandedIds={expandedCommandIds}
+                />
+              )}
             </>
           )}
         </div>

--- a/frontend/src/pages/Displays/DisplayProfile/components/fields/DynamicSettingField.tsx
+++ b/frontend/src/pages/Displays/DisplayProfile/components/fields/DynamicSettingField.tsx
@@ -139,6 +139,7 @@ export function DynamicSettingField({
         helpText={meta.helpText}
         value={Number(value ?? 0)}
         onChange={onChange}
+        min={meta.min}
       />
     );
   }

--- a/frontend/src/pages/Displays/DisplayProfile/components/fields/fieldMetadata.ts
+++ b/frontend/src/pages/Displays/DisplayProfile/components/fields/fieldMetadata.ts
@@ -142,6 +142,8 @@ export interface FieldMeta {
   options?: Array<{ value: string; label: string }>;
   /** CMS setting key that must be truthy (default: enabled) for this field to be shown at all. */
   requiresSetting?: string;
+  /** Minimum allowed value for number inputs. */
+  min?: number;
 }
 
 export type FieldMetaMap = Record<string, FieldMeta>;
@@ -294,6 +296,7 @@ function commonMeta(t: TFunction): FieldMetaMap {
         'The duration between status screen shots in minutes. 0 to disable. Warning: This is bandwidth intensive.',
       ),
       inputType: 'number',
+      min: 0,
       requiresSetting: 'DISPLAY_PROFILE_SCREENSHOT_INTERVAL_ENABLED',
     },
     screenShotSize: {
@@ -301,6 +304,7 @@ function commonMeta(t: TFunction): FieldMetaMap {
       tab: 'advanced',
       helpText: t('The size of the largest dimension. Empty or 0 means the screen size.'),
       inputType: 'number',
+      min: 0,
     },
     dayPartId: {
       label: t('Operating Hours'),
@@ -464,6 +468,7 @@ function androidMeta(t: TFunction): FieldMetaMap {
       tab: 'advanced',
       helpText: t('How long should the Action Bar be shown for, in seconds?'),
       inputType: 'number',
+      min: 0,
     },
     actionBarIntent: {
       label: t('Action Bar Intent'),
@@ -486,6 +491,7 @@ function androidMeta(t: TFunction): FieldMetaMap {
         'The number of seconds to wait before starting the application after the device has started. Minimum 10.',
       ),
       inputType: 'number',
+      min: 10,
     },
     screenShotIntent: {
       label: t('Action for Screen Shot Intent'),
@@ -569,6 +575,7 @@ function androidMeta(t: TFunction): FieldMetaMap {
         'This setting is a memory limit protection setting which will stop rendering regions beyond the limit set. Leave at 0 for no limit.',
       ),
       inputType: 'number',
+      min: 0,
     },
     videoEngine: {
       label: t('Video Engine'),
@@ -722,9 +729,49 @@ function lgSsspMeta(t: TFunction): FieldMetaMap {
       ),
       inputType: 'player-version',
     },
+    // LG/SSSP profiles have no Network or Location tabs — surface these common
+    // fields on the General tab so they remain accessible.
+    forceHttps: {
+      label: t('Force HTTPS?'),
+      tab: 'general',
+      helpText: t('Should Displays be forced to use HTTPS connection to the CMS?'),
+      inputType: 'checkbox',
+    },
+    downloadStartWindow: {
+      label: t('Download Window Start Time'),
+      tab: 'general',
+      helpText: t('The start of the time window to connect to the CMS and download updates.'),
+      inputType: 'time',
+    },
+    downloadEndWindow: {
+      label: t('Download Window End Time'),
+      tab: 'general',
+      helpText: t('The end of the time window to connect to the CMS and download updates.'),
+      inputType: 'time',
+    },
+    updateStartWindow: {
+      label: t('Update Window Start Time'),
+      tab: 'general',
+      helpText: t('The start of the time window to install application updates.'),
+      inputType: 'time',
+    },
+    updateEndWindow: {
+      label: t('Update Window End Time'),
+      tab: 'general',
+      helpText: t('The end of the time window to install application updates.'),
+      inputType: 'time',
+    },
+    dayPartId: {
+      label: t('Operating Hours'),
+      tab: 'general',
+      helpText: t(
+        'Select a day part that should act as operating hours for this display - email alerts will not be sent outside of operating hours',
+      ),
+      inputType: 'daypart',
+    },
     orientation: {
       label: t('Orientation'),
-      tab: 'location',
+      tab: 'general',
       helpText: t('Set the orientation of the device.'),
       inputType: 'dropdown',
       options: [
@@ -749,6 +796,7 @@ function lgSsspMeta(t: TFunction): FieldMetaMap {
       tab: 'advanced',
       helpText: t('How long should the Action Bar be shown for, in seconds?'),
       inputType: 'number',
+      min: 0,
     },
     mediaInventoryTimer: {
       label: t('Media Inventory Timer'),

--- a/frontend/src/services/displayProfileApi.ts
+++ b/frontend/src/services/displayProfileApi.ts
@@ -123,10 +123,18 @@ export interface HisensePictureControlEntry {
   value: number | null;
 }
 
+export interface CommandOverrideEntry {
+  commandId: number;
+  commandString: string;
+  validationString: string;
+  createAlertOn: string;
+}
+
 export interface UpdateDisplayProfileRequest {
   name: string;
   isDefault: number;
   config: Record<string, string | number | null>;
+  commandOverrides?: CommandOverrideEntry[];
   timers?: TimerEntry[];
   pictureControls?: PictureControlEntry[];
   lockOptions?: LockOptionsPayload;
@@ -192,6 +200,15 @@ export async function updateDisplayProfile(
     data.hisensePictureControls.forEach((ctrl) => {
       params.append(ctrl.property, ctrl.value !== null ? String(ctrl.value) : '');
     });
+  }
+
+  if (data.commandOverrides !== undefined) {
+    params.append('commandsSubmitted', 'on');
+    for (const cmd of data.commandOverrides) {
+      params.append(`commandString_${cmd.commandId}`, cmd.commandString);
+      params.append(`validationString_${cmd.commandId}`, cmd.validationString);
+      params.append(`createAlertOn_${cmd.commandId}`, cmd.createAlertOn);
+    }
   }
 
   const response = await http.put(`/displayprofile/${displayProfileId}`, params.toString(), {

--- a/frontend/src/types/displayProfile.ts
+++ b/frontend/src/types/displayProfile.ts
@@ -54,7 +54,14 @@ export interface DisplayProfile {
 export interface DisplayProfileCommand {
   commandId: number;
   command: string;
-  commandString?: string;
-  validationString?: string;
+  code: string;
+  description?: string | null;
+  commandString?: string | null;
+  validationString?: string | null;
+  availableOn?: string | null;
   createAlertOn?: string;
+  commandStringDisplayProfile?: string | null;
+  validationStringDisplayProfile?: string | null;
+  createAlertOnDisplayProfile?: string | null;
+  displayProfileId?: number | null;
 }

--- a/lib/Controller/DisplayProfile.php
+++ b/lib/Controller/DisplayProfile.php
@@ -358,17 +358,20 @@ class DisplayProfile extends Base
         // Different fields for each client type
         $this->editConfigFields($displayProfile, $parsedParams);
 
-        // Capture and update commands
-        foreach ($this->commandFactory->query() as $command) {
-            if ($parsedParams->getString('commandString_' . $command->commandId) != null) {
-                // Set and assign the command
-                $command->commandString = $parsedParams->getString('commandString_' . $command->commandId);
-                $command->validationString = $parsedParams->getString('validationString_' . $command->commandId);
-                $command->createAlertOn = $parsedParams->getString('createAlertOn_' . $command->commandId);
+        // Capture and update commands (only when the form explicitly submits command data)
+        if ($parsedParams->getCheckbox('commandsSubmitted')) {
+            foreach ($this->commandFactory->query() as $command) {
+                $commandString = $parsedParams->getString('commandString_' . $command->commandId);
+                if ($commandString !== null && $commandString !== '') {
+                    // Set and assign the command
+                    $command->commandString = $commandString;
+                    $command->validationString = $parsedParams->getString('validationString_' . $command->commandId);
+                    $command->createAlertOn = $parsedParams->getString('createAlertOn_' . $command->commandId);
 
-                $displayProfile->assignCommand($command);
-            } else {
-                $displayProfile->unassignCommand($command);
+                    $displayProfile->assignCommand($command);
+                } else {
+                    $displayProfile->unassignCommand($command);
+                }
             }
         }
 

--- a/lib/Entity/DisplayProfile.php
+++ b/lib/Entity/DisplayProfile.php
@@ -420,6 +420,22 @@ class DisplayProfile implements \JsonSerializable
                     'maxRegionCount',
                 );
             }
+
+            if ($configName == 'startOnBootDelay' && $configValue < 10) {
+                throw new InvalidArgumentException(
+                    __('Start delay for device start up must be at least 10'),
+                    'startOnBootDelay',
+                );
+            }
+
+            if (in_array($configName, ['actionBarDisplayDuration', 'screenShotRequestInterval', 'screenShotSize'])
+                && $configValue < 0
+            ) {
+                throw new InvalidArgumentException(
+                    __('This field must be a non-negative number'),
+                    $configName,
+                );
+            }
         }
         // Check there is only 1 default (including this one)
         $sql = '


### PR DESCRIPTION
relates to: https://github.com/xibosignageltd/xibo-private/issues/1627
- Commands tab override wipe fix: Fixed a bug where saving a Display Profile would silently delete all previously configured command overrides. The frontend now always sends all command parameters (even for commands with empty strings), and the backend properly checks for non-empty command strings before assigning, so unmodified overrides are preserved on save.

relates to: https://github.com/xibosignageltd/xibo-private/issues/1624
- Numeric field minimum enforcement (Android): Added client-side and server-side validation for five numeric fields that previously accepted values below their documented minimums:
    - "Start delay for device start up" (startOnBootDelay) — enforces minimum of 10
    - "Action Bar Display Duration" (actionBarDisplayDuration) — enforces minimum of 0
    - "Screen Shot Request Interval" (screenShotRequestInterval) — enforces minimum of 0
    - "Screen Shot Size" (screenShotSize) — enforces minimum of 0
    - "Maximum Region Count" (maxRegionCount) — enforces minimum of 0 (backend validation already existed)

relates to:https://github.com/xibosignageltd/xibo-private/issues/1629 & https://github.com/xibosignageltd/xibo-private/issues/1628
- LG/SSSP Display Profile fields: Confirmed that the Troubleshooting tab (Log Level, Elevate Logging until) and the seven General tab fields (Orientation, Download/Update Window Start/End Times, Force HTTPS, Operating Hours) are present for LG/SSSP profiles.