### PR TITLE
Fix remaining i18n extraction issues

### DIFF
--- a/bin/locale.php
+++ b/bin/locale.php
@@ -233,10 +233,5 @@ foreach (json_decode($jsonReact, true) as $key => $value) {
     $content .= 'echo __(\''.addslashes(trim($key)).'\');' . PHP_EOL;
 }
 
-$jsonReactNotes = file_get_contents(PROJECT_ROOT . '/frontend/public/locale/translations/en/Note.json');
-foreach (json_decode($jsonReactNotes, true) as $key => $value) {
-    $content .= 'echo __(\''.addslashes(trim($value)).'\');' . PHP_EOL;
-}
-
 file_put_contents($file, $content);
 echo 'reacttranslate.file created and data written successfully.';

--- a/frontend/i18next.config.ts
+++ b/frontend/i18next.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
   locales: ['en'],
   extract: {
     keySeparator: false,
+    nsSeparator: false,
     input: 'src/**/*.{js,jsx,ts,tsx}',
     extractFromComments: false,
     output: 'public/locale/translations/{{language}}/{{namespace}}.json',

--- a/frontend/src/pages/Library/Dataset/subPages/Data/DatasetDataConfig.tsx
+++ b/frontend/src/pages/Library/Dataset/subPages/Data/DatasetDataConfig.tsx
@@ -85,7 +85,7 @@ export const getDynamicDataColumns = (
         }
 
         if (col.dataTypeId === 6) {
-          return <TextCell className="italic text-gray-500">{t('<HTML Content>')}</TextCell>;
+          return <TextCell className="italic text-gray-500">{t('HTML Content')}</TextCell>;
         }
 
         return <TextCell>{String(value)}</TextCell>;


### PR DESCRIPTION
- frontend/i18next.config.ts: set extract.nsSeparator to false so colon-containing strings aren't split into separate namespace files
- bin/locale.php: remove dead Note.json read, now redundant since translation.json contains everything
- frontend/src/pages/Library/Dataset/subPages/Data/DatasetDataConfig.tsx: drop angle brackets from the HTML-content placeholder label so it doesn't read as markup