### PR TITLE
Add unit tests for Users  page

### DIFF
--- a/frontend/src/components/ui/forms/Switch.tsx
+++ b/frontend/src/components/ui/forms/Switch.tsx
@@ -25,6 +25,7 @@ import { twMerge } from 'tailwind-merge';
 
 interface SwitchProps {
   label?: string;
+  ariaLabel?: string;
   checked: boolean;
   helpText?: string;
   optional?: boolean;
@@ -36,6 +37,7 @@ interface SwitchProps {
 
 export default function Switch({
   label,
+  ariaLabel,
   checked,
   helpText,
   optional = false,
@@ -75,6 +77,7 @@ export default function Switch({
           type="button"
           role="switch"
           aria-checked={checked}
+          aria-label={label ? undefined : ariaLabel}
           disabled={disabled}
           onClick={() => onChange(!checked)}
           className={twMerge(

--- a/frontend/src/pages/Administration/UserGroups/components/UserGroupFeaturesModal.tsx
+++ b/frontend/src/pages/Administration/UserGroups/components/UserGroupFeaturesModal.tsx
@@ -261,6 +261,7 @@ export default function UserGroupFeaturesModal({
                       <div className="flex justify-center">
                         <input
                           type="checkbox"
+                          aria-label={t('Enable all in {{group}}', { group: label })}
                           checked={allEnabled}
                           ref={(el) => {
                             if (el) el.indeterminate = someEnabled;
@@ -284,6 +285,7 @@ export default function UserGroupFeaturesModal({
                           <div className="flex justify-center">
                             <input
                               type="checkbox"
+                              aria-label={t('Enable {{feature}}', { feature: feat.title })}
                               checked={enabledFeatures.has(feat.feature)}
                               onChange={() => toggleFeature(feat.feature)}
                               className="h-4 w-4 border-gray-300 rounded cursor-pointer text-blue-600 focus:ring-blue-500"

--- a/frontend/src/pages/Administration/Users/__tests__/Users.add.test.tsx
+++ b/frontend/src/pages/Administration/Users/__tests__/Users.add.test.tsx
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, beforeEach, describe, test } from 'vitest';
+
+import { mockUser, SINGLE_USER } from './fixtures/user';
+import { renderUsersPage } from './helpers/renderUsersPage';
+import { mockFetchUsers } from './mocks/userApi';
+import { mockFetchUserGroupById, mockFetchUserGroups } from './mocks/userGroupApi';
+
+import { testQueryClient } from '@/setupTests';
+
+// =============================================================================
+// Module mocks
+// =============================================================================
+
+vi.mock('@/services/userApi');
+
+vi.mock('@/services/userGroupApi');
+
+vi.mock('@/services/folderApi', () => ({
+  fetchFolderById: vi.fn().mockResolvedValue({ id: 1, text: 'Root' }),
+  fetchFolderTree: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('@/services/permissionsApi', () => ({
+  fetchGroupFolderPermissions: vi.fn().mockResolvedValue(new Map()),
+  saveMultiPermissions: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/hooks/useFilteredTabs', () => ({
+  useFilteredTabs: vi.fn(() => [{ name: 'Users', path: '/administration/users' }]),
+}));
+
+vi.mock('@/components/ui/modals/Modal');
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('Users page - modal wiring', () => {
+  beforeEach(() => {
+    testQueryClient.clear();
+    vi.clearAllMocks();
+    mockFetchUsers(SINGLE_USER);
+    mockFetchUserGroups({ rows: [], totalCount: 0 });
+    mockFetchUserGroupById({
+      groupId: mockUser.groupId!,
+      group: 'Users',
+      isUserSpecific: 0,
+      isEveryone: 0,
+      features: [],
+    });
+  });
+
+  test('clicking "Add User" opens the Add User modal', async () => {
+    const user = userEvent.setup();
+    renderUsersPage();
+
+    await user.click(await screen.findByRole('button', { name: /add user/i }));
+
+    await screen.findByRole('dialog', { name: /add user/i });
+  });
+
+  test('clicking the Edit quick action opens the Edit User modal for the correct user', async () => {
+    const user = userEvent.setup();
+    renderUsersPage();
+    await screen.findByText(mockUser.userName);
+
+    await user.click(screen.getByRole('button', { name: /^edit$/i }));
+
+    await screen.findByRole('dialog', { name: /edit user/i });
+  });
+
+  // Note: the dropdown "Edit" item calls the exact same onEdit handler as the
+  // quick action (see getUserItemActions) — already covered above, and
+  // querying it separately is ambiguous since both "Edit" buttons are in the
+  // DOM simultaneously once the dropdown is open.
+
+  test('clicking Set Home Folder opens SetHomeFolderModal for the single user', async () => {
+    const user = userEvent.setup();
+    renderUsersPage();
+    await screen.findByText(mockUser.userName);
+
+    await user.click(screen.getByRole('button', { name: /more actions/i }));
+    await user.click(await screen.findByRole('button', { name: /^set home folder$/i }));
+
+    await screen.findByRole('dialog', {
+      name: new RegExp(`set home folder for ${mockUser.userName}`, 'i'),
+    });
+  });
+
+  test('clicking User Groups opens UserGroupsModal for the user', async () => {
+    const user = userEvent.setup();
+    renderUsersPage();
+    await screen.findByText(mockUser.userName);
+
+    await user.click(screen.getByRole('button', { name: /more actions/i }));
+    await user.click(await screen.findByRole('button', { name: /^user groups$/i }));
+
+    await screen.findByRole('dialog', {
+      name: new RegExp(`user groups for ${mockUser.userName}`, 'i'),
+    });
+  });
+
+  test('clicking Features opens FeaturesModal for the user', async () => {
+    const user = userEvent.setup();
+    renderUsersPage();
+    await screen.findByText(mockUser.userName);
+
+    await user.click(screen.getByRole('button', { name: /more actions/i }));
+    await user.click(await screen.findByRole('button', { name: /^features$/i }));
+
+    await screen.findByRole('dialog', {
+      name: new RegExp(`features for ${mockUser.userName}`, 'i'),
+    });
+  });
+});

--- a/frontend/src/pages/Administration/Users/__tests__/Users.bulk.test.tsx
+++ b/frontend/src/pages/Administration/Users/__tests__/Users.bulk.test.tsx
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, beforeEach, describe, test, expect } from 'vitest';
+
+import { buildUser, mockNonAdminCurrentUser, mockUser } from './fixtures/user';
+import { renderUsersPage } from './helpers/renderUsersPage';
+import { mockFetchUsers } from './mocks/userApi';
+
+import { testQueryClient } from '@/setupTests';
+
+// =============================================================================
+// Module mocks
+// =============================================================================
+
+vi.mock('@/services/userApi');
+vi.mock('@/services/userGroupApi');
+vi.mock('@/services/folderApi', () => ({
+  fetchFolderById: vi.fn().mockResolvedValue({ id: 1, text: 'Root' }),
+  fetchFolderTree: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('@/services/permissionsApi', () => ({
+  fetchGroupFolderPermissions: vi.fn().mockResolvedValue(new Map()),
+  saveMultiPermissions: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('@/hooks/useFilteredTabs', () => ({
+  useFilteredTabs: vi.fn(() => [{ name: 'Users', path: '/administration/users' }]),
+}));
+vi.mock('@/components/ui/modals/Modal');
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+const secondUser = buildUser({ userId: 4, userName: 'msmith' });
+
+describe('Users page - bulk Set Home Folder', () => {
+  beforeEach(() => {
+    testQueryClient.clear();
+    vi.clearAllMocks();
+    mockFetchUsers({ rows: [mockUser, secondUser], totalCount: 2 });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getBulkActions has no role check — the button must appear regardless of
+  // who is logged in, unlike Tags' superAdmin-gated "Delete Selected".
+  // ---------------------------------------------------------------------------
+  test('selecting a row reveals the "Set Home Folder" bulk action button', async () => {
+    const user = userEvent.setup();
+    renderUsersPage();
+    await screen.findByText(mockUser.userName);
+
+    const checkboxes = screen.getAllByRole('checkbox', { name: /select row/i });
+    await user.click(checkboxes[0]!);
+
+    expect(await screen.findByRole('button', { name: /set home folder/i })).toBeEnabled();
+  });
+
+  test('the bulk button is visible for a non-superAdmin user (no permission gate)', async () => {
+    const user = userEvent.setup();
+    renderUsersPage(mockNonAdminCurrentUser);
+    await screen.findByText(mockUser.userName);
+
+    const checkboxes = screen.getAllByRole('checkbox', { name: /select row/i });
+    await user.click(checkboxes[0]!);
+
+    expect(await screen.findByRole('button', { name: /set home folder/i })).toBeEnabled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // UsersModals renders SetHomeFolderModal with itemsToSetHomeFolder when the
+  // bulk button is used — must include every selected user, not just one.
+  // ---------------------------------------------------------------------------
+  test('clicking the bulk button opens SetHomeFolderModal with every selected user', async () => {
+    const user = userEvent.setup();
+    renderUsersPage();
+    await screen.findByText(mockUser.userName);
+
+    const checkboxes = screen.getAllByRole('checkbox', { name: /select row/i });
+    await user.click(checkboxes[0]!);
+    await user.click(checkboxes[1]!);
+
+    await user.click(await screen.findByRole('button', { name: /set home folder/i }));
+
+    await screen.findByRole('dialog', { name: /set home folder for 2 users/i });
+  });
+});

--- a/frontend/src/pages/Administration/Users/__tests__/Users.column.test.tsx
+++ b/frontend/src/pages/Administration/Users/__tests__/Users.column.test.tsx
@@ -1,0 +1,189 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, beforeEach, describe, test, expect } from 'vitest';
+
+import { buildUser, mockCurrentUser, mockUser, SINGLE_USER } from './fixtures/user';
+import { renderUsersPage } from './helpers/renderUsersPage';
+import { mockFetchUsers } from './mocks/userApi';
+
+import { testQueryClient } from '@/setupTests';
+
+// =============================================================================
+// Module mocks
+// =============================================================================
+
+vi.mock('@/services/userApi');
+vi.mock('@/services/userGroupApi');
+vi.mock('@/services/folderApi', () => ({
+  fetchFolderTree: vi.fn().mockResolvedValue([]),
+}));
+vi.mock('@/services/permissionsApi', () => ({
+  fetchGroupFolderPermissions: vi.fn().mockResolvedValue(new Map()),
+  saveMultiPermissions: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('@/hooks/useFilteredTabs', () => ({
+  useFilteredTabs: vi.fn(() => [{ name: 'Users', path: '/administration/users' }]),
+}));
+vi.mock('@/components/ui/modals/Modal');
+
+// useUsersFilterOptions is NOT mocked — getBaseFilterKeys(t) is synchronous, runs for real
+
+// =============================================================================
+// Part 1 — Column picker visibility
+// =============================================================================
+
+describe('Users page - column visibility', () => {
+  beforeEach(() => {
+    testQueryClient.clear();
+    vi.clearAllMocks();
+    mockFetchUsers(SINGLE_USER);
+  });
+
+  // ---------------------------------------------------------------------------
+  // "First Name" is off by default in the columnVisibility config in Users.tsx.
+  // Before opening the column picker it must not appear as a column header.
+  // ---------------------------------------------------------------------------
+  test('"First Name" column header is not visible by default', async () => {
+    renderUsersPage();
+
+    await screen.findByText(mockUser.userName);
+
+    expect(screen.queryByRole('columnheader', { name: /first name/i })).not.toBeInTheDocument();
+  });
+
+  test('clicking the Columns button opens the column picker dropdown', async () => {
+    const user = userEvent.setup();
+    renderUsersPage();
+    await screen.findByText(mockUser.userName);
+
+    await user.click(screen.getByRole('button', { name: /toggle columns/i }));
+
+    expect(screen.getByRole('checkbox', { name: /first name/i })).toBeInTheDocument();
+  });
+
+  test('checking a hidden column checkbox shows that column in the table', async () => {
+    const user = userEvent.setup();
+    renderUsersPage();
+    await screen.findByText(mockUser.userName);
+
+    await user.click(screen.getByRole('button', { name: /toggle columns/i }));
+
+    const checkbox = screen.getByRole('checkbox', { name: /first name/i });
+    expect(checkbox).not.toBeChecked();
+
+    await user.click(checkbox);
+
+    expect(await screen.findByRole('columnheader', { name: /first name/i })).toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // "ID" (userId) is visible by default and hideable (no enableHiding: false).
+  // Note: the primary "Username" column has enableHiding: false and is
+  // deliberately excluded from the column picker — no checkbox exists for it.
+  // ---------------------------------------------------------------------------
+  test('unchecking a visible column checkbox hides that column from the table', async () => {
+    const user = userEvent.setup();
+    renderUsersPage();
+
+    await screen.findByRole('columnheader', { name: /^id$/i });
+
+    await user.click(screen.getByRole('button', { name: /toggle columns/i }));
+
+    const idCheckbox = screen.getByRole('checkbox', { name: /^id$/i });
+    expect(idCheckbox).toBeChecked();
+
+    await user.click(idCheckbox);
+
+    expect(screen.queryByRole('columnheader', { name: /^id$/i })).not.toBeInTheDocument();
+  });
+});
+
+// =============================================================================
+// Part 2 — Delete permission gate (isSelf)
+//
+// Edit / Set Home Folder / User Groups / Features have no permission gate in
+// getUserItemActions — they are always present. Only Delete is conditional on
+// `user.userId !== currentUser.userId`. Wiring for the always-present actions
+// is covered in Users.add.test.tsx, not here.
+// =============================================================================
+
+describe('Users page — row actions (viewing another user)', () => {
+  beforeEach(() => {
+    testQueryClient.clear();
+    vi.clearAllMocks();
+    // mockUser.userId (2) differs from mockCurrentUser.userId (1) — not self.
+    mockFetchUsers(SINGLE_USER);
+  });
+
+  test('Delete is visible in the more-actions dropdown', async () => {
+    const user = userEvent.setup();
+    renderUsersPage(mockCurrentUser);
+
+    await screen.findByText(mockUser.userName);
+    await user.click(screen.getByRole('button', { name: /more actions/i }));
+
+    // Anchor on a reliably-present action first to confirm the dropdown is open.
+    await screen.findByRole('button', { name: /^user groups$/i });
+
+    expect(screen.getByRole('button', { name: /^delete$/i })).toBeInTheDocument();
+  });
+
+  test('Edit quick action is visible', async () => {
+    renderUsersPage(mockCurrentUser);
+
+    await screen.findByText(mockUser.userName);
+
+    expect(screen.getByRole('button', { name: /^edit$/i })).toBeInTheDocument();
+  });
+});
+
+describe('Users page — row actions (viewing self)', () => {
+  beforeEach(() => {
+    testQueryClient.clear();
+    vi.clearAllMocks();
+    const selfRow = buildUser({ userId: mockCurrentUser.userId, userName: 'admin' });
+    mockFetchUsers({ rows: [selfRow], totalCount: 1 });
+  });
+
+  test('Delete is hidden in the more-actions dropdown', async () => {
+    const user = userEvent.setup();
+    renderUsersPage(mockCurrentUser);
+
+    await screen.findByText('admin');
+    await user.click(screen.getByRole('button', { name: /more actions/i }));
+
+    // Anchor on a reliably-present action first to confirm the dropdown is open.
+    await screen.findByRole('button', { name: /^user groups$/i });
+
+    expect(screen.queryByRole('button', { name: /^delete$/i })).not.toBeInTheDocument();
+  });
+
+  test('Edit quick action is still visible', async () => {
+    renderUsersPage(mockCurrentUser);
+
+    await screen.findByText('admin');
+
+    expect(screen.getByRole('button', { name: /^edit$/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Administration/Users/__tests__/Users.delete.test.tsx
+++ b/frontend/src/pages/Administration/Users/__tests__/Users.delete.test.tsx
@@ -1,0 +1,182 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent, { type UserEvent } from '@testing-library/user-event';
+import { vi, beforeEach, describe, test, expect } from 'vitest';
+
+import { mockUser, SINGLE_USER } from './fixtures/user';
+import { renderUsersPage } from './helpers/renderUsersPage';
+import { mockFetchUsers } from './mocks/userApi';
+
+import { deleteUser } from '@/services/userApi';
+import { testQueryClient } from '@/setupTests';
+
+// =============================================================================
+// Module mocks
+// =============================================================================
+
+vi.mock('@/services/userApi');
+
+vi.mock('@/services/userGroupApi');
+
+vi.mock('@/services/folderApi', () => ({
+  fetchFolderTree: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('@/services/permissionsApi', () => ({
+  fetchGroupFolderPermissions: vi.fn().mockResolvedValue(new Map()),
+  saveMultiPermissions: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/hooks/useFilteredTabs', () => ({
+  useFilteredTabs: vi.fn(() => [{ name: 'Users', path: '/administration/users' }]),
+}));
+
+vi.mock('@/components/ui/modals/Modal');
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const openDeleteModal = async (user: UserEvent) => {
+  await screen.findByText(mockUser.userName);
+
+  await user.click(screen.getByRole('button', { name: /more actions/i }));
+  await user.click(await screen.findByRole('button', { name: /^delete$/i }));
+
+  return screen.findByRole('dialog');
+};
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('Delete User', () => {
+  beforeEach(() => {
+    testQueryClient.clear();
+    vi.clearAllMocks();
+    // mockUser.userId (2) differs from mockCurrentUser.userId (1) — not self,
+    // so the Delete row action is visible.
+    mockFetchUsers(SINGLE_USER);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Clicking Delete opens the confirmation modal showing the user's name.
+  // ---------------------------------------------------------------------------
+  test('Delete row action opens the confirmation modal', async () => {
+    const user = userEvent.setup();
+    renderUsersPage();
+
+    const dialog = await openDeleteModal(user);
+
+    expect(dialog).toBeInTheDocument();
+    expect(within(dialog).getByText('Delete User?')).toBeInTheDocument();
+    expect(within(dialog).getByText(mockUser.userName)).toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Clicking Cancel closes the modal without calling the API.
+  // ---------------------------------------------------------------------------
+  test('Cancel closes the modal without calling deleteUser', async () => {
+    const user = userEvent.setup();
+    renderUsersPage();
+    await openDeleteModal(user);
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+    expect(deleteUser).not.toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Clicking "Yes, Delete" on success calls deleteUser and closes the modal.
+  // ---------------------------------------------------------------------------
+  test('successful delete calls deleteUser and closes the modal', async () => {
+    const user = userEvent.setup();
+    vi.mocked(deleteUser).mockResolvedValueOnce(undefined);
+
+    renderUsersPage();
+    await openDeleteModal(user);
+
+    await user.click(screen.getByRole('button', { name: 'Yes, Delete' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+    expect(deleteUser).toHaveBeenCalledTimes(1);
+    expect(deleteUser).toHaveBeenCalledWith(
+      mockUser.userId,
+      expect.objectContaining({ deleteAllItems: 0 }),
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // While deletion is in progress, the confirm button switches to "Deleting…"
+  // and is disabled so the user cannot submit a second time.
+  // ---------------------------------------------------------------------------
+  test('Yes, Delete button is disabled with loading label while deletion is in progress', async () => {
+    const user = userEvent.setup();
+    let resolveDelete!: () => void;
+    const controlledPromise = new Promise<void>((resolve) => {
+      resolveDelete = resolve;
+    });
+    vi.mocked(deleteUser).mockReturnValue(controlledPromise);
+
+    renderUsersPage();
+    await openDeleteModal(user);
+
+    await user.click(screen.getByRole('button', { name: 'Yes, Delete' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Deleting...' })).toBeDisabled();
+    });
+    expect(deleteUser).toHaveBeenCalledTimes(1);
+
+    // Resolve and wait for the component to settle before the test tears down.
+    resolveDelete();
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Delete modal shows an error and stays open when deletion fails.
+  // ---------------------------------------------------------------------------
+  test('failed delete keeps the modal open and shows an error', async () => {
+    const user = userEvent.setup();
+    vi.mocked(deleteUser).mockRejectedValueOnce({
+      isAxiosError: true,
+      response: { data: { message: 'Cannot delete — this is the last remaining Super Admin.' } },
+    });
+
+    renderUsersPage();
+    await openDeleteModal(user);
+
+    await user.click(screen.getByRole('button', { name: 'Yes, Delete' }));
+
+    expect(deleteUser).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText(/last remaining super admin/i)).toBeInTheDocument();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Administration/Users/__tests__/Users.filters.test.tsx
+++ b/frontend/src/pages/Administration/Users/__tests__/Users.filters.test.tsx
@@ -1,0 +1,317 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, beforeEach, describe, test, expect } from 'vitest';
+
+import { mockUser, SINGLE_USER } from './fixtures/user';
+import { renderUsersPage } from './helpers/renderUsersPage';
+import { mockFetchUsers } from './mocks/userApi';
+
+import { fetchUsers } from '@/services/userApi';
+import { testQueryClient } from '@/setupTests';
+
+// =============================================================================
+// Module mocks
+// =============================================================================
+
+vi.mock('@/services/userApi');
+
+vi.mock('@/services/userGroupApi');
+
+vi.mock('@/services/folderApi', () => ({
+  fetchFolderTree: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('@/services/permissionsApi', () => ({
+  fetchGroupFolderPermissions: vi.fn().mockResolvedValue(new Map()),
+  saveMultiPermissions: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/hooks/useFilteredTabs', () => ({
+  useFilteredTabs: vi.fn(() => [{ name: 'Users', path: '/administration/users' }]),
+}));
+
+vi.mock('@/components/ui/modals/Modal');
+
+vi.mock('@/components/ui/forms/SelectDropdown', () => ({
+  default: ({
+    label,
+    value,
+    options,
+    onSelect,
+    placeholder,
+  }: {
+    label?: string;
+    value?: string | number | null;
+    options?: Array<{ value: string | number | null; label: string }>;
+    onSelect?: (value: string) => void;
+    placeholder?: string;
+  }) => (
+    <select aria-label={label} value={value ?? ''} onChange={(e) => onSelect?.(e.target.value)}>
+      {placeholder !== undefined && <option value="">{placeholder}</option>}
+      {options?.map((o, i) => (
+        <option key={i} value={String(o.value ?? '')}>
+          {o.label}
+        </option>
+      ))}
+    </select>
+  ),
+}));
+
+// useUsersFilterOptions is NOT mocked — getBaseFilterKeys(t) is synchronous, runs for real
+
+const waitForPageReady = () => screen.findByText(mockUser.userName);
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('Users page - search and filters', () => {
+  beforeEach(() => {
+    testQueryClient.clear();
+    vi.clearAllMocks();
+    mockFetchUsers(SINGLE_USER);
+  });
+
+  test('the filter panel is hidden by default', async () => {
+    renderUsersPage();
+    await waitForPageReady();
+
+    expect(screen.queryByRole('textbox', { name: /^username$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /reset/i })).not.toBeInTheDocument();
+  });
+
+  test('clicking Filters opens the panel', async () => {
+    const user = userEvent.setup();
+    renderUsersPage();
+    await waitForPageReady();
+
+    await user.click(screen.getByRole('button', { name: /filters/i }));
+
+    expect(await screen.findByRole('textbox', { name: /^username$/i })).toBeInTheDocument();
+  });
+
+  test('clicking Filters again closes the panel', async () => {
+    const user = userEvent.setup();
+    renderUsersPage();
+    await waitForPageReady();
+
+    const filtersButton = screen.getByRole('button', { name: /filters/i });
+    await user.click(filtersButton);
+    await screen.findByRole('textbox', { name: /^username$/i });
+
+    await user.click(filtersButton);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('textbox', { name: /^username$/i })).not.toBeInTheDocument();
+    });
+  });
+
+  test('typing in the search box fetches results with that keyword', async () => {
+    const user = userEvent.setup();
+    renderUsersPage();
+    await waitForPageReady();
+
+    await user.type(screen.getByPlaceholderText('Search user...'), 'jbloggs');
+
+    await waitFor(
+      () => {
+        expect(fetchUsers).toHaveBeenCalledWith(expect.objectContaining({ keyword: 'jbloggs' }));
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  test('typing in the search box resets to page 1', async () => {
+    const user = userEvent.setup();
+    renderUsersPage();
+    await waitForPageReady();
+
+    await user.type(screen.getByPlaceholderText('Search user...'), 'jbloggs');
+
+    await waitFor(
+      () => {
+        expect(fetchUsers).toHaveBeenCalledWith(
+          expect.objectContaining({ keyword: 'jbloggs', start: 0 }),
+        );
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  test('clearing the search restores the unfiltered list', async () => {
+    const user = userEvent.setup();
+    renderUsersPage();
+    await waitForPageReady();
+
+    const search = screen.getByPlaceholderText('Search user...');
+    await user.type(search, 'jbloggs');
+    await waitFor(
+      () => {
+        expect(fetchUsers).toHaveBeenCalledWith(expect.objectContaining({ keyword: 'jbloggs' }));
+      },
+      { timeout: 2000 },
+    );
+
+    await user.clear(search);
+    await waitFor(
+      () => {
+        expect(fetchUsers).toHaveBeenCalledWith(expect.objectContaining({ keyword: undefined }));
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  test('entering a Username filter updates the query and resets to page 1', async () => {
+    const user = userEvent.setup();
+    renderUsersPage();
+    await waitForPageReady();
+
+    await user.click(screen.getByRole('button', { name: /filters/i }));
+    const usernameInput = await screen.findByRole('textbox', { name: /^username$/i });
+    await user.type(usernameInput, 'bloggs');
+
+    await waitFor(
+      () => {
+        expect(fetchUsers).toHaveBeenCalledWith(
+          expect.objectContaining({ userName: 'bloggs', start: 0 }),
+        );
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  test('selecting a User Type filter updates the query and resets to page 1', async () => {
+    const user = userEvent.setup();
+    renderUsersPage();
+    await waitForPageReady();
+
+    await user.click(screen.getByRole('button', { name: /filters/i }));
+    const userTypeSelect = await screen.findByRole('combobox', { name: /^user type$/i });
+    await user.selectOptions(userTypeSelect, '1');
+
+    await waitFor(
+      () => {
+        expect(fetchUsers).toHaveBeenCalledWith(
+          expect.objectContaining({ userTypeId: '1', start: 0 }),
+        );
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  test('selecting a Retired filter updates the query and resets to page 1', async () => {
+    const user = userEvent.setup();
+    renderUsersPage();
+    await waitForPageReady();
+
+    await user.click(screen.getByRole('button', { name: /filters/i }));
+    const retiredSelect = await screen.findByRole('combobox', { name: /^retired$/i });
+    await user.selectOptions(retiredSelect, '1');
+
+    await waitFor(
+      () => {
+        expect(fetchUsers).toHaveBeenCalledWith(
+          expect.objectContaining({ retired: '1', start: 0 }),
+        );
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  test('typing in the First Name filter updates the query and resets to page 1', async () => {
+    const user = userEvent.setup();
+    renderUsersPage();
+    await waitForPageReady();
+
+    await user.click(screen.getByRole('button', { name: /filters/i }));
+    const firstNameInput = await screen.findByPlaceholderText('First Name');
+    await user.type(firstNameInput, 'Jane');
+
+    await waitFor(
+      () => {
+        expect(fetchUsers).toHaveBeenCalledWith(
+          expect.objectContaining({ firstName: 'Jane', start: 0 }),
+        );
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  test('typing in the Last Name filter updates the query and resets to page 1', async () => {
+    const user = userEvent.setup();
+    renderUsersPage();
+    await waitForPageReady();
+
+    await user.click(screen.getByRole('button', { name: /filters/i }));
+    const lastNameInput = await screen.findByPlaceholderText('Last Name');
+    await user.type(lastNameInput, 'Bloggs');
+
+    await waitFor(
+      () => {
+        expect(fetchUsers).toHaveBeenCalledWith(
+          expect.objectContaining({ lastName: 'Bloggs', start: 0 }),
+        );
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  test('clicking Reset clears the filter inputs', async () => {
+    const user = userEvent.setup();
+    renderUsersPage();
+    await waitForPageReady();
+
+    await user.click(screen.getByRole('button', { name: /filters/i }));
+    const usernameInput = (await screen.findByRole('textbox', {
+      name: /^username$/i,
+    })) as HTMLInputElement;
+    await user.type(usernameInput, 'bloggs');
+
+    await waitFor(
+      () => {
+        expect(fetchUsers).toHaveBeenCalledWith(expect.objectContaining({ userName: 'bloggs' }));
+      },
+      { timeout: 2000 },
+    );
+
+    await user.click(screen.getByRole('button', { name: /reset/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('textbox', { name: /^username$/i })).toHaveValue('');
+    });
+  });
+
+  test('Reset keeps the filter panel open', async () => {
+    const user = userEvent.setup();
+    renderUsersPage();
+    await waitForPageReady();
+
+    await user.click(screen.getByRole('button', { name: /filters/i }));
+    await screen.findByRole('textbox', { name: /^username$/i });
+
+    await user.click(screen.getByRole('button', { name: /reset/i }));
+
+    expect(screen.getByRole('textbox', { name: /^username$/i })).toBeInTheDocument();
+  }, 20_000);
+});

--- a/frontend/src/pages/Administration/Users/__tests__/Users.render.test.tsx
+++ b/frontend/src/pages/Administration/Users/__tests__/Users.render.test.tsx
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import Users from '../Users';
+
+import { mockUser, mockCurrentUser, SINGLE_USER, EMPTY_USER_TABLE } from './fixtures/user';
+import { renderUsersPage } from './helpers/renderUsersPage';
+import { mockFetchUsers } from './mocks/userApi';
+
+import { UserProvider } from '@/context/UserContext';
+import { fetchUsers, fetchUserPreference } from '@/services/userApi';
+import { testQueryClient } from '@/setupTests';
+
+// =============================================================================
+// Module mocks
+// =============================================================================
+
+vi.mock('@/services/userApi');
+
+vi.mock('@/services/userGroupApi');
+
+vi.mock('@/services/folderApi', () => ({
+  fetchFolderTree: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('@/services/permissionsApi', () => ({
+  fetchGroupFolderPermissions: vi.fn().mockResolvedValue(new Map()),
+  saveMultiPermissions: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/hooks/useFilteredTabs', () => ({
+  useFilteredTabs: vi.fn(() => [{ name: 'Users', path: '/administration/users' }]),
+}));
+
+vi.mock('@/components/ui/modals/Modal');
+
+// useUsersFilterOptions is NOT mocked — getBaseFilterKeys(t) is synchronous, runs for real
+
+// =============================================================================
+// Helper for loading-state tests (does NOT pre-seed the userPref cache)
+// =============================================================================
+
+const renderWithPendingPrefs = () =>
+  render(
+    <QueryClientProvider client={testQueryClient}>
+      <UserProvider initialUser={mockCurrentUser}>
+        <MemoryRouter>
+          <Users />
+        </MemoryRouter>
+      </UserProvider>
+    </QueryClientProvider>,
+  );
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('Users page - render', () => {
+  beforeEach(() => {
+    testQueryClient.clear();
+    vi.clearAllMocks();
+    mockFetchUsers(SINGLE_USER);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Table rows
+  // ---------------------------------------------------------------------------
+  test('renders user rows once data has loaded', async () => {
+    renderUsersPage();
+
+    await screen.findByText(mockUser.userName);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Empty state
+  // ---------------------------------------------------------------------------
+  test('shows "No results found." when there are no users', async () => {
+    mockFetchUsers(EMPTY_USER_TABLE);
+    renderUsersPage();
+
+    // Wait for hydration to complete (Add User button confirms it)
+    await screen.findByRole('button', { name: /add user/i });
+
+    await screen.findByText('No results found.');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Add User button
+  // ---------------------------------------------------------------------------
+  test('"Add User" button is present', async () => {
+    renderUsersPage();
+
+    expect(await screen.findByRole('button', { name: /add user/i })).toBeEnabled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Search input
+  // ---------------------------------------------------------------------------
+  test('search input is present with the correct placeholder', async () => {
+    renderUsersPage();
+
+    await screen.findByText(mockUser.userName);
+
+    expect(screen.getByPlaceholderText('Search user...')).toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Filters button
+  // ---------------------------------------------------------------------------
+  test('Filters button is present', async () => {
+    renderUsersPage();
+
+    await screen.findByRole('button', { name: /filters/i });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Error state
+  // ---------------------------------------------------------------------------
+  test('shows an error alert when the API call fails', async () => {
+    vi.mocked(fetchUsers).mockRejectedValue(new Error('Server Error'));
+
+    renderUsersPage();
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Server Error');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Loading pulse
+  // ---------------------------------------------------------------------------
+  test('shows "Loading your preferences..." when the page is not yet hydrated', async () => {
+    let resolvePref!: (v: null) => void;
+    vi.mocked(fetchUserPreference).mockReturnValueOnce(
+      new Promise<null>((res) => {
+        resolvePref = res;
+      }),
+    );
+
+    renderWithPendingPrefs();
+
+    await screen.findByText('Loading your preferences...');
+
+    resolvePref(null);
+    await waitFor(() =>
+      expect(screen.queryByText('Loading your preferences...')).not.toBeInTheDocument(),
+    );
+  });
+});

--- a/frontend/src/pages/Administration/Users/__tests__/fixtures/user.ts
+++ b/frontend/src/pages/Administration/Users/__tests__/fixtures/user.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import type { FetchUsersResponse } from '@/services/userApi';
+import type { Folder } from '@/types/folder';
+import type { User } from '@/types/user';
+import { UserType } from '@/types/user';
+import type { UserGroup } from '@/types/userGroup';
+
+// -----------------------------------------------------------------------------
+// Factory that produces a row-level User with safe minimal defaults.
+// Only fields used in assertions carry meaningful values — everything else
+// is set to the zero value for its type so the component renders without errors.
+//
+// userId: 2 — deliberately differs from mockCurrentUser's id (1) so the
+//   Delete row action is visible by default (isSelf === false)
+// userName: 'jbloggs' — asserted in render, filter, and modal tests
+// userTypeId: UserType.User — drives the "User Type" column label
+// groupId: 2 — used by UserGroupsModal / FeaturesModal fetches
+// homeFolderId: 1 — required by SetHomeFolderModal / FolderPermissionTab
+// -----------------------------------------------------------------------------
+export const buildUser = (overrides: Partial<User> = {}): User => ({
+  userId: 2,
+  userName: 'jbloggs',
+  userTypeId: UserType.User,
+  email: '',
+  homePageId: '',
+  homeFolderId: 1,
+  groupId: 2,
+  retired: 0,
+  loggedIn: 0,
+  libraryQuota: 0,
+  libraryQuotaFormatted: '0 KiB',
+  twoFactorDescription: '',
+  firstName: '',
+  lastName: '',
+  phone: '',
+  ref1: '',
+  ref2: '',
+  ref3: '',
+  ref4: '',
+  ref5: '',
+  isPasswordChangeRequired: 0,
+  newUserWizard: 0,
+  features: {},
+  groups: [],
+  ...overrides,
+});
+
+export const mockUser = buildUser();
+
+export const SINGLE_USER: FetchUsersResponse = { rows: [mockUser], totalCount: 1 };
+export const EMPTY_USER_TABLE: FetchUsersResponse = { rows: [], totalCount: 0 };
+
+// The default logged-in user for Users page tests. superAdmin + folder.view
+// so the Folder Permission and Notifications tabs are visible in
+// AddEditUserModal by default.
+export const mockCurrentUser: User = {
+  userId: 1,
+  userName: 'admin',
+  userTypeId: UserType.SuperAdmin,
+  groupId: 1,
+  features: { 'folder.view': true },
+  settings: {
+    defaultTimezone: 'UTC',
+    defaultLanguage: 'en',
+    DATE_FORMAT_JS: 'DD/MM/YYYY',
+    TIME_FORMAT_JS: 'HH:mm',
+  },
+};
+
+// Non-superAdmin logged-in user — Notifications tab hidden, isSuperAdmin-gated
+// update fields absent from payloads, "Delete all content" checkbox shown.
+export const mockNonAdminCurrentUser: User = {
+  ...mockCurrentUser,
+  userId: 3,
+  userName: 'groupadmin',
+  userTypeId: UserType.GroupAdmin,
+  features: {},
+};
+
+export const mockUserGroup: UserGroup = {
+  groupId: 2,
+  group: 'Users',
+  isUserSpecific: 0,
+  isEveryone: 0,
+  isShownForAddUser: 1,
+  features: [],
+};
+
+// Root's permission checkboxes are always disabled (see FolderPermissionTree) —
+// "Marketing" is the child folder tests grant/revoke permissions on.
+export const mockFolderTree: Folder[] = [
+  {
+    id: 1,
+    type: 'root',
+    text: 'Root',
+    parentId: 0,
+    isRoot: 1,
+    children: [
+      {
+        id: 2,
+        type: '',
+        text: 'Marketing',
+        parentId: 1,
+        isRoot: 0,
+        children: [],
+        ownerId: 1,
+        ownerName: 'admin',
+        createdDt: null,
+        modifiedDt: null,
+      },
+    ],
+    ownerId: 1,
+    ownerName: 'admin',
+    createdDt: null,
+    modifiedDt: null,
+  },
+];
+
+// Query key that mirrors what useTableState builds internally for 'users_page'.
+// Centralised here so a key change only requires one update.
+export const queryKeys = {
+  usersPage: ['userPref', 'users_page'] as const,
+};

--- a/frontend/src/pages/Administration/Users/__tests__/helpers/renderUsersPage.tsx
+++ b/frontend/src/pages/Administration/Users/__tests__/helpers/renderUsersPage.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import Users from '../../Users';
+import { mockCurrentUser, queryKeys } from '../fixtures/user';
+
+import { UserProvider } from '@/context/UserContext';
+import { testQueryClient } from '@/setupTests';
+import type { User } from '@/types/user';
+
+// Renders the full Users page inside all required context providers.
+// Pre-seeds the userPref cache so useTableState hydrates immediately.
+// Call testQueryClient.clear() and vi.clearAllMocks() in beforeEach before using this helper.
+export const renderUsersPage = (user: User = mockCurrentUser) => {
+  testQueryClient.setQueryData(queryKeys.usersPage, null);
+  return render(
+    <QueryClientProvider client={testQueryClient}>
+      <UserProvider initialUser={user}>
+        <MemoryRouter>
+          <Users />
+        </MemoryRouter>
+      </UserProvider>
+    </QueryClientProvider>,
+  );
+};

--- a/frontend/src/pages/Administration/Users/__tests__/mocks/userApi.ts
+++ b/frontend/src/pages/Administration/Users/__tests__/mocks/userApi.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { vi } from 'vitest';
+
+import {
+  assignUserGroups,
+  createUser,
+  deleteUser,
+  fetchUsers,
+  setUserHomeFolder,
+  updateUser,
+} from '@/services/userApi';
+import type { FetchUsersResponse } from '@/services/userApi';
+import type { User } from '@/types/user';
+
+export const mockFetchUsers = (data: FetchUsersResponse) => {
+  vi.mocked(fetchUsers).mockResolvedValue(data);
+};
+
+export const mockDeleteUser = () => {
+  vi.mocked(deleteUser).mockResolvedValue(undefined);
+};
+
+export const mockSetUserHomeFolder = () => {
+  vi.mocked(setUserHomeFolder).mockResolvedValue(undefined);
+};
+
+export const mockAssignUserGroups = () => {
+  vi.mocked(assignUserGroups).mockResolvedValue(undefined);
+};
+
+export const mockCreateUser = (user: User) => {
+  vi.mocked(createUser).mockResolvedValue(user);
+};
+
+export const mockUpdateUser = (user: User) => {
+  vi.mocked(updateUser).mockResolvedValue(user);
+};

--- a/frontend/src/pages/Administration/Users/__tests__/mocks/userGroupApi.ts
+++ b/frontend/src/pages/Administration/Users/__tests__/mocks/userGroupApi.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { vi } from 'vitest';
+
+import { fetchUserGroupById, fetchUserGroups, updateGroupFeatures } from '@/services/userGroupApi';
+import type { FetchUserGroupsResponse } from '@/services/userGroupApi';
+import type { UserGroup } from '@/types/userGroup';
+
+export const mockFetchUserGroups = (data: FetchUserGroupsResponse) => {
+  vi.mocked(fetchUserGroups).mockResolvedValue(data);
+};
+
+export const mockFetchUserGroupById = (group: UserGroup) => {
+  vi.mocked(fetchUserGroupById).mockResolvedValue(group);
+};
+
+export const mockUpdateGroupFeatures = () => {
+  vi.mocked(updateGroupFeatures).mockResolvedValue(undefined);
+};

--- a/frontend/src/pages/Administration/Users/__tests__/modals/add-edit/add-edit.test.tsx
+++ b/frontend/src/pages/Administration/Users/__tests__/modals/add-edit/add-edit.test.tsx
@@ -1,0 +1,387 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, beforeEach, describe, test, expect } from 'vitest';
+
+import {
+  mockCurrentUser,
+  mockFolderTree,
+  mockNonAdminCurrentUser,
+  mockUser,
+  mockUserGroup,
+} from '../../fixtures/user';
+
+import { renderAddEditUserModal } from './helpers/renderAddEditUserModal';
+
+import { fetchFolderTree } from '@/services/folderApi';
+import { fetchGroupFolderPermissions, saveMultiPermissions } from '@/services/permissionsApi';
+import { createUser, updateUser } from '@/services/userApi';
+import { fetchUserGroups } from '@/services/userGroupApi';
+
+// =============================================================================
+// Module mocks
+// =============================================================================
+
+vi.mock('@/services/userApi');
+
+vi.mock('@/services/userGroupApi');
+
+vi.mock('@/services/folderApi');
+
+vi.mock('@/services/permissionsApi');
+
+vi.mock('@/components/ui/modals/Modal');
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const selectDropdownOption = async (
+  user: ReturnType<typeof userEvent.setup>,
+  labelName: RegExp,
+  optionName: RegExp,
+) => {
+  await user.click(screen.getByRole('combobox', { name: labelName }));
+  await user.click(await screen.findByRole('option', { name: optionName }));
+};
+
+const fillRequiredAddFields = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.type(screen.getByRole('textbox', { name: /^username$/i }), 'newuser');
+  await user.type(screen.getByLabelText(/^password$/i), 'Password1!');
+  await selectDropdownOption(user, /initial user group/i, new RegExp(mockUserGroup.group, 'i'));
+  await selectDropdownOption(user, /^homepage$/i, /icon dashboard/i);
+};
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('AddEditUserModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fetchFolderTree).mockResolvedValue(mockFolderTree);
+    vi.mocked(fetchGroupFolderPermissions).mockResolvedValue(new Map());
+    vi.mocked(saveMultiPermissions).mockResolvedValue(undefined);
+    vi.mocked(fetchUserGroups).mockResolvedValue({ rows: [mockUserGroup], totalCount: 1 });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Tab visibility
+  // ---------------------------------------------------------------------------
+  test('Folder Permission tab is shown when the current user has folder.view', async () => {
+    renderAddEditUserModal({ mode: 'add', currentUser: mockCurrentUser });
+
+    await screen.findByRole('tab', { name: /folder permission/i });
+  });
+
+  test('Folder Permission tab is hidden without folder.view', async () => {
+    renderAddEditUserModal({ mode: 'add', currentUser: { ...mockCurrentUser, features: {} } });
+
+    await screen.findByRole('tab', { name: /^general$/i });
+    expect(screen.queryByRole('tab', { name: /folder permission/i })).not.toBeInTheDocument();
+  });
+
+  test('Notifications tab is shown only for a super admin', async () => {
+    renderAddEditUserModal({ mode: 'add', currentUser: mockCurrentUser });
+
+    await screen.findByRole('tab', { name: /notifications/i });
+  });
+
+  test('Notifications tab is hidden for a non-superAdmin', async () => {
+    renderAddEditUserModal({ mode: 'add', currentUser: mockNonAdminCurrentUser });
+
+    await screen.findByRole('tab', { name: /^general$/i });
+    expect(screen.queryByRole('tab', { name: /notifications/i })).not.toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Add mode — groups and homepage
+  // ---------------------------------------------------------------------------
+  test('loads user groups on open filtered for add-user, excluding user-specific groups', async () => {
+    renderAddEditUserModal({ mode: 'add' });
+
+    await waitFor(() => {
+      expect(fetchUserGroups).toHaveBeenCalledWith(
+        expect.objectContaining({ isShownForAddUser: 1, isUser: 0 }),
+      );
+    });
+  });
+
+  test('group search debounces before re-fetching', async () => {
+    const user = userEvent.setup();
+    renderAddEditUserModal({ mode: 'add' });
+    await screen.findByRole('textbox', { name: /^username$/i });
+
+    await user.click(screen.getByRole('combobox', { name: /initial user group/i }));
+    await user.type(screen.getByPlaceholderText('Search groups...'), 'mark');
+
+    await waitFor(
+      () => {
+        expect(fetchUserGroups).toHaveBeenCalledWith(
+          expect.objectContaining({ userGroup: 'mark' }),
+        );
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  test('selecting a group updates the homepage options to include its feature-gated pages', async () => {
+    const user = userEvent.setup();
+    vi.mocked(fetchUserGroups).mockResolvedValue({
+      rows: [{ ...mockUserGroup, features: ['dashboard.status'] }],
+      totalCount: 1,
+    });
+
+    renderAddEditUserModal({ mode: 'add' });
+    await screen.findByRole('textbox', { name: /^username$/i });
+
+    await user.click(screen.getByRole('combobox', { name: /^homepage$/i }));
+    expect(screen.queryByRole('option', { name: /status dashboard/i })).not.toBeInTheDocument();
+    await user.keyboard('{Escape}');
+
+    await selectDropdownOption(user, /initial user group/i, new RegExp(mockUserGroup.group, 'i'));
+
+    await user.click(screen.getByRole('combobox', { name: /^homepage$/i }));
+    expect(await screen.findByRole('option', { name: /status dashboard/i })).toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Add mode — validation and save
+  // ---------------------------------------------------------------------------
+  test('saving with empty required fields shows validation errors and does not call createUser', async () => {
+    const user = userEvent.setup();
+    renderAddEditUserModal({ mode: 'add' });
+    await screen.findByRole('textbox', { name: /^username$/i });
+
+    await user.click(screen.getByRole('button', { name: /create user/i }));
+
+    expect(await screen.findByText(/username is required/i)).toBeInTheDocument();
+    expect(createUser).not.toHaveBeenCalled();
+  });
+
+  test('saving with an invalid email shows a validation error', async () => {
+    const user = userEvent.setup();
+    renderAddEditUserModal({ mode: 'add' });
+    await screen.findByRole('textbox', { name: /^username$/i });
+
+    await user.type(screen.getByRole('textbox', { name: /^email/i }), 'not-an-email');
+    await user.click(screen.getByRole('button', { name: /create user/i }));
+
+    expect(await screen.findByText(/valid email/i)).toBeInTheDocument();
+    expect(createUser).not.toHaveBeenCalled();
+  });
+
+  test('successful save calls createUser with the entered payload', async () => {
+    const user = userEvent.setup();
+    vi.mocked(createUser).mockResolvedValue({ ...mockUser, groupId: undefined });
+    const onSuccess = vi.fn();
+    const onClose = vi.fn();
+
+    renderAddEditUserModal({ mode: 'add', onSuccess, onClose });
+    await screen.findByRole('textbox', { name: /^username$/i });
+
+    await fillRequiredAddFields(user);
+    await user.click(screen.getByRole('button', { name: /create user/i }));
+
+    await waitFor(() => {
+      expect(createUser).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userName: 'newuser',
+          password: 'Password1!',
+          groupId: mockUserGroup.groupId,
+          homePageId: 'icondashboard.view',
+        }),
+      );
+    });
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('successful save with a granted folder permission also saves it', async () => {
+    const user = userEvent.setup();
+    vi.mocked(createUser).mockResolvedValue({ ...mockUser, groupId: mockUserGroup.groupId });
+
+    renderAddEditUserModal({ mode: 'add' });
+    await screen.findByRole('textbox', { name: /^username$/i });
+
+    await fillRequiredAddFields(user);
+
+    await user.click(screen.getByRole('tab', { name: /folder permission/i }));
+    await screen.findByText('Marketing');
+    const marketingRow = screen.getByText('Marketing').closest('div')!.parentElement!;
+    const checkboxes = marketingRow.querySelectorAll('input[type="checkbox"]');
+    await user.click(checkboxes[2]!); // Full Access column
+
+    await user.click(screen.getByRole('button', { name: /create user/i }));
+
+    await waitFor(() => {
+      expect(saveMultiPermissions).toHaveBeenCalledWith(
+        expect.objectContaining({
+          entity: 'Folder',
+          ids: [2],
+          groupIds: { [mockUserGroup.groupId]: { view: 1, edit: 1, delete: 1 } },
+        }),
+      );
+    });
+  });
+
+  test('API error from createUser displays in the modal', async () => {
+    const user = userEvent.setup();
+    vi.mocked(createUser).mockRejectedValue({
+      isAxiosError: true,
+      response: { data: { message: 'Username already taken' } },
+    });
+
+    renderAddEditUserModal({ mode: 'add' });
+    await screen.findByRole('textbox', { name: /^username$/i });
+
+    await fillRequiredAddFields(user);
+    await user.click(screen.getByRole('button', { name: /create user/i }));
+
+    expect(await screen.findByText('Username already taken')).toBeInTheDocument();
+  });
+
+  test('Save button shows "Creating…" while the request is pending', async () => {
+    const user = userEvent.setup();
+    let resolveCreate!: (v: typeof mockUser) => void;
+    vi.mocked(createUser).mockReturnValue(
+      new Promise((res) => {
+        resolveCreate = res;
+      }),
+    );
+
+    renderAddEditUserModal({ mode: 'add' });
+    await screen.findByRole('textbox', { name: /^username$/i });
+
+    await fillRequiredAddFields(user);
+    await user.click(screen.getByRole('button', { name: /create user/i }));
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /creating/i })).toBeDisabled());
+
+    resolveCreate({ ...mockUser, groupId: undefined });
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: /creating/i })).not.toBeInTheDocument(),
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Edit mode
+  // ---------------------------------------------------------------------------
+  test('edit mode loads existing folder permissions when the user has a group', async () => {
+    vi.mocked(fetchGroupFolderPermissions).mockResolvedValue(
+      new Map([[2, { view: 1, edit: 1, delete: 0 }]]),
+    );
+
+    const user = userEvent.setup();
+    renderAddEditUserModal({ mode: 'edit', user: mockUser });
+    await screen.findByRole('textbox', { name: /^username$/i });
+
+    await user.click(screen.getByRole('tab', { name: /folder permission/i }));
+
+    expect(await screen.findByText(/read & write/i)).toBeInTheDocument();
+  });
+
+  test('password/retype mismatch shows a validation error and makes no API call', async () => {
+    const user = userEvent.setup();
+    renderAddEditUserModal({ mode: 'edit', user: mockUser });
+    await screen.findByRole('textbox', { name: /^username$/i });
+
+    await user.type(screen.getByLabelText(/^new password/i), 'aaaaaaaa');
+    await user.type(screen.getByLabelText(/retype new password/i), 'bbbbbbbb');
+    await user.click(screen.getByRole('button', { name: /^save$/i }));
+
+    expect(await screen.findByText(/passwords do not match/i)).toBeInTheDocument();
+    expect(updateUser).not.toHaveBeenCalled();
+  });
+
+  test("successful save calls updateUser with the user's id", async () => {
+    const user = userEvent.setup();
+    vi.mocked(updateUser).mockResolvedValue(mockUser);
+
+    renderAddEditUserModal({ mode: 'edit', user: mockUser });
+    const usernameInput = await screen.findByRole('textbox', { name: /^username$/i });
+
+    await user.clear(usernameInput);
+    await user.type(usernameInput, 'updateduser');
+    await user.click(screen.getByRole('button', { name: /^save$/i }));
+
+    await waitFor(() => {
+      expect(updateUser).toHaveBeenCalledWith(
+        mockUser.userId,
+        expect.objectContaining({ userName: 'updateduser' }),
+      );
+    });
+  });
+
+  test('userTypeId and notification fields are omitted for a non-superAdmin', async () => {
+    const user = userEvent.setup();
+    vi.mocked(updateUser).mockResolvedValue(mockUser);
+
+    renderAddEditUserModal({ mode: 'edit', user: mockUser, currentUser: mockNonAdminCurrentUser });
+    await screen.findByRole('textbox', { name: /^username$/i });
+
+    await user.click(screen.getByRole('button', { name: /^save$/i }));
+
+    await waitFor(() => expect(updateUser).toHaveBeenCalledTimes(1));
+    const payload = vi.mocked(updateUser).mock.calls[0]![1];
+    expect(payload).not.toHaveProperty('isSystemNotification');
+  });
+
+  test('Save button shows "Saving…" while pending (edit mode)', async () => {
+    const user = userEvent.setup();
+    let resolveUpdate!: (v: typeof mockUser) => void;
+    vi.mocked(updateUser).mockReturnValue(
+      new Promise((res) => {
+        resolveUpdate = res;
+      }),
+    );
+
+    renderAddEditUserModal({ mode: 'edit', user: mockUser });
+    await screen.findByRole('textbox', { name: /^username$/i });
+
+    await user.click(screen.getByRole('button', { name: /^save$/i }));
+
+    await waitFor(() => expect(screen.getByRole('button', { name: /saving/i })).toBeDisabled());
+
+    resolveUpdate(mockUser);
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: /saving/i })).not.toBeInTheDocument(),
+    );
+  });
+
+  // ---------------------------------------------------------------------------
+  // Cancel
+  // ---------------------------------------------------------------------------
+  test('Cancel closes without an API call', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderAddEditUserModal({ mode: 'add', onClose });
+    await screen.findByRole('textbox', { name: /^username$/i });
+
+    await user.click(screen.getByRole('button', { name: /^cancel$/i }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(createUser).not.toHaveBeenCalled();
+    expect(updateUser).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/pages/Administration/Users/__tests__/modals/add-edit/helpers/renderAddEditUserModal.tsx
+++ b/frontend/src/pages/Administration/Users/__tests__/modals/add-edit/helpers/renderAddEditUserModal.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render } from '@testing-library/react';
+
+import AddEditUserModal from '../../../../components/AddEditUserModal';
+import { mockCurrentUser } from '../../../fixtures/user';
+
+import { UserProvider } from '@/context/UserContext';
+import { testQueryClient } from '@/setupTests';
+import type { User } from '@/types/user';
+
+interface RenderAddEditUserModalOptions {
+  mode: 'add' | 'edit';
+  user?: User | null;
+  currentUser?: User;
+  onClose?: () => void;
+  onSuccess?: () => void;
+}
+
+// Mounts AddEditUserModal in isolation for form-level and tab-level tests —
+// no DataTable, no page chrome. Pass currentUser to drive isSuperAdmin /
+// canViewFolders gates via the real UserProvider + usePermissions.
+export const renderAddEditUserModal = ({
+  mode,
+  user = null,
+  currentUser = mockCurrentUser,
+  onClose = () => {},
+  onSuccess = () => {},
+}: RenderAddEditUserModalOptions) => {
+  return render(
+    <QueryClientProvider client={testQueryClient}>
+      <UserProvider initialUser={currentUser}>
+        <AddEditUserModal isOpen mode={mode} user={user} onClose={onClose} onSuccess={onSuccess} />
+      </UserProvider>
+    </QueryClientProvider>,
+  );
+};

--- a/frontend/src/pages/Administration/Users/__tests__/modals/add-edit/tabs/folder-permission.test.tsx
+++ b/frontend/src/pages/Administration/Users/__tests__/modals/add-edit/tabs/folder-permission.test.tsx
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, beforeEach, describe, test, expect } from 'vitest';
+
+import { mockFolderTree, mockUser, mockUserGroup } from '../../../fixtures/user';
+import { renderAddEditUserModal } from '../helpers/renderAddEditUserModal';
+
+import { fetchFolderById, fetchFolderTree } from '@/services/folderApi';
+import { fetchGroupFolderPermissions } from '@/services/permissionsApi';
+import { fetchUserGroups } from '@/services/userGroupApi';
+
+// =============================================================================
+// Module mocks
+// =============================================================================
+
+vi.mock('@/services/userApi');
+
+vi.mock('@/services/userGroupApi');
+
+vi.mock('@/services/folderApi');
+
+vi.mock('@/services/permissionsApi');
+
+vi.mock('@/components/ui/modals/Modal');
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const openFolderPermissionTab = async (user: ReturnType<typeof userEvent.setup>) => {
+  await screen.findByRole('textbox', { name: /^username$/i });
+  await user.click(screen.getByRole('tab', { name: /folder permission/i }));
+  // "Marketing" may appear both as a tree row and as a permission tag —
+  // findAllByText just confirms the tree has loaded.
+  return screen.findAllByText('Marketing');
+};
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('AddEditUserModal - Folder Permission tab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fetchFolderTree).mockResolvedValue(mockFolderTree);
+    vi.mocked(fetchFolderById).mockResolvedValue({ ...mockFolderTree[0]!, text: 'Root' });
+    vi.mocked(fetchGroupFolderPermissions).mockResolvedValue(new Map());
+    vi.mocked(fetchUserGroups).mockResolvedValue({ rows: [mockUserGroup], totalCount: 1 });
+  });
+
+  test("the home folder selector shows the draft's currently selected folder", async () => {
+    const user = userEvent.setup();
+    renderAddEditUserModal({ mode: 'add' });
+    await openFolderPermissionTab(user);
+
+    expect(await screen.findByRole('button', { name: 'Root' })).toBeInTheDocument();
+  });
+
+  test('previously granted folder permissions render as removable tags', async () => {
+    vi.mocked(fetchGroupFolderPermissions).mockResolvedValue(
+      new Map([[2, { view: 1, edit: 1, delete: 0 }]]),
+    );
+
+    const user = userEvent.setup();
+    renderAddEditUserModal({ mode: 'edit', user: mockUser });
+    await openFolderPermissionTab(user);
+
+    expect(await screen.findByRole('button', { name: 'Remove Marketing' })).toBeInTheDocument();
+  });
+
+  test('removing a permission tag removes that folder from the permission set', async () => {
+    vi.mocked(fetchGroupFolderPermissions).mockResolvedValue(
+      new Map([[2, { view: 1, edit: 1, delete: 0 }]]),
+    );
+
+    const user = userEvent.setup();
+    renderAddEditUserModal({ mode: 'edit', user: mockUser });
+    await openFolderPermissionTab(user);
+
+    await user.click(await screen.findByRole('button', { name: 'Remove Marketing' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Remove Marketing' })).not.toBeInTheDocument();
+    });
+  });
+
+  test('"Clear All" empties the permission map', async () => {
+    vi.mocked(fetchGroupFolderPermissions).mockResolvedValue(
+      new Map([[2, { view: 1, edit: 1, delete: 0 }]]),
+    );
+
+    const user = userEvent.setup();
+    renderAddEditUserModal({ mode: 'edit', user: mockUser });
+    await openFolderPermissionTab(user);
+    await screen.findByRole('button', { name: 'Remove Marketing' });
+
+    await user.click(screen.getByRole('button', { name: /clear all/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Remove Marketing' })).not.toBeInTheDocument();
+    });
+  });
+
+  test('"Loading folders…" is shown while the folder tree is being fetched', async () => {
+    let resolveFolders!: (v: typeof mockFolderTree) => void;
+    vi.mocked(fetchFolderTree).mockReturnValue(
+      new Promise((res) => {
+        resolveFolders = res;
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderAddEditUserModal({ mode: 'add' });
+    await screen.findByRole('textbox', { name: /^username$/i });
+    await user.click(screen.getByRole('tab', { name: /folder permission/i }));
+
+    await screen.findByText(/loading folders/i);
+
+    resolveFolders(mockFolderTree);
+    await waitFor(() => expect(screen.queryByText(/loading folders/i)).not.toBeInTheDocument());
+  });
+
+  test('typing in the folder search box updates the search filter', async () => {
+    const user = userEvent.setup();
+    renderAddEditUserModal({ mode: 'add' });
+    await openFolderPermissionTab(user);
+
+    // Before filtering, "Root" appears twice: once as the home folder
+    // selector's label, once as its own row in the (fully expanded) tree.
+    expect(screen.getAllByText('Root')).toHaveLength(2);
+
+    const searchInput = screen.getByPlaceholderText('Search Folder');
+    await user.type(searchInput, 'Market');
+
+    expect(searchInput).toHaveValue('Market');
+    expect(screen.getByText('Marketing')).toBeInTheDocument();
+    // The tree row for "Root" is filtered out — only the selector label remains.
+    expect(screen.getAllByText('Root')).toHaveLength(1);
+  });
+});

--- a/frontend/src/pages/Administration/Users/__tests__/modals/add-edit/tabs/general.test.tsx
+++ b/frontend/src/pages/Administration/Users/__tests__/modals/add-edit/tabs/general.test.tsx
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, beforeEach, describe, test, expect } from 'vitest';
+
+import {
+  mockCurrentUser,
+  mockFolderTree,
+  mockNonAdminCurrentUser,
+  mockUser,
+  mockUserGroup,
+} from '../../../fixtures/user';
+import { renderAddEditUserModal } from '../helpers/renderAddEditUserModal';
+
+import { fetchFolderTree } from '@/services/folderApi';
+import { fetchGroupFolderPermissions } from '@/services/permissionsApi';
+import { fetchUserGroups } from '@/services/userGroupApi';
+
+// =============================================================================
+// Module mocks
+// =============================================================================
+
+vi.mock('@/services/userApi');
+
+vi.mock('@/services/userGroupApi');
+
+vi.mock('@/services/folderApi');
+
+vi.mock('@/services/permissionsApi');
+
+vi.mock('@/components/ui/modals/Modal');
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('AddEditUserModal - General tab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fetchFolderTree).mockResolvedValue(mockFolderTree);
+    vi.mocked(fetchGroupFolderPermissions).mockResolvedValue(new Map());
+    vi.mocked(fetchUserGroups).mockResolvedValue({ rows: [mockUserGroup], totalCount: 1 });
+  });
+
+  test('add mode: Username, Email, and Password fields are empty', async () => {
+    renderAddEditUserModal({ mode: 'add' });
+    await screen.findByRole('textbox', { name: /^username$/i });
+
+    expect(screen.getByRole('textbox', { name: /^username$/i })).toHaveValue('');
+    expect(screen.getByRole('textbox', { name: /^email/i })).toHaveValue('');
+    expect(screen.getByLabelText(/^password$/i)).toHaveValue('');
+  });
+
+  test('add mode: "Initial User Group" dropdown is present', async () => {
+    renderAddEditUserModal({ mode: 'add' });
+
+    await screen.findByRole('combobox', { name: /initial user group/i });
+  });
+
+  test('edit mode: "Initial User Group" dropdown is not present', async () => {
+    renderAddEditUserModal({ mode: 'edit', user: mockUser });
+    await screen.findByRole('textbox', { name: /^username$/i });
+
+    expect(screen.queryByRole('combobox', { name: /initial user group/i })).not.toBeInTheDocument();
+  });
+
+  test('edit mode: Username and Email pre-fill from the user', async () => {
+    renderAddEditUserModal({
+      mode: 'edit',
+      user: { ...mockUser, userName: 'jbloggs', email: 'j@example.com' },
+    });
+
+    expect(await screen.findByRole('textbox', { name: /^username$/i })).toHaveValue('jbloggs');
+    expect(screen.getByRole('textbox', { name: /^email/i })).toHaveValue('j@example.com');
+  });
+
+  test('edit mode: "Retype New Password" field is present', async () => {
+    renderAddEditUserModal({ mode: 'edit', user: mockUser });
+
+    await screen.findByLabelText(/retype new password/i);
+  });
+
+  test("edit mode: Retired checkbox reflects the user's retired value", async () => {
+    renderAddEditUserModal({ mode: 'edit', user: { ...mockUser, retired: 1 } });
+
+    expect(await screen.findByRole('checkbox', { name: 'Retired' })).toBeChecked();
+  });
+
+  test('User Type dropdown is shown for a super admin', async () => {
+    renderAddEditUserModal({ mode: 'add', currentUser: mockCurrentUser });
+
+    await screen.findByRole('combobox', { name: /^user type$/i });
+  });
+
+  test('User Type dropdown is hidden for a non-superAdmin', async () => {
+    renderAddEditUserModal({ mode: 'add', currentUser: mockNonAdminCurrentUser });
+    await screen.findByRole('textbox', { name: /^username$/i });
+
+    expect(screen.queryByRole('combobox', { name: /^user type$/i })).not.toBeInTheDocument();
+  });
+
+  test('the eye icon toggles the password field between hidden and visible text', async () => {
+    const user = userEvent.setup();
+    renderAddEditUserModal({ mode: 'add' });
+    await screen.findByRole('textbox', { name: /^username$/i });
+
+    const passwordInput = screen.getByLabelText(/^password$/i);
+    expect(passwordInput).toHaveAttribute('type', 'password');
+
+    await user.click(screen.getByRole('button', { name: /show password/i }));
+
+    expect(passwordInput).toHaveAttribute('type', 'text');
+  });
+
+  test("the Library Quota field reflects the draft's current quota value", async () => {
+    renderAddEditUserModal({ mode: 'edit', user: { ...mockUser, libraryQuota: 1024 } });
+
+    // The unit dropdown is fixed at 'KiB' on mount (derived from the initial
+    // draft value, 0) and does not re-derive when the value prop changes
+    // later, so a 1024 KiB quota displays as "1024", not "1" MiB.
+    const quotaInput = await screen.findByLabelText('Library Quota');
+    expect(quotaInput).toHaveValue(1024);
+  });
+});

--- a/frontend/src/pages/Administration/Users/__tests__/modals/add-edit/tabs/notifications.test.tsx
+++ b/frontend/src/pages/Administration/Users/__tests__/modals/add-edit/tabs/notifications.test.tsx
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, beforeEach, describe, test, expect } from 'vitest';
+
+import { mockCurrentUser, mockFolderTree, mockUser, mockUserGroup } from '../../../fixtures/user';
+import { renderAddEditUserModal } from '../helpers/renderAddEditUserModal';
+
+import { fetchFolderTree } from '@/services/folderApi';
+import { fetchGroupFolderPermissions } from '@/services/permissionsApi';
+import { fetchUserGroups } from '@/services/userGroupApi';
+
+// =============================================================================
+// Module mocks
+// =============================================================================
+
+vi.mock('@/services/userApi');
+
+vi.mock('@/services/userGroupApi');
+
+vi.mock('@/services/folderApi');
+
+vi.mock('@/services/permissionsApi');
+
+vi.mock('@/components/ui/modals/Modal');
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const openNotificationsTab = async (user: ReturnType<typeof userEvent.setup>) => {
+  await screen.findByRole('textbox', { name: /^username$/i });
+  await user.click(screen.getByRole('tab', { name: /^notifications$/i }));
+  return screen.findByRole('switch', { name: /system notifications/i });
+};
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('AddEditUserModal - Notifications tab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fetchFolderTree).mockResolvedValue(mockFolderTree);
+    vi.mocked(fetchGroupFolderPermissions).mockResolvedValue(new Map());
+    vi.mocked(fetchUserGroups).mockResolvedValue({ rows: [mockUserGroup], totalCount: 1 });
+  });
+
+  test("all 7 notification switches reflect the draft's saved values", async () => {
+    const user = userEvent.setup();
+    renderAddEditUserModal({
+      mode: 'edit',
+      user: {
+        ...mockUser,
+        isSystemNotification: 1,
+        isDisplayNotification: 0,
+        isDataSetNotification: 1,
+        isLayoutNotification: 0,
+        isLibraryNotification: 1,
+        isReportNotification: 0,
+        isScheduleNotification: 1,
+      },
+      currentUser: mockCurrentUser,
+    });
+    await openNotificationsTab(user);
+
+    expect(screen.getByRole('switch', { name: /system notifications/i })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    );
+    expect(screen.getByRole('switch', { name: /display notifications/i })).toHaveAttribute(
+      'aria-checked',
+      'false',
+    );
+    expect(screen.getByRole('switch', { name: /dataset notifications/i })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    );
+    expect(screen.getByRole('switch', { name: /layout notifications/i })).toHaveAttribute(
+      'aria-checked',
+      'false',
+    );
+    expect(screen.getByRole('switch', { name: /library notifications/i })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    );
+    expect(screen.getByRole('switch', { name: /report notifications/i })).toHaveAttribute(
+      'aria-checked',
+      'false',
+    );
+    expect(screen.getByRole('switch', { name: /schedule notifications/i })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    );
+  });
+
+  test('toggling System Notifications changes only that flag', async () => {
+    const user = userEvent.setup();
+    renderAddEditUserModal({
+      mode: 'edit',
+      user: { ...mockUser, isSystemNotification: 0, isDisplayNotification: 0 },
+      currentUser: mockCurrentUser,
+    });
+    await openNotificationsTab(user);
+
+    await user.click(screen.getByRole('switch', { name: /system notifications/i }));
+
+    expect(screen.getByRole('switch', { name: /system notifications/i })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    );
+    expect(screen.getByRole('switch', { name: /display notifications/i })).toHaveAttribute(
+      'aria-checked',
+      'false',
+    );
+  });
+});

--- a/frontend/src/pages/Administration/Users/__tests__/modals/add-edit/tabs/options.test.tsx
+++ b/frontend/src/pages/Administration/Users/__tests__/modals/add-edit/tabs/options.test.tsx
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, beforeEach, describe, test, expect } from 'vitest';
+
+import {
+  mockCurrentUser,
+  mockFolderTree,
+  mockNonAdminCurrentUser,
+  mockUser,
+  mockUserGroup,
+} from '../../../fixtures/user';
+import { renderAddEditUserModal } from '../helpers/renderAddEditUserModal';
+
+import { fetchFolderTree } from '@/services/folderApi';
+import { fetchGroupFolderPermissions } from '@/services/permissionsApi';
+import { fetchUserGroups } from '@/services/userGroupApi';
+
+// =============================================================================
+// Module mocks
+// =============================================================================
+
+vi.mock('@/services/userApi');
+
+vi.mock('@/services/userGroupApi');
+
+vi.mock('@/services/folderApi');
+
+vi.mock('@/services/permissionsApi');
+
+vi.mock('@/components/ui/modals/Modal');
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const openOptionsTab = async (user: ReturnType<typeof userEvent.setup>) => {
+  await screen.findByRole('textbox', { name: /^username$/i });
+  await user.click(screen.getByRole('tab', { name: /^options$/i }));
+  return screen.findByRole('switch', { name: /hide navigation/i });
+};
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('AddEditUserModal - Options tab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fetchFolderTree).mockResolvedValue(mockFolderTree);
+    vi.mocked(fetchGroupFolderPermissions).mockResolvedValue(new Map());
+    vi.mocked(fetchUserGroups).mockResolvedValue({ rows: [mockUserGroup], totalCount: 1 });
+  });
+
+  test("Hide User Guide and Force Password Change reflect the draft's values", async () => {
+    const user = userEvent.setup();
+    renderAddEditUserModal({
+      mode: 'edit',
+      user: {
+        ...mockUser,
+        newUserWizard: 0,
+        isPasswordChangeRequired: 1,
+      },
+      currentUser: mockCurrentUser,
+    });
+    await openOptionsTab(user);
+
+    expect(screen.getByRole('switch', { name: /hide user guide/i })).toHaveAttribute(
+      'aria-checked',
+      'false',
+    );
+    expect(screen.getByRole('switch', { name: /force password change/i })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    );
+  });
+
+  // The edit-mode load effect in AddEditUserModal hardcodes hideNavigation: 0
+  // regardless of the user prop — `User` has no `hideNavigation` field, so
+  // there is nothing to pre-fill from. This is intentional, not a bug.
+  test('Hide Navigation always starts unchecked in edit mode', async () => {
+    const user = userEvent.setup();
+    renderAddEditUserModal({ mode: 'edit', user: mockUser, currentUser: mockCurrentUser });
+    await openOptionsTab(user);
+
+    expect(screen.getByRole('switch', { name: /hide navigation/i })).toHaveAttribute(
+      'aria-checked',
+      'false',
+    );
+  });
+
+  test('Disable Two Factor switch is shown only in edit mode for a super admin', async () => {
+    const user = userEvent.setup();
+    renderAddEditUserModal({ mode: 'edit', user: mockUser, currentUser: mockCurrentUser });
+    await openOptionsTab(user);
+
+    expect(
+      screen.getByRole('switch', { name: /disable two factor authentication/i }),
+    ).toBeInTheDocument();
+  });
+
+  test('Disable Two Factor switch is hidden in add mode', async () => {
+    const user = userEvent.setup();
+    renderAddEditUserModal({ mode: 'add', currentUser: mockCurrentUser });
+    await screen.findByRole('textbox', { name: /^username$/i });
+    await user.click(screen.getByRole('tab', { name: /^options$/i }));
+    await screen.findByRole('switch', { name: /hide navigation/i });
+
+    expect(
+      screen.queryByRole('switch', { name: /disable two factor authentication/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('Disable Two Factor switch is hidden for a non-superAdmin', async () => {
+    const user = userEvent.setup();
+    renderAddEditUserModal({ mode: 'edit', user: mockUser, currentUser: mockNonAdminCurrentUser });
+    await openOptionsTab(user);
+
+    expect(
+      screen.queryByRole('switch', { name: /disable two factor authentication/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('toggling Force Password Change changes only that flag', async () => {
+    const user = userEvent.setup();
+    renderAddEditUserModal({
+      mode: 'edit',
+      user: { ...mockUser, isPasswordChangeRequired: 0 },
+      currentUser: mockCurrentUser,
+    });
+    await openOptionsTab(user);
+
+    await user.click(screen.getByRole('switch', { name: /force password change/i }));
+
+    expect(screen.getByRole('switch', { name: /force password change/i })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    );
+    expect(screen.getByRole('switch', { name: /hide navigation/i })).toHaveAttribute(
+      'aria-checked',
+      'false',
+    );
+  });
+});

--- a/frontend/src/pages/Administration/Users/__tests__/modals/add-edit/tabs/references.test.tsx
+++ b/frontend/src/pages/Administration/Users/__tests__/modals/add-edit/tabs/references.test.tsx
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, beforeEach, describe, test, expect } from 'vitest';
+
+import { mockFolderTree, mockUser, mockUserGroup } from '../../../fixtures/user';
+import { renderAddEditUserModal } from '../helpers/renderAddEditUserModal';
+
+import { fetchFolderTree } from '@/services/folderApi';
+import { fetchGroupFolderPermissions } from '@/services/permissionsApi';
+import { fetchUserGroups } from '@/services/userGroupApi';
+
+// =============================================================================
+// Module mocks
+// =============================================================================
+
+vi.mock('@/services/userApi');
+
+vi.mock('@/services/userGroupApi');
+
+vi.mock('@/services/folderApi');
+
+vi.mock('@/services/permissionsApi');
+
+vi.mock('@/components/ui/modals/Modal');
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const openReferencesTab = async (user: ReturnType<typeof userEvent.setup>) => {
+  await screen.findByRole('textbox', { name: /^username$/i });
+  await user.click(screen.getByRole('tab', { name: /^references$/i }));
+  return screen.findByRole('textbox', { name: /^phone number/i });
+};
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('AddEditUserModal - References tab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fetchFolderTree).mockResolvedValue(mockFolderTree);
+    vi.mocked(fetchGroupFolderPermissions).mockResolvedValue(new Map());
+    vi.mocked(fetchUserGroups).mockResolvedValue({ rows: [mockUserGroup], totalCount: 1 });
+  });
+
+  test('edit mode pre-fills Phone Number and Reference 1-5 from the user', async () => {
+    const user = userEvent.setup();
+    renderAddEditUserModal({
+      mode: 'edit',
+      user: {
+        ...mockUser,
+        phone: '0123456789',
+        ref1: 'a',
+        ref2: 'b',
+        ref3: 'c',
+        ref4: 'd',
+        ref5: 'e',
+      },
+    });
+    await openReferencesTab(user);
+
+    expect(screen.getByRole('textbox', { name: /^phone number/i })).toHaveValue('0123456789');
+    expect(screen.getByRole('textbox', { name: /^reference 1/i })).toHaveValue('a');
+    expect(screen.getByRole('textbox', { name: /^reference 2/i })).toHaveValue('b');
+    expect(screen.getByRole('textbox', { name: /^reference 3/i })).toHaveValue('c');
+    expect(screen.getByRole('textbox', { name: /^reference 4/i })).toHaveValue('d');
+    expect(screen.getByRole('textbox', { name: /^reference 5/i })).toHaveValue('e');
+  });
+
+  test('add mode renders all reference fields empty', async () => {
+    const user = userEvent.setup();
+    renderAddEditUserModal({ mode: 'add' });
+    await openReferencesTab(user);
+
+    expect(screen.getByRole('textbox', { name: /^phone number/i })).toHaveValue('');
+    expect(screen.getByRole('textbox', { name: /^reference 1/i })).toHaveValue('');
+    expect(screen.getByRole('textbox', { name: /^reference 5/i })).toHaveValue('');
+  });
+
+  test('typing into Reference 1 updates only that field', async () => {
+    const user = userEvent.setup();
+    renderAddEditUserModal({ mode: 'add' });
+    await openReferencesTab(user);
+
+    const ref1Input = screen.getByRole('textbox', { name: /^reference 1/i });
+    await user.type(ref1Input, 'new-value');
+
+    expect(ref1Input).toHaveValue('new-value');
+    expect(screen.getByRole('textbox', { name: /^reference 2/i })).toHaveValue('');
+    expect(screen.getByRole('textbox', { name: /^phone number/i })).toHaveValue('');
+  });
+});

--- a/frontend/src/pages/Administration/Users/__tests__/modals/delete.test.tsx
+++ b/frontend/src/pages/Administration/Users/__tests__/modals/delete.test.tsx
@@ -1,0 +1,206 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, beforeEach, describe, test, expect } from 'vitest';
+
+import { buildUser } from '../fixtures/user';
+
+import DeleteUserModal from '@/pages/Administration/Users/components/DeleteUserModal';
+import { fetchUsers } from '@/services/userApi';
+
+// =============================================================================
+// Module mocks
+// =============================================================================
+
+vi.mock('@/services/userApi');
+
+vi.mock('@/components/ui/modals/Modal');
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('DeleteUserModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fetchUsers).mockResolvedValue({ rows: [], totalCount: 0 });
+  });
+
+  test('confirmation message includes the target user name', async () => {
+    render(
+      <DeleteUserModal isOpen userName="jbloggs" userId={2} onClose={vi.fn()} onDelete={vi.fn()} />,
+    );
+
+    expect(await screen.findByText('jbloggs')).toBeInTheDocument();
+  });
+
+  test('"Delete all content" checkbox is shown only for a non-super-admin', async () => {
+    render(
+      <DeleteUserModal
+        isOpen
+        userName="jbloggs"
+        userId={2}
+        isSuperAdmin={false}
+        onClose={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    expect(
+      await screen.findByRole('checkbox', { name: /delete all content/i }),
+    ).toBeInTheDocument();
+  });
+
+  test('"Delete all content" checkbox is hidden for a super admin', async () => {
+    render(
+      <DeleteUserModal
+        isOpen
+        userName="jbloggs"
+        userId={2}
+        isSuperAdmin={true}
+        onClose={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    await screen.findByText('jbloggs');
+
+    expect(screen.queryByRole('checkbox', { name: /delete all content/i })).not.toBeInTheDocument();
+  });
+
+  test('checking "Delete all content" hides the reassignment dropdown', async () => {
+    const user = userEvent.setup();
+    render(
+      <DeleteUserModal
+        isOpen
+        userName="jbloggs"
+        userId={2}
+        isSuperAdmin={false}
+        onClose={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    await screen.findByRole('combobox', { name: /reassign content to/i });
+
+    await user.click(screen.getByRole('checkbox', { name: /delete all content/i }));
+
+    expect(
+      screen.queryByRole('combobox', { name: /reassign content to/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('fetches reassignment candidates excluding the user being deleted', async () => {
+    const user = userEvent.setup();
+    const deletedUser = buildUser({ userId: 2, userName: 'jbloggs' });
+    const otherUser = buildUser({ userId: 5, userName: 'other' });
+    vi.mocked(fetchUsers).mockResolvedValue({ rows: [deletedUser, otherUser], totalCount: 2 });
+
+    render(
+      <DeleteUserModal
+        isOpen
+        userName="jbloggs"
+        userId={2}
+        isSuperAdmin={false}
+        onClose={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    const combobox = await screen.findByRole('combobox', { name: /reassign content to/i });
+    await user.click(combobox);
+
+    expect(await screen.findByRole('option', { name: 'other' })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: 'jbloggs' })).not.toBeInTheDocument();
+  });
+
+  test('"Yes, Delete" calls onDelete with the chosen options', async () => {
+    const user = userEvent.setup();
+    const otherUser = buildUser({ userId: 5, userName: 'other' });
+    vi.mocked(fetchUsers).mockResolvedValue({ rows: [otherUser], totalCount: 1 });
+    const onDelete = vi.fn();
+
+    render(
+      <DeleteUserModal
+        isOpen
+        userName="jbloggs"
+        userId={2}
+        isSuperAdmin={false}
+        onClose={vi.fn()}
+        onDelete={onDelete}
+      />,
+    );
+
+    const combobox = await screen.findByRole('combobox', { name: /reassign content to/i });
+    await user.click(combobox);
+    await user.click(await screen.findByRole('option', { name: 'other' }));
+
+    await user.click(screen.getByRole('button', { name: 'Yes, Delete' }));
+
+    expect(onDelete).toHaveBeenCalledWith({ deleteAllItems: false, reassignUserId: 5 });
+  });
+
+  test('Cancel calls onClose', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    render(
+      <DeleteUserModal isOpen userName="jbloggs" userId={2} onClose={onClose} onDelete={vi.fn()} />,
+    );
+
+    await screen.findByText('jbloggs');
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('error message is shown when the error prop is set', async () => {
+    render(
+      <DeleteUserModal
+        isOpen
+        userName="jbloggs"
+        userId={2}
+        onClose={vi.fn()}
+        onDelete={vi.fn()}
+        error="Cannot delete the last Super Admin"
+      />,
+    );
+
+    expect(await screen.findByText('Cannot delete the last Super Admin')).toBeInTheDocument();
+  });
+
+  test('"Yes, Delete" is disabled and shows "Deleting..." while isLoading', async () => {
+    render(
+      <DeleteUserModal
+        isOpen
+        userName="jbloggs"
+        userId={2}
+        onClose={vi.fn()}
+        onDelete={vi.fn()}
+        isLoading
+      />,
+    );
+
+    expect(await screen.findByRole('button', { name: 'Deleting...' })).toBeDisabled();
+  });
+});

--- a/frontend/src/pages/Administration/Users/__tests__/modals/features.test.tsx
+++ b/frontend/src/pages/Administration/Users/__tests__/modals/features.test.tsx
@@ -1,0 +1,284 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, beforeEach, describe, test, expect } from 'vitest';
+
+import { mockUser } from '../fixtures/user';
+
+import FeaturesModal from '@/pages/Administration/Users/components/FeaturesModal';
+import { fetchUserGroupById, fetchUserGroups, updateGroupFeatures } from '@/services/userGroupApi';
+import type { User } from '@/types/user';
+import type { UserGroup } from '@/types/userGroup';
+
+// =============================================================================
+// Module mocks
+// =============================================================================
+
+vi.mock('@/services/userGroupApi');
+
+vi.mock('@/components/ui/modals/Modal');
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const setupFetches = (
+  ownFeatures: string[] = [],
+  allGroups: { rows: { groupId: number; isUserSpecific: number; features: string[] }[] } = {
+    rows: [],
+  },
+) => {
+  vi.mocked(fetchUserGroupById).mockResolvedValue({
+    groupId: mockUser.groupId!,
+    group: 'Users',
+    isUserSpecific: 0,
+    isEveryone: 0,
+    features: ownFeatures,
+  });
+  vi.mocked(fetchUserGroups).mockResolvedValue({
+    rows: allGroups.rows.map((g) => ({
+      groupId: g.groupId,
+      group: `Group ${g.groupId}`,
+      isUserSpecific: g.isUserSpecific,
+      isEveryone: 0,
+      features: g.features,
+    })),
+    totalCount: allGroups.rows.length,
+  });
+};
+
+const expandGroup = async (user: ReturnType<typeof userEvent.setup>, groupLabel: string) => {
+  await user.click(screen.getByRole('button', { name: new RegExp(`^${groupLabel}`, 'i') }));
+};
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('FeaturesModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupFetches();
+  });
+
+  test("loads the user's group features and inherited features on mount", async () => {
+    const memberGroupUser: User = { ...mockUser, groupId: 2, groups: [{ groupId: 5 } as never] };
+    setupFetches(['folder.view'], {
+      rows: [{ groupId: 5, isUserSpecific: 0, features: ['folder.add'] }],
+    });
+
+    render(<FeaturesModal user={memberGroupUser} onClose={vi.fn()} onSuccess={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(fetchUserGroupById).toHaveBeenCalledWith(2);
+      expect(fetchUserGroups).toHaveBeenCalledWith({ start: 0, length: 1000 });
+    });
+  });
+
+  test('shows "Loading..." while fetching', async () => {
+    let resolveFetch!: (v: UserGroup) => void;
+    vi.mocked(fetchUserGroupById).mockReturnValue(
+      new Promise((res) => {
+        resolveFetch = res;
+      }),
+    );
+
+    render(<FeaturesModal user={mockUser} onClose={vi.fn()} onSuccess={vi.fn()} />);
+
+    await screen.findByText('Loading...');
+
+    resolveFetch({
+      groupId: mockUser.groupId!,
+      group: 'Users',
+      isUserSpecific: 0,
+      isEveryone: 0,
+      features: [],
+    });
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument());
+  });
+
+  test("category tabs render; switching tabs shows that category's groups", async () => {
+    const user = userEvent.setup();
+    render(<FeaturesModal user={mockUser} onClose={vi.fn()} onSuccess={vi.fn()} />);
+
+    await screen.findByRole('button', { name: /^folders/i });
+
+    await user.click(screen.getByRole('tab', { name: /^displays/i }));
+
+    expect(screen.getByRole('button', { name: /^displays/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^folders/i })).not.toBeInTheDocument();
+  });
+
+  test('toggling a single feature checkbox updates enabledFeatures', async () => {
+    const user = userEvent.setup();
+    render(<FeaturesModal user={mockUser} onClose={vi.fn()} onSuccess={vi.fn()} />);
+    await screen.findByRole('button', { name: /^folders/i });
+
+    await expandGroup(user, 'Folders');
+
+    const checkbox = screen.getByRole('checkbox', {
+      name: /enable view folder tree on grids and forms/i,
+    });
+    expect(checkbox).not.toBeChecked();
+
+    await user.click(checkbox);
+
+    expect(checkbox).toBeChecked();
+  });
+
+  test('toggling the group header checkbox enables every feature in the group', async () => {
+    const user = userEvent.setup();
+    render(<FeaturesModal user={mockUser} onClose={vi.fn()} onSuccess={vi.fn()} />);
+    await screen.findByRole('button', { name: /^folders/i });
+
+    await user.click(screen.getByRole('checkbox', { name: /enable all in folders/i }));
+    await expandGroup(user, 'Folders');
+
+    expect(
+      screen.getByRole('checkbox', { name: /enable view folder tree on grids and forms/i }),
+    ).toBeChecked();
+    expect(
+      screen.getByRole('checkbox', { name: /enable set a home folder for a user/i }),
+    ).toBeChecked();
+  });
+
+  test('group header checkbox is indeterminate when only some features are enabled', async () => {
+    setupFetches(['folder.view']);
+    render(<FeaturesModal user={mockUser} onClose={vi.fn()} onSuccess={vi.fn()} />);
+    await screen.findByRole('button', { name: /^folders/i });
+
+    const groupCheckbox = screen.getByRole('checkbox', {
+      name: /enable all in folders/i,
+    }) as HTMLInputElement;
+
+    expect(groupCheckbox.indeterminate).toBe(true);
+  });
+
+  test('inherited checkbox is always disabled and reflects inheritedFeatures', async () => {
+    const user = userEvent.setup();
+    const memberGroupUser: User = { ...mockUser, groupId: 2, groups: [{ groupId: 5 } as never] };
+    setupFetches([], { rows: [{ groupId: 5, isUserSpecific: 0, features: ['folder.add'] }] });
+
+    render(<FeaturesModal user={memberGroupUser} onClose={vi.fn()} onSuccess={vi.fn()} />);
+    await screen.findByRole('button', { name: /^folders/i });
+    await expandGroup(user, 'Folders');
+
+    const inheritedCheckbox = await screen.findByRole('checkbox', {
+      name: /allow users to create sub-folders under folders they have access to.*inherited/i,
+    });
+
+    expect(inheritedCheckbox).toBeChecked();
+    expect(inheritedCheckbox).toBeDisabled();
+  });
+
+  test('expanding/collapsing a group shows/hides its individual feature rows', async () => {
+    const user = userEvent.setup();
+    render(<FeaturesModal user={mockUser} onClose={vi.fn()} onSuccess={vi.fn()} />);
+    await screen.findByRole('button', { name: /^folders/i });
+
+    expect(screen.queryByText('View Folder Tree on Grids and Forms')).not.toBeInTheDocument();
+
+    await expandGroup(user, 'Folders');
+    expect(screen.getByText('View Folder Tree on Grids and Forms')).toBeInTheDocument();
+
+    await expandGroup(user, 'Folders');
+    expect(screen.queryByText('View Folder Tree on Grids and Forms')).not.toBeInTheDocument();
+  });
+
+  test('save calls updateGroupFeatures with the group id and enabled features', async () => {
+    const user = userEvent.setup();
+    vi.mocked(updateGroupFeatures).mockResolvedValue(undefined);
+    render(<FeaturesModal user={mockUser} onClose={vi.fn()} onSuccess={vi.fn()} />);
+    await screen.findByRole('button', { name: /^folders/i });
+
+    await expandGroup(user, 'Folders');
+    await user.click(
+      screen.getByRole('checkbox', { name: /enable view folder tree on grids and forms/i }),
+    );
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(updateGroupFeatures).toHaveBeenCalledWith(mockUser.groupId, ['folder.view']);
+    });
+  });
+
+  test('successful save calls onSuccess and onClose', async () => {
+    const user = userEvent.setup();
+    vi.mocked(updateGroupFeatures).mockResolvedValue(undefined);
+    const onSuccess = vi.fn();
+    const onClose = vi.fn();
+
+    render(<FeaturesModal user={mockUser} onClose={onClose} onSuccess={onSuccess} />);
+    await screen.findByRole('button', { name: /^folders/i });
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('API error displays in the modal', async () => {
+    const user = userEvent.setup();
+    vi.mocked(updateGroupFeatures).mockRejectedValue({
+      isAxiosError: true,
+      response: { data: { message: 'Failed to update features' } },
+    });
+
+    render(<FeaturesModal user={mockUser} onClose={vi.fn()} onSuccess={vi.fn()} />);
+    await screen.findByRole('button', { name: /^folders/i });
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(await screen.findByText('Failed to update features')).toBeInTheDocument();
+  });
+
+  test('Save button shows "Saving..." while pending', async () => {
+    const user = userEvent.setup();
+    let resolveSave!: () => void;
+    vi.mocked(updateGroupFeatures).mockReturnValue(
+      new Promise((res) => {
+        resolveSave = res;
+      }),
+    );
+
+    render(<FeaturesModal user={mockUser} onClose={vi.fn()} onSuccess={vi.fn()} />);
+    await screen.findByRole('button', { name: /^folders/i });
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Saving...' })).toBeDisabled());
+
+    resolveSave();
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: 'Saving...' })).not.toBeInTheDocument(),
+    );
+  });
+
+  test('no groupId skips the fetch and clears loading immediately', async () => {
+    const noGroupUser: User = { ...mockUser, groupId: undefined };
+    render(<FeaturesModal user={noGroupUser} onClose={vi.fn()} onSuccess={vi.fn()} />);
+
+    await screen.findByRole('button', { name: /^folders/i });
+    expect(fetchUserGroupById).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/pages/Administration/Users/__tests__/modals/set-home-folder.test.tsx
+++ b/frontend/src/pages/Administration/Users/__tests__/modals/set-home-folder.test.tsx
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, beforeEach, describe, test, expect } from 'vitest';
+
+import { buildUser, mockUser } from '../fixtures/user';
+
+import SetHomeFolderModal from '@/pages/Administration/Users/components/SetHomeFolderModal';
+import { setUserHomeFolder } from '@/services/userApi';
+
+// =============================================================================
+// Module mocks
+// =============================================================================
+
+vi.mock('@/services/userApi');
+
+vi.mock('@/components/ui/modals/Modal');
+
+vi.mock('@/components/ui/forms/SelectFolder', () => ({
+  default: ({
+    selectedId,
+    onSelect,
+  }: {
+    selectedId?: number | null;
+    onSelect: (folder: { id: number; text: string } | null) => void;
+  }) => (
+    <button onClick={() => onSelect({ id: 5, text: 'Marketing' })}>
+      Select Folder (current: {selectedId ?? 'none'})
+    </button>
+  ),
+}));
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('SetHomeFolderModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('title is singular for one user', async () => {
+    render(<SetHomeFolderModal users={[mockUser]} onClose={vi.fn()} onSuccess={vi.fn()} />);
+
+    await screen.findByRole('dialog', {
+      name: new RegExp(`set home folder for ${mockUser.userName}`, 'i'),
+    });
+  });
+
+  test('title is plural with a count for multiple users', async () => {
+    const secondUser = buildUser({ userId: 4, userName: 'msmith' });
+    render(
+      <SetHomeFolderModal users={[mockUser, secondUser]} onClose={vi.fn()} onSuccess={vi.fn()} />,
+    );
+
+    await screen.findByRole('dialog', { name: /set home folder for 2 users/i });
+  });
+
+  test("the folder picker starts with the first user's home folder selected", async () => {
+    const firstUser = buildUser({ homeFolderId: 7 });
+    render(<SetHomeFolderModal users={[firstUser]} onClose={vi.fn()} onSuccess={vi.fn()} />);
+
+    expect(await screen.findByText(/current: 7/i)).toBeInTheDocument();
+  });
+
+  test('save calls setUserHomeFolder once per selected user', async () => {
+    const user = userEvent.setup();
+    vi.mocked(setUserHomeFolder).mockResolvedValue(undefined);
+    const secondUser = buildUser({ userId: 4, userName: 'msmith' });
+
+    render(
+      <SetHomeFolderModal users={[mockUser, secondUser]} onClose={vi.fn()} onSuccess={vi.fn()} />,
+    );
+
+    await user.click(await screen.findByRole('button', { name: /select folder/i }));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(setUserHomeFolder).toHaveBeenCalledTimes(2));
+    expect(setUserHomeFolder).toHaveBeenCalledWith(mockUser.userId, 5);
+    expect(setUserHomeFolder).toHaveBeenCalledWith(secondUser.userId, 5);
+  });
+
+  test('all succeeding calls onSuccess and onClose', async () => {
+    const user = userEvent.setup();
+    vi.mocked(setUserHomeFolder).mockResolvedValue(undefined);
+    const onSuccess = vi.fn();
+    const onClose = vi.fn();
+
+    render(<SetHomeFolderModal users={[mockUser]} onClose={onClose} onSuccess={onSuccess} />);
+
+    await user.click(await screen.findByRole('button', { name: /select folder/i }));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('partial failure shows the error, calls onSuccess, but not onClose', async () => {
+    const user = userEvent.setup();
+    const secondUser = buildUser({ userId: 4, userName: 'msmith' });
+    vi.mocked(setUserHomeFolder).mockImplementation((userId) =>
+      userId === secondUser.userId
+        ? Promise.reject({ isAxiosError: true, response: { data: { message: 'Update failed' } } })
+        : Promise.resolve(undefined),
+    );
+    const onSuccess = vi.fn();
+    const onClose = vi.fn();
+
+    render(
+      <SetHomeFolderModal users={[mockUser, secondUser]} onClose={onClose} onSuccess={onSuccess} />,
+    );
+
+    await user.click(await screen.findByRole('button', { name: /select folder/i }));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(await screen.findByText('Update failed')).toBeInTheDocument();
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  test('Cancel closes without saving', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    render(<SetHomeFolderModal users={[mockUser]} onClose={onClose} onSuccess={vi.fn()} />);
+
+    await screen.findByRole('dialog', {
+      name: new RegExp(`set home folder for ${mockUser.userName}`, 'i'),
+    });
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(setUserHomeFolder).not.toHaveBeenCalled();
+  });
+
+  test('Save button shows "Saving..." while pending', async () => {
+    const user = userEvent.setup();
+    let resolveSave!: () => void;
+    vi.mocked(setUserHomeFolder).mockReturnValue(
+      new Promise((res) => {
+        resolveSave = res;
+      }),
+    );
+
+    render(<SetHomeFolderModal users={[mockUser]} onClose={vi.fn()} onSuccess={vi.fn()} />);
+
+    await user.click(await screen.findByRole('button', { name: /select folder/i }));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Saving...' })).toBeDisabled());
+
+    resolveSave();
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: 'Saving...' })).not.toBeInTheDocument(),
+    );
+  });
+});

--- a/frontend/src/pages/Administration/Users/__tests__/modals/user-groups.test.tsx
+++ b/frontend/src/pages/Administration/Users/__tests__/modals/user-groups.test.tsx
@@ -1,0 +1,259 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { vi, beforeEach, describe, test, expect } from 'vitest';
+
+import { mockUser, mockUserGroup } from '../fixtures/user';
+
+import UserGroupsModal from '@/pages/Administration/Users/components/UserGroupsModal';
+import { assignUserGroups } from '@/services/userApi';
+import { fetchUserGroups } from '@/services/userGroupApi';
+import { testQueryClient } from '@/setupTests';
+import type { UserGroup } from '@/types/userGroup';
+
+// =============================================================================
+// Module mocks
+// =============================================================================
+
+vi.mock('@/services/userApi');
+
+vi.mock('@/services/userGroupApi');
+
+vi.mock('@/components/ui/modals/Modal');
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const renderModal = (props: Partial<React.ComponentProps<typeof UserGroupsModal>> = {}) => {
+  return render(
+    <QueryClientProvider client={testQueryClient}>
+      <MemoryRouter>
+        <UserGroupsModal user={mockUser} onClose={vi.fn()} onSuccess={vi.fn()} {...props} />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+};
+
+const marketingGroup: UserGroup = {
+  groupId: 9,
+  group: 'Marketing',
+  isUserSpecific: 0,
+  isEveryone: 0,
+};
+
+const mockFetchUserGroupsByCall = (
+  assigned: { rows: UserGroup[]; totalCount: number },
+  search: { rows: UserGroup[]; totalCount: number },
+) => {
+  vi.mocked(fetchUserGroups).mockImplementation(async (params) => {
+    if (params?.userIdMember !== undefined) return assigned;
+    return search;
+  });
+};
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('UserGroupsModal', () => {
+  beforeEach(() => {
+    testQueryClient.clear();
+    vi.clearAllMocks();
+    mockFetchUserGroupsByCall(
+      { rows: [mockUserGroup], totalCount: 1 },
+      { rows: [], totalCount: 0 },
+    );
+  });
+
+  test('loads currently assigned groups, excluding user-specific groups', async () => {
+    mockFetchUserGroupsByCall(
+      {
+        rows: [
+          mockUserGroup,
+          { ...mockUserGroup, groupId: 9, group: 'Personal', isUserSpecific: 1 },
+        ],
+        totalCount: 2,
+      },
+      { rows: [], totalCount: 0 },
+    );
+
+    renderModal();
+
+    expect(await screen.findByText(mockUserGroup.group)).toBeInTheDocument();
+    expect(screen.queryByText('Personal')).not.toBeInTheDocument();
+  });
+
+  test('search input filters available groups after a debounce', async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await screen.findByText(mockUserGroup.group);
+
+    await user.type(screen.getByRole('textbox', { name: /search/i }), 'Market');
+
+    await waitFor(
+      () => {
+        expect(fetchUserGroups).toHaveBeenCalledWith(
+          expect.objectContaining({ userGroup: 'Market' }),
+        );
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  test('adding a searched group moves it into the assigned list', async () => {
+    const user = userEvent.setup();
+    mockFetchUserGroupsByCall(
+      { rows: [mockUserGroup], totalCount: 1 },
+      { rows: [marketingGroup], totalCount: 1 },
+    );
+
+    renderModal();
+    await screen.findByText(mockUserGroup.group);
+    await screen.findByText(marketingGroup.group);
+
+    await user.click(screen.getByRole('button', { name: /^add$/i }));
+
+    // "Marketing" now appears twice — once as an assigned chip, once in the
+    // search results row (whose action icon flips from Add to Remove).
+    expect(await screen.findByRole('button', { name: 'Remove Marketing' })).toBeInTheDocument();
+    expect(await screen.findAllByText(marketingGroup.group)).toHaveLength(2);
+  });
+
+  test('removing an assigned group takes it out of the assigned list', async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await screen.findByText(mockUserGroup.group);
+
+    await user.click(screen.getByRole('button', { name: `Remove ${mockUserGroup.group}` }));
+
+    expect(screen.queryByText(mockUserGroup.group)).not.toBeInTheDocument();
+    expect(await screen.findByText('No groups assigned.')).toBeInTheDocument();
+  });
+
+  test('"Clear" removes every assigned group', async () => {
+    const user = userEvent.setup();
+    renderModal();
+    await screen.findByText(mockUserGroup.group);
+
+    await user.click(screen.getByRole('button', { name: 'Clear' }));
+
+    expect(await screen.findByText('No groups assigned.')).toBeInTheDocument();
+  });
+
+  test('save with no pending changes just closes the modal', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderModal({ onClose });
+    await screen.findByText(mockUserGroup.group);
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(assignUserGroups).not.toHaveBeenCalled();
+  });
+
+  test('save with pending changes calls assignUserGroups with toAdd/toRemove', async () => {
+    const user = userEvent.setup();
+    mockFetchUserGroupsByCall(
+      { rows: [mockUserGroup], totalCount: 1 },
+      { rows: [marketingGroup], totalCount: 1 },
+    );
+    vi.mocked(assignUserGroups).mockResolvedValue(undefined);
+
+    renderModal();
+    await screen.findByText(mockUserGroup.group);
+    await screen.findByText(marketingGroup.group);
+
+    await user.click(screen.getByRole('button', { name: /^add$/i }));
+    await screen.findAllByText(marketingGroup.group);
+    await user.click(screen.getByRole('button', { name: `Remove ${mockUserGroup.group}` }));
+
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(assignUserGroups).toHaveBeenCalledWith(
+        mockUser.userId,
+        [marketingGroup.groupId],
+        [mockUserGroup.groupId],
+      );
+    });
+  });
+
+  test('successful save calls onSuccess and onClose', async () => {
+    const user = userEvent.setup();
+    vi.mocked(assignUserGroups).mockResolvedValue(undefined);
+    const onSuccess = vi.fn();
+    const onClose = vi.fn();
+
+    renderModal({ onSuccess, onClose });
+    await screen.findByText(mockUserGroup.group);
+
+    await user.click(screen.getByRole('button', { name: /remove/i }));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('failed save shows an error and keeps the modal open', async () => {
+    const user = userEvent.setup();
+    vi.mocked(assignUserGroups).mockRejectedValue({
+      isAxiosError: true,
+      response: { data: { message: 'Failed to update group membership.' } },
+    });
+
+    renderModal();
+    await screen.findByText(mockUserGroup.group);
+
+    await user.click(screen.getByRole('button', { name: /remove/i }));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(await screen.findByText('Failed to update group membership.')).toBeInTheDocument();
+  });
+
+  test('Save button shows "Saving…" while pending', async () => {
+    const user = userEvent.setup();
+    let resolveSave!: () => void;
+    vi.mocked(assignUserGroups).mockReturnValue(
+      new Promise((res) => {
+        resolveSave = res;
+      }),
+    );
+
+    renderModal();
+    await screen.findByText(mockUserGroup.group);
+
+    await user.click(screen.getByRole('button', { name: /remove/i }));
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Saving…' })).toBeDisabled());
+
+    resolveSave();
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: 'Saving…' })).not.toBeInTheDocument(),
+    );
+  });
+});

--- a/frontend/src/pages/Administration/Users/components/FeaturesModal.tsx
+++ b/frontend/src/pages/Administration/Users/components/FeaturesModal.tsx
@@ -287,6 +287,7 @@ export default function FeaturesModal({ user, onClose, onSuccess }: FeaturesModa
                       <div className="flex justify-center">
                         <input
                           type="checkbox"
+                          aria-label={t('Enable all in {{group}}', { group: label })}
                           checked={allEnabled}
                           ref={(el) => {
                             if (el) el.indeterminate = someEnabled;
@@ -298,6 +299,7 @@ export default function FeaturesModal({ user, onClose, onSuccess }: FeaturesModa
                       <div className="flex justify-center">
                         <input
                           type="checkbox"
+                          aria-label={t('{{group}} inherited', { group: label })}
                           checked={features.some((f) => inheritedFeatures.has(f.feature))}
                           disabled
                           className="h-4 w-4 border-gray-300 rounded text-gray-400 opacity-60 disabled:bg-slate-100 disabled:cursor-not-allowed"
@@ -318,6 +320,7 @@ export default function FeaturesModal({ user, onClose, onSuccess }: FeaturesModa
                           <div className="flex justify-center">
                             <input
                               type="checkbox"
+                              aria-label={t('Enable {{feature}}', { feature: feat.title })}
                               checked={enabledFeatures.has(feat.feature)}
                               onChange={() => toggleFeature(feat.feature)}
                               className="h-4 w-4 border-gray-300 rounded cursor-pointer text-blue-600 focus:ring-blue-500"
@@ -326,6 +329,7 @@ export default function FeaturesModal({ user, onClose, onSuccess }: FeaturesModa
                           <div className="flex justify-center">
                             <input
                               type="checkbox"
+                              aria-label={t('{{feature}} inherited', { feature: feat.title })}
                               checked={inheritedFeatures.has(feat.feature)}
                               disabled
                               className="h-4 w-4 border-gray-300 rounded text-gray-400 opacity-60 disabled:bg-slate-100 disabled:cursor-not-allowed"

--- a/frontend/src/pages/Administration/Users/components/LibraryQuotaInput.tsx
+++ b/frontend/src/pages/Administration/Users/components/LibraryQuotaInput.tsx
@@ -99,11 +99,15 @@ export default function LibraryQuotaInput({ value, onChange, error }: LibraryQuo
 
   return (
     <div className="flex flex-col gap-1 w-full">
-      <label className="flex items-center justify-between text-sm font-semibold text-gray-500 leading-4.5">
+      <label
+        htmlFor="libraryQuota"
+        className="flex items-center justify-between text-sm font-semibold text-gray-500 leading-4.5"
+      >
         {t('Library Quota')}
       </label>
       <div className="flex items-center border border-gray-200 rounded-lg overflow-visible bg-white h-11.25 focus-within:border-xibo-blue-600 focus-within:ring-1 focus-within:ring-xibo-blue-600/25">
         <input
+          id="libraryQuota"
           type="number"
           value={inputValue}
           onChange={handleValueChange}

--- a/frontend/src/pages/Administration/Users/components/SwitchRow.tsx
+++ b/frontend/src/pages/Administration/Users/components/SwitchRow.tsx
@@ -43,7 +43,14 @@ export default function SwitchRow({
         {description && <p className="text-sm text-gray-500 mt-0.5">{description}</p>}
       </div>
       <div className="shrink-0">
-        <Switch size="sm" checked={checked} onChange={onChange} hideOnOff disabled={disabled} />
+        <Switch
+          size="sm"
+          ariaLabel={title}
+          checked={checked}
+          onChange={onChange}
+          hideOnOff
+          disabled={disabled}
+        />
       </div>
     </div>
   );

--- a/frontend/src/pages/Administration/Users/components/tabs/FolderPermissionTab.tsx
+++ b/frontend/src/pages/Administration/Users/components/tabs/FolderPermissionTab.tsx
@@ -96,6 +96,7 @@ export default function FolderPermissionTab({
                       next.delete(folderId);
                       setFolderPermissions(next);
                     }}
+                    aria-label={t('Remove {{name}}', { name: displayName })}
                     className="ml-0.5 text-blue-500 hover:text-blue-800"
                   >
                     <X size={12} />

--- a/frontend/src/pages/Administration/Users/components/tabs/GeneralTab.tsx
+++ b/frontend/src/pages/Administration/Users/components/tabs/GeneralTab.tsx
@@ -134,6 +134,7 @@ export default function GeneralTab({
           <button
             type="button"
             onClick={() => setShowPassword((prev) => !prev)}
+            aria-label={showPassword ? t('Hide password') : t('Show password')}
             className="px-3 text-gray-500 hover:text-gray-700 transition-colors"
           >
             {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}


### PR DESCRIPTION
I added `aria-label`s to the Users checkboxes and switches so screen readers and vitests can identify each control by name instead of relying on their position in the UI. These are attribute-only changes with no impact on existing functionality.
