### PR TITLE
Menu Boards: Fix updating modifiedDt, add auditing.

### DIFF
--- a/frontend/src/pages/Library/MenuBoard/subPages/Categories/components/AddAndEditMenuBoardCategoryModal.tsx
+++ b/frontend/src/pages/Library/MenuBoard/subPages/Categories/components/AddAndEditMenuBoardCategoryModal.tsx
@@ -67,7 +67,7 @@ const createDraftFromData = (data?: MenuBoardCategory | null): CategoryDraft => 
     name: data.name ?? '',
     description: data.description ?? '',
     code: data.code ?? '',
-    mediaId: data.mediaId != null ? Number(data.mediaId) : null,
+    mediaId: data.mediaId ? Number(data.mediaId) : null,
   };
 };
 

--- a/lib/Controller/MenuBoardCategory.php
+++ b/lib/Controller/MenuBoardCategory.php
@@ -268,6 +268,7 @@ class MenuBoardCategory extends Base
             $params->getString('description'),
             $params->getString('code')
         );
+        $menuBoard->touch();
 
         return $response
             ->withStatus(201)
@@ -345,7 +346,7 @@ class MenuBoardCategory extends Base
             $sanitizedParams->getString('description')
         );
         $menuBoardCategory->save();
-        $menuBoard->save(['audit' => false]);
+        $menuBoard->touch();
 
         return $response
             ->withStatus(201)
@@ -406,11 +407,11 @@ class MenuBoardCategory extends Base
         $menuBoardCategory = $this->menuBoardCategoryFactory->getById($id);
 
         $menuBoardCategory->name = $sanitizedParams->getString('name');
-        $menuBoardCategory->mediaId = $sanitizedParams->getInt('mediaId');
+        $menuBoardCategory->mediaId = $sanitizedParams->getInt('mediaId') ?: null;
         $menuBoardCategory->code = $sanitizedParams->getString('code');
         $menuBoardCategory->description = $sanitizedParams->getString('description');
         $menuBoardCategory->save();
-        $menuBoard->save();
+        $menuBoard->touch();
 
         return $response
             ->withStatus(200)
@@ -442,6 +443,7 @@ class MenuBoardCategory extends Base
 
         $menuBoardCategory = $this->menuBoardCategoryFactory->getById($id);
         $menuBoardCategory->delete();
+        $menuBoard->touch();
 
         return $response->withStatus(204);
     }

--- a/lib/Controller/MenuBoardProduct.php
+++ b/lib/Controller/MenuBoardProduct.php
@@ -355,7 +355,7 @@ class MenuBoardProduct extends Base
             }
         }
         $menuBoardProduct->productOptions = $menuBoardProduct->getOptions();
-        $menuBoard->save();
+        $menuBoard->touch();
 
         return $response
             ->withStatus(201)
@@ -472,7 +472,7 @@ class MenuBoardProduct extends Base
         }
         $menuBoardProduct->productOptions = $menuBoardProduct->getOptions();
         $menuBoardProduct->save();
-        $menuBoard->save();
+        $menuBoard->touch();
 
         return $response
             ->withStatus(200)
@@ -504,6 +504,7 @@ class MenuBoardProduct extends Base
         }
 
         $menuBoardProduct->delete();
+        $menuBoard->touch();
 
         return $response->withStatus(204);
     }

--- a/lib/Entity/MenuBoard.php
+++ b/lib/Entity/MenuBoard.php
@@ -183,10 +183,6 @@ class MenuBoard implements \JsonSerializable
             'audit' => true
         ], $options);
 
-        if ($options['audit']) {
-            $this->getLog()->debug('Saving ' . $this);
-        }
-
         if ($options['validate']) {
             $this->validate();
         }
@@ -194,8 +190,17 @@ class MenuBoard implements \JsonSerializable
         if ($this->menuId == null || $this->menuId == 0) {
             $this->add();
             $this->loaded = true;
+
+            if ($options['audit']) {
+                $this->audit($this->menuId, 'Added');
+            }
         } else {
+            $changedProperties = $this->getChangedProperties();
             $this->update();
+
+            if ($options['audit'] && count($changedProperties) > 0) {
+                $this->audit($this->menuId, 'Saved', $changedProperties);
+            }
         }
 
         $this->setActive();
@@ -244,6 +249,22 @@ class MenuBoard implements \JsonSerializable
     {
         $this->getLog()->debug('MenuBoard ' . $this->menuId . ' wants to notify');
         $this->getDisplayNotifyService()->collectNow()->notifyByMenuBoardId($this->menuId);
+    }
+
+    /**
+     * Bump modifiedDt and notify displays without the validate/full-row save overhead of save().
+     * Use when a child category/product changes and this board's own fields are unchanged.
+     * @throws NotFoundException
+     */
+    public function touch(): void
+    {
+        $this->modifiedDt = Carbon::now()->format('U');
+        $this->getStore()->update(
+            'UPDATE `menu_board` SET modifiedDt = :modifiedDt WHERE menuId = :menuId',
+            ['menuId' => $this->menuId, 'modifiedDt' => $this->modifiedDt]
+        );
+        $this->setActive();
+        $this->notify();
     }
 
     private function add(): void
@@ -305,5 +326,11 @@ class MenuBoard implements \JsonSerializable
         }
 
         $this->getStore()->update('DELETE FROM `menu_board` WHERE menuId = :menuId', ['menuId' => $this->menuId]);
+
+        $this->audit($this->menuId, 'Deleted', [
+            'menuId' => $this->menuId,
+            'name' => $this->name,
+            'code' => $this->code,
+        ]);
     }
 }

--- a/lib/Entity/MenuBoardCategory.php
+++ b/lib/Entity/MenuBoardCategory.php
@@ -163,8 +163,6 @@ class MenuBoardCategory implements \JsonSerializable
             'validate' => true,
         ], $options);
 
-        $this->getLog()->debug('Saving ' . $this);
-
         if ($options['validate']) {
             $this->validate();
         }
@@ -172,8 +170,15 @@ class MenuBoardCategory implements \JsonSerializable
         if ($this->menuCategoryId == null || $this->menuCategoryId == 0) {
             $this->add();
             $this->loaded = true;
+            $this->audit($this->menuCategoryId, 'Added');
         } else {
+            $changedProperties = $this->getChangedProperties();
             $this->update();
+
+            if (count($changedProperties) > 0) {
+                $changedProperties['menuId'] = $this->menuId;
+                $this->audit($this->menuCategoryId, 'Saved', $changedProperties);
+            }
         }
     }
 
@@ -235,7 +240,7 @@ class MenuBoardCategory implements \JsonSerializable
         ', [
             'menuCategoryId' => $this->menuCategoryId,
             'name' => $this->name,
-            'mediaId' => $this->mediaId,
+            'mediaId' => $this->mediaId ?: null,
             'code' => $this->code,
             'description' => $this->description,
         ]);
@@ -257,5 +262,10 @@ class MenuBoardCategory implements \JsonSerializable
             'DELETE FROM `menu_category` WHERE menuCategoryId = :menuCategoryId',
             ['menuCategoryId' => $this->menuCategoryId]
         );
+
+        $this->audit($this->menuCategoryId, 'Deleted', [
+            'menuId' => $this->menuId,
+            'name' => $this->name,
+        ]);
     }
 }

--- a/lib/Entity/MenuBoardProduct.php
+++ b/lib/Entity/MenuBoardProduct.php
@@ -158,16 +158,22 @@ class MenuBoardProduct implements \JsonSerializable
             'validate' => true,
         ], $options);
 
-        $this->getLog()->debug('Saving ' . $this);
-
         if ($options['validate']) {
             $this->validate();
         }
 
         if ($this->menuProductId == null || $this->menuProductId == 0) {
             $this->add();
+            $this->audit($this->menuProductId, 'Added');
         } else {
+            $changedProperties = $this->getChangedProperties();
             $this->update();
+
+            if (count($changedProperties) > 0) {
+                $changedProperties['menuId'] = $this->menuId;
+                $changedProperties['menuCategoryId'] = $this->menuCategoryId;
+                $this->audit($this->menuProductId, 'Saved', $changedProperties);
+            }
         }
     }
 
@@ -233,7 +239,7 @@ class MenuBoardProduct implements \JsonSerializable
             'name' => $this->name,
             'price' => $this->price,
             'description' => $this->description,
-            'mediaId' => $this->mediaId,
+            'mediaId' => $this->mediaId ?: null,
             'displayOrder' => $this->displayOrder,
             'availability' => $this->availability,
             'allergyInfo' => $this->allergyInfo,
@@ -250,6 +256,12 @@ class MenuBoardProduct implements \JsonSerializable
             'DELETE FROM `menu_product` WHERE menuProductId = :menuProductId',
             ['menuProductId' => $this->menuProductId]
         );
+
+        $this->audit($this->menuProductId, 'Deleted', [
+            'menuId' => $this->menuId,
+            'menuCategoryId' => $this->menuCategoryId,
+            'name' => $this->name,
+        ]);
     }
 
     /**

--- a/lib/Listener/OnMediaDelete/MenuBoardListener.php
+++ b/lib/Listener/OnMediaDelete/MenuBoardListener.php
@@ -24,8 +24,10 @@ namespace Xibo\Listener\OnMediaDelete;
 
 use Xibo\Event\MediaDeleteEvent;
 use Xibo\Factory\MenuBoardCategoryFactory;
+use Xibo\Factory\MenuBoardFactory;
 use Xibo\Listener\ListenerLoggerTrait;
 use Xibo\Support\Exception\InvalidArgumentException;
+use Xibo\Support\Exception\NotFoundException;
 
 class MenuBoardListener
 {
@@ -34,9 +36,13 @@ class MenuBoardListener
     /** @var MenuBoardCategoryFactory */
     private $menuBoardCategoryFactory;
 
-    public function __construct($menuBoardCategoryFactory)
+    /** @var MenuBoardFactory */
+    private $menuBoardFactory;
+
+    public function __construct($menuBoardCategoryFactory, $menuBoardFactory)
     {
         $this->menuBoardCategoryFactory = $menuBoardCategoryFactory;
+        $this->menuBoardFactory = $menuBoardFactory;
     }
 
     /**
@@ -46,15 +52,26 @@ class MenuBoardListener
     public function __invoke(MediaDeleteEvent $event)
     {
         $media = $event->getMedia();
+        $affectedMenuIds = [];
 
         foreach ($this->menuBoardCategoryFactory->query(null, ['mediaId' => $media->mediaId]) as $category) {
             $category->mediaId = null;
             $category->save();
+            $affectedMenuIds[$category->menuId] = true;
         }
 
         foreach ($this->menuBoardCategoryFactory->getProductData(null, ['mediaId' => $media->mediaId]) as $product) {
             $product->mediaId = null;
             $product->save();
+            $affectedMenuIds[$product->menuId] = true;
+        }
+
+        foreach (array_keys($affectedMenuIds) as $menuId) {
+            try {
+                $this->menuBoardFactory->getById($menuId)->touch();
+            } catch (NotFoundException) {
+                $this->getLogger()->error('MenuBoardListener: menu board ' . $menuId . ' not found while touching');
+            }
         }
     }
 }

--- a/lib/Middleware/ListenersMiddleware.php
+++ b/lib/Middleware/ListenersMiddleware.php
@@ -165,7 +165,8 @@ class ListenersMiddleware implements MiddlewareInterface
 
         // Media Delete Events
         $dispatcher->addListener(MediaDeleteEvent::$NAME, (new \Xibo\Listener\OnMediaDelete\MenuBoardListener(
-            $c->get('menuBoardCategoryFactory')
+            $c->get('menuBoardCategoryFactory'),
+            $c->get('menuBoardFactory')
         )));
 
         $dispatcher->addListener(MediaDeleteEvent::$NAME, (new \Xibo\Listener\OnMediaDelete\WidgetListener(


### PR DESCRIPTION
fixes xibosignage/xibo#3874

In addition to what's in the issue, this PR also: 
- Adds auditing to add/edit/delete menu board/category/product actions
- Fixes an issue whereby saving a category without mediaId set would throw sql error about mediaId constraint