### PR TITLE
v5: When a Resolution is not Enabled, it still shows in Templates option

### DIFF
--- a/frontend/src/pages/Design/Templates/components/AddAndEditTemplate.tsx
+++ b/frontend/src/pages/Design/Templates/components/AddAndEditTemplate.tsx
@@ -109,6 +109,7 @@ export default function AddAndEditTemplateModal({
         const res = await fetchResolution({
           start: 0,
           length: 100,
+          enabled: 1,
         });
 
         setResolutions(res.rows);

--- a/frontend/src/services/resolutionApi.ts
+++ b/frontend/src/services/resolutionApi.ts
@@ -26,7 +26,7 @@ export interface FetchResolutionRequest {
   start: number;
   length: number;
   resolution?: string;
-  enabled?: boolean;
+  enabled?: number;
   sortBy?: string;
   sortDir?: string;
   signal?: AbortSignal;


### PR DESCRIPTION
relates to xibosignageltd/xibo-private#1358