### PR TITLE
Fix: Campaign layout assignments

### DIFF
--- a/frontend/src/components/ui/SearchAssignPanel.tsx
+++ b/frontend/src/components/ui/SearchAssignPanel.tsx
@@ -174,9 +174,24 @@ export function SearchAssignPanel<TItem>({
     size: 20,
     enableSorting: false,
     cell: ({ row }) => {
-      const assignedIndex = allowMultiple
-        ? -1
-        : assignedItems.findIndex((item) => getItemId(item) === getItemId(row.original));
+      const itemId = getItemId(row.original);
+
+      if (allowMultiple) {
+        return (
+          <div className="flex items-center justify-center">
+            <button
+              type="button"
+              onClick={() => onAddItem(row.original)}
+              className="w-5 h-5 rounded-full flex items-center justify-center transition-colors cursor-pointer text-xibo-blue-600 hover:text-xibo-blue-80 hover:bg-xibo-blue-50"
+              title={t('Add')}
+            >
+              <PlusCircle size={20} />
+            </button>
+          </div>
+        );
+      }
+
+      const assignedIndex = assignedItems.findIndex((item) => getItemId(item) === itemId);
       const isAssigned = assignedIndex !== -1;
       return (
         <div className="flex justify-center">

--- a/frontend/src/pages/Design/Campaigns/Campaigns.tsx
+++ b/frontend/src/pages/Design/Campaigns/Campaigns.tsx
@@ -205,6 +205,7 @@ export default function Campaigns() {
 
   const handleRefresh = () => {
     queryClient.invalidateQueries({ queryKey: ['campaign'] });
+    queryClient.invalidateQueries({ queryKey: ['layouts', 'campaign'] });
   };
 
   const handleFolderChange = (folder: { id: number | null; text: string | '' }) => {


### PR DESCRIPTION
relates to: https://github.com/xibosignageltd/xibo-private/issues/1675

- Invalidate assigned layouts query cache on campaign save so the Edit modal shows up-to-date data when reopened                                                                     
- Add distinct allowMultiple branch in SearchAssignPanel action column 