### PR TITLE
Fix: Playlist Dashboard media preview and upload error

### DIFF
--- a/frontend/src/pages/Dashboard/PlaylistDashboard/PlaylistDashboard.tsx
+++ b/frontend/src/pages/Dashboard/PlaylistDashboard/PlaylistDashboard.tsx
@@ -30,6 +30,7 @@ import SpotRow from './components/SpotRow';
 import { usePlaylistDashboardActions } from './hooks/usePlaylistDashboardActions';
 import { usePlaylistSpots } from './hooks/usePlaylistSpots';
 
+import MediaPreviewer from '@/pages/Library/Media/components/MediaPreviewer';
 import { fetchUserPreference, saveUserPreference } from '@/services/userApi';
 import type { SpotWidget } from '@/types/dashboard';
 
@@ -76,6 +77,8 @@ export default function PlaylistDashboard() {
     }, 500);
     return () => clearTimeout(saveTimeoutRef.current);
   }, [selectedPlaylistId]);
+  const [previewWidget, setPreviewWidget] = useState<SpotWidget | null>(null);
+
   const [deleteTarget, setDeleteTarget] = useState<
     | {
         type: 'single';
@@ -172,6 +175,7 @@ export default function PlaylistDashboard() {
                   const widget = widgets.find((w) => w.widgetId === widgetId);
                   if (widget) setDeleteTarget({ type: 'single', widget });
                 }}
+                onPreview={setPreviewWidget}
               />
             ))}
           </div>
@@ -202,6 +206,13 @@ export default function PlaylistDashboard() {
           isDynamic={isDynamic}
         />
       )}
+
+      <MediaPreviewer
+        mediaId={previewWidget?.mediaIds[0] ?? null}
+        mediaType={previewWidget?.type}
+        fileName={previewWidget?.mediaFiles[0]?.fileName ?? previewWidget?.name}
+        onClose={() => setPreviewWidget(null)}
+      />
     </section>
   );
 }

--- a/frontend/src/pages/Dashboard/PlaylistDashboard/components/SpotRow.tsx
+++ b/frontend/src/pages/Dashboard/PlaylistDashboard/components/SpotRow.tsx
@@ -38,9 +38,18 @@ interface SpotRowProps {
   uploadState?: SpotUploadState;
   onSelectFile: (spotIndex: number, file: File) => void;
   onDeleteWidget: (widgetId: number) => void;
+  onPreview?: (widget: SpotWidget) => void;
 }
 
-function SpotThumbnail({ widget, blobUrl }: { widget?: SpotWidget; blobUrl?: string }) {
+function SpotThumbnail({
+  widget,
+  blobUrl,
+  onPreview,
+}: {
+  widget?: SpotWidget;
+  blobUrl?: string;
+  onPreview?: () => void;
+}) {
   const [loaded, setLoaded] = useState(false);
 
   const thumbnailSrc =
@@ -49,8 +58,10 @@ function SpotThumbnail({ widget, blobUrl }: { widget?: SpotWidget; blobUrl?: str
       ? withPublicPath(`library/thumbnail/${widget.mediaIds[0]}`)
       : null);
 
+  const isPreviewable = onPreview && widget && widget.mediaIds.length > 0;
+
   if (thumbnailSrc) {
-    return (
+    const img = (
       <div className="relative h-16 w-16 shrink-0 rounded">
         {!loaded && <div className="absolute inset-0 animate-pulse rounded bg-gray-300" />}
         <img
@@ -61,14 +72,48 @@ function SpotThumbnail({ widget, blobUrl }: { widget?: SpotWidget; blobUrl?: str
         />
       </div>
     );
+
+    if (isPreviewable) {
+      return (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onPreview();
+          }}
+          className="cursor-pointer rounded hover:ring-2 hover:ring-xibo-blue-600"
+        >
+          {img}
+        </button>
+      );
+    }
+
+    return img;
   }
 
   const Icon = widget?.type === 'subplaylist' ? ListOrdered : getMediaIcon(widget?.type ?? '');
-  return (
+  const iconDiv = (
     <div className="flex h-16 w-16 items-center justify-center rounded bg-gray-400">
       <Icon className="size-6 text-gray-500" />
     </div>
   );
+
+  if (isPreviewable) {
+    return (
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          onPreview();
+        }}
+        className="cursor-pointer rounded hover:ring-2 hover:ring-xibo-blue-600"
+      >
+        {iconDiv}
+      </button>
+    );
+  }
+
+  return iconDiv;
 }
 
 export default function SpotRow({
@@ -77,6 +122,7 @@ export default function SpotRow({
   uploadState,
   onSelectFile,
   onDeleteWidget,
+  onPreview,
 }: SpotRowProps) {
   const { t } = useTranslation();
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -84,6 +130,9 @@ export default function SpotRow({
 
   const isUploading = uploadState?.status === 'uploading';
   const isLocked = widget?.type === 'subplaylist';
+
+  const previewHandler =
+    onPreview && widget && widget.mediaIds.length > 0 ? () => onPreview(widget) : undefined;
 
   const acceptType = (() => {
     if (!widget) return undefined;
@@ -133,7 +182,7 @@ export default function SpotRow({
       return (
         <>
           <div className="shrink-0">
-            <SpotThumbnail widget={widget} />
+            <SpotThumbnail widget={widget} onPreview={previewHandler} />
           </div>
           <div className="flex min-w-0 flex-1 flex-col gap-1">
             <span className="truncate text-sm font-semibold text-gray-600" aria-label={widget.name}>
@@ -153,7 +202,11 @@ export default function SpotRow({
       return (
         <>
           <div className="shrink-0">
-            <SpotThumbnail widget={widget} blobUrl={uploadState?.blobUrl} />
+            <SpotThumbnail
+              widget={widget}
+              blobUrl={uploadState?.blobUrl}
+              onPreview={previewHandler}
+            />
           </div>
           <div className="flex min-w-0 flex-1 flex-col gap-1">
             {uploadState ? (

--- a/frontend/src/pages/Dashboard/PlaylistDashboard/hooks/usePlaylistDashboardActions.ts
+++ b/frontend/src/pages/Dashboard/PlaylistDashboard/hooks/usePlaylistDashboardActions.ts
@@ -87,6 +87,7 @@ export function usePlaylistDashboardActions(queryClient: QueryClient, playlistId
 
   const startUpload = async (spotIndex: number, file: File, widget?: SpotWidget) => {
     if (playlistId === null) return;
+    if (widget?.type === 'subplaylist') return;
 
     const blobUrl = file.type.startsWith('image/') ? URL.createObjectURL(file) : undefined;
 

--- a/lib/Helper/XiboUploadHandler.php
+++ b/lib/Helper/XiboUploadHandler.php
@@ -521,8 +521,12 @@ class XiboUploadHandler extends BlueImpUploadHandler
                 // Assign the new widget to the playlist
                 $playlist->assignWidget($widget, $this->options['displayOrder'] ?? null);
 
-                // Save the playlist
-                $playlist->save();
+                // Save without re-saving existing widgets to avoid triggering
+                // validation on unrelated widgets (e.g. sub-playlists).
+                $playlist->save(['saveWidgets' => false]);
+
+                // Save just the new widget
+                $widget->save();
 
                 // Configure widgetId is response
                 $file->widgetId = $widget->widgetId;


### PR DESCRIPTION
relates to: https://github.com/xibosignageltd/xibo-private/issues/1694

- Add media preview on thumbnail click, reusing the existing `MediaPreviewer `component                                                                                                  - Fix pre-existing upload bug where uploading to a playlist containing a sub-playlist widget fails with "Please select at least 1 Playlist to embed" — `playlist->save()` was re-saving all existing widgets, triggering validation on unrelated widgets. Fixed by saving only the new widget.