### PR TITLE
Fix: Missing component on Layout copy modal

### DIFF
--- a/frontend/src/pages/Design/Campaigns/Campaigns.tsx
+++ b/frontend/src/pages/Design/Campaigns/Campaigns.tsx
@@ -83,9 +83,6 @@ export default function Campaigns() {
     sorting: [],
     columnVisibility: {
       campaign: true,
-      type: true,
-      startDt: false,
-      endDt: false,
       numberLayouts: true,
       tags: true,
       totalDuration: true,
@@ -101,6 +98,9 @@ export default function Campaigns() {
       modifiedByName: true,
       ...(canAccessAdCampaign
         ? {
+            type: true,
+            startDt: false,
+            endDt: false,
             targetType: false,
             target: false,
             plays: false,

--- a/frontend/src/pages/Design/Layouts/components/CopyLayoutModal.tsx
+++ b/frontend/src/pages/Design/Layouts/components/CopyLayoutModal.tsx
@@ -22,9 +22,11 @@
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import InfoBanner from '@/components/ui/InfoBanner';
 import Checkbox from '@/components/ui/forms/Checkbox';
 import TextInput from '@/components/ui/forms/TextInput';
 import Modal from '@/components/ui/modals/Modal';
+import { useUserContext } from '@/context/UserContext';
 import type { Layout } from '@/types/layout';
 import { incrementName } from '@/utils/stringUtils';
 
@@ -46,20 +48,25 @@ export default function CopyLayoutModal({
   existingNames,
 }: CopyLayoutModalProps) {
   const { t } = useTranslation();
+  const { user } = useUserContext();
+  const defaultCopyMedia =
+    user?.settings?.LAYOUT_COPY_MEDIA_CHECKB === '1' ||
+    user?.settings?.LAYOUT_COPY_MEDIA_CHECKB === 'Checked';
+
   const [newName, setNewName] = useState('');
   const [description, setDescription] = useState('');
-  const [copyMediaFiles, setCopyMediaFiles] = useState(false);
+  const [copyMediaFiles, setCopyMediaFiles] = useState(defaultCopyMedia);
   const [error, setError] = useState<string | undefined>();
 
   useEffect(() => {
     if (layout && isOpen) {
       setNewName(incrementName(layout.layout));
       setDescription(layout.description ?? '');
-      setCopyMediaFiles(false);
+      setCopyMediaFiles(defaultCopyMedia);
     }
 
     setError(undefined);
-  }, [layout, isOpen]);
+  }, [layout, isOpen, defaultCopyMedia]);
 
   const handleSave = () => {
     const trimmed = newName.trim();
@@ -105,6 +112,13 @@ export default function CopyLayoutModal({
       ]}
     >
       <div className="px-8 pb-8 space-y-4">
+        {layout?.publishedStatus !== 'Published' && (
+          <InfoBanner type="info">
+            {t(
+              'Copying this Layout will create an exact copy of the last time this Layout was Published. Any changes made to this Layout while it has been a Draft will not be copied. Publish the Layout before making a copy if the Draft changes should be included in the copy.',
+            )}
+          </InfoBanner>
+        )}
         <TextInput
           name="newName"
           value={newName}

--- a/frontend/src/pages/Design/Templates/components/CopyTemplateModal.tsx
+++ b/frontend/src/pages/Design/Templates/components/CopyTemplateModal.tsx
@@ -25,6 +25,7 @@ import { useTranslation } from 'react-i18next';
 import Checkbox from '@/components/ui/forms/Checkbox';
 import TextInput from '@/components/ui/forms/TextInput';
 import Modal from '@/components/ui/modals/Modal';
+import { useUserContext } from '@/context/UserContext';
 import { getTemplateSchema } from '@/schema/templates';
 import type { Template } from '@/types/templates';
 import { incrementName } from '@/utils/stringUtils';
@@ -49,20 +50,23 @@ export default function CopyTemplateModal({
   existingNames,
 }: CopyTemplateModalProps) {
   const { t } = useTranslation();
+  const { user } = useUserContext();
+  const defaultCopyMedia = user?.settings?.LAYOUT_COPY_MEDIA_CHECKB === '1';
+
   const [newName, setNewName] = useState('');
   const [description, setDescription] = useState('');
-  const [copyMediaFiles, setCopyMediaFiles] = useState(false);
+  const [copyMediaFiles, setCopyMediaFiles] = useState(defaultCopyMedia);
   const [formErrors, setFormErrors] = useState<CopyTemplateFormErrors>({});
 
   useEffect(() => {
     if (template && isOpen) {
       setNewName(incrementName(template.layout));
       setDescription(template.description ?? '');
-      setCopyMediaFiles(false);
+      setCopyMediaFiles(defaultCopyMedia);
     }
 
     setFormErrors({});
-  }, [template, isOpen]);
+  }, [template, isOpen, defaultCopyMedia]);
 
   const handleSave = () => {
     const schema = getTemplateSchema(t).pick({


### PR DESCRIPTION
relates to: https://github.com/xibosignageltd/xibo-private/issues/1612

Note: 
- Sub issue: https://github.com/xibosignageltd/xibo-private/issues/1612#issuecomment-4866208401 will be implemented in a different issue. The fix requires a validation for the Tags that requires value which should be updated across all the pages that uses `TagInput`.
- Added minor changes on `Campaigns.tsx` (revert correct column conditions)