### PR TITLE
Fix i18n extraction warnings

### DIFF
--- a/frontend/i18next.config.ts
+++ b/frontend/i18next.config.ts
@@ -24,6 +24,7 @@ import { defineConfig } from 'i18next-cli';
 export default defineConfig({
   locales: ['en'],
   extract: {
+    keySeparator: false,
     input: 'src/**/*.{js,jsx,ts,tsx}',
     extractFromComments: false,
     output: 'public/locale/translations/{{language}}/{{namespace}}.json',

--- a/lib/Controller/Display.php
+++ b/lib/Controller/Display.php
@@ -1799,10 +1799,7 @@ class Display extends Base
         } catch (\Exception $e) {
             $this->getLog()->debug($e->getMessage());
             throw new InvalidArgumentException(
-                __(
-                    'The code provided does not match.
-                     Please double-check the code shown on the device you are trying to connect.'
-                ),
+                __('The code provided does not match. Please double-check the code shown on the device you are trying to connect.'),//phpcs:ignore
                 'user_code'
             );
         }

--- a/lib/Controller/DisplayGroup.php
+++ b/lib/Controller/DisplayGroup.php
@@ -1274,8 +1274,7 @@ class DisplayGroup extends Base
             $media = $this->mediaFactory->getById($mediaId);
 
             if (!$this->getUser()->checkViewable($media)) {
-                throw new AccessDeniedException(__('You have selected media that you no longer have 
-                    permission to use. Please reload the form.'));
+                throw new AccessDeniedException(__('You have selected media that you no longer have permission to use. Please reload the form.'));//phpcs:ignore
             }
 
             $displayGroup->assignMedia($media);
@@ -1289,8 +1288,7 @@ class DisplayGroup extends Base
             $media = $this->mediaFactory->getById($mediaId);
 
             if (!$this->getUser()->checkViewable($media)) {
-                throw new AccessDeniedException(__('You have selected media that you no longer have 
-                    permission to use. Please reload the form.'));
+                throw new AccessDeniedException(__('You have selected media that you no longer have permission to use. Please reload the form.'));//phpcs:ignore
             }
 
             $displayGroup->unassignMedia($media);
@@ -1455,8 +1453,7 @@ class DisplayGroup extends Base
             $layout = $this->layoutFactory->getById($layoutId);
 
             if (!$this->getUser()->checkViewable($layout)) {
-                throw new AccessDeniedException(__('You have selected a layout that you no longer 
-                    have permission to use. Please reload the form.'));
+                throw new AccessDeniedException(__('You have selected a layout that you no longer have permission to use. Please reload the form.'));//phpcs:ignore
             }
 
             $displayGroup->assignLayout($layout);
@@ -1468,8 +1465,7 @@ class DisplayGroup extends Base
             $layout = $this->layoutFactory->getById($layoutId);
 
             if (!$this->getUser()->checkViewable($layout)) {
-                throw new AccessDeniedException(__('You have selected a layout that you no longer 
-                    have permission to use. Please reload the form.'));
+                throw new AccessDeniedException(__('You have selected a layout that you no longer have permission to use. Please reload the form.'));//phpcs:ignore
             }
 
             $displayGroup->unassignLayout($layout);

--- a/lib/Controller/Library.php
+++ b/lib/Controller/Library.php
@@ -915,8 +915,7 @@ class Library extends Base
             $playlist = $this->playlistFactory->getById($parsedBody->getInt('playlistId'));
 
             if ($playlist->isDynamic === 1) {
-                throw new InvalidArgumentException(__('This Playlist is dynamically managed so cannot accept 
-                    manual assignments.'), 'isDynamic');
+                throw new InvalidArgumentException(__('This Playlist is dynamically managed so cannot accept manual assignments.'), 'isDynamic');//phpcs:ignore
             }
         }
 

--- a/lib/Controller/SavedReport.php
+++ b/lib/Controller/SavedReport.php
@@ -264,8 +264,7 @@ class SavedReport extends Base
 
         if ($rowCount > 5000) {
             throw new GeneralException(
-                __('This report contains %d rows and is too large to export as PDF. Maximum is 5,000 rows. 
-                Please narrow the date range and try again.', $rowCount)
+                __('This report contains %d rows and is too large to export as PDF. Maximum is 5,000 rows. Please narrow the date range and try again.', $rowCount)//phpcs:ignore
             );
         }
 

--- a/lib/Controller/ScheduleReport.php
+++ b/lib/Controller/ScheduleReport.php
@@ -262,8 +262,7 @@ class ScheduleReport extends Base
             $reportSchedule->delete();
         } catch (\RuntimeException $e) {
             throw new InvalidArgumentException(
-                __('Report schedule cannot be deleted.
-                 Please ensure there are no saved reports against the schedule.'),
+                __('Report schedule cannot be deleted. Please ensure there are no saved reports against the schedule.'),//phpcs:ignore
                 'reportScheduleId'
             );
         }

--- a/lib/Factory/PlaylistFactory.php
+++ b/lib/Factory/PlaylistFactory.php
@@ -94,12 +94,10 @@ class PlaylistFactory extends BaseFactory
 
         if (count($playlists) <= 0) {
             $this->getLog()->error(
-                'Region ' . $regionId . ' does not have a Playlist associated,
-                 please try to set a new owner in Permissions.'
+                'Region ' . $regionId . ' does not have a Playlist associated, please try to set a new owner in Permissions.'//phpcs:ignore
             );
             throw new NotFoundException(
-                __('One of the Regions on this Layout does not have a Playlist,
-                 please contact your administrator.')
+                __('One of the Regions on this Layout does not have a Playlist, please contact your administrator.')//phpcs:ignore
             );
         }
 


### PR DESCRIPTION
- frontend/i18next.config.ts: set extract.keySeparator to false to stop dotted keys being treated as nested paths
- lib/Controller/{DisplayGroup,ScheduleReport,SavedReport,Library,Display}.php, lib/Factory/PlaylistFactory.php: join wrapped __() (and one log message) strings onto single lines