### PR TITLE
Display page: Highlight Bandwidth Limit error and fix negative number

### DIFF
--- a/frontend/src/components/ui/forms/BandwidthInput.tsx
+++ b/frontend/src/components/ui/forms/BandwidthInput.tsx
@@ -69,6 +69,7 @@ interface BandwidthInputProps {
   onChange: (kb: number | null) => void;
   label?: string;
   helpText?: string;
+  error?: string;
   optional?: boolean;
 }
 
@@ -77,6 +78,7 @@ export default function BandwidthInput({
   onChange,
   label,
   helpText,
+  error,
   optional = false,
 }: BandwidthInputProps) {
   const { t } = useTranslation();
@@ -103,7 +105,13 @@ export default function BandwidthInput({
       </label>
       <div className="flex gap-2">
         <div className="flex-1">
-          <NumberInput name="bandwidthLimit" value={displayValue} onChange={handleValueChange} />
+          <NumberInput
+            name="bandwidthLimit"
+            value={displayValue}
+            onChange={handleValueChange}
+            min={0}
+            className={error ? 'border-red-500!' : undefined}
+          />
         </div>
         <SelectDropdown
           value={unit}
@@ -124,7 +132,11 @@ export default function BandwidthInput({
           ]}
         ></SelectDropdown>
       </div>
-      {helpText && <span className="text-xs text-gray-400">{helpText}</span>}
+      {error ? (
+        <p className="text-xs text-red-600 mt-1">{error}</p>
+      ) : (
+        helpText && <span className="text-xs text-gray-400">{helpText}</span>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/Displays/Displays/components/EditDisplayModal.tsx
+++ b/frontend/src/pages/Displays/Displays/components/EditDisplayModal.tsx
@@ -1639,6 +1639,7 @@ export default function EditDisplayModal({
                 valueKb={draft.bandwidthLimit}
                 onChange={(kb) => set('bandwidthLimit', kb)}
                 helpText={t('The bandwidth limit that should be applied. Enter 0 for no limit.')}
+                error={fieldErrors.bandwidthLimit}
               />
               <Checkbox
                 id="clearCachedData"

--- a/frontend/src/pages/Displays/Displays/components/SetBandwidthModal.tsx
+++ b/frontend/src/pages/Displays/Displays/components/SetBandwidthModal.tsx
@@ -24,6 +24,7 @@ import { useTranslation } from 'react-i18next';
 
 import BandwidthInput from '@/components/ui/forms/BandwidthInput';
 import Modal from '@/components/ui/modals/Modal';
+import { getBandwidthLimitSchema } from '@/schema/display';
 
 interface SetBandwidthModalProps {
   displayCount: number;
@@ -42,6 +43,22 @@ export default function SetBandwidthModal({
 }: SetBandwidthModalProps) {
   const { t } = useTranslation();
   const [bandwidthKb, setBandwidthKb] = useState<number | null>(null);
+  const [fieldError, setFieldError] = useState<string | undefined>();
+
+  const handleChange = (kb: number | null) => {
+    setBandwidthKb(kb);
+    setFieldError(undefined);
+  };
+
+  const handleSave = () => {
+    const result = getBandwidthLimitSchema(t).safeParse(bandwidthKb ?? 0);
+    if (!result.success) {
+      setFieldError(result.error.issues[0]?.message);
+      return;
+    }
+    setFieldError(undefined);
+    onConfirm(result.data);
+  };
 
   return (
     <Modal
@@ -55,9 +72,7 @@ export default function SetBandwidthModal({
         { label: t('Cancel'), onClick: onClose, variant: 'secondary', disabled: isActionPending },
         {
           label: isActionPending ? t('Saving…') : t('Save'),
-          onClick: () => {
-            onConfirm(bandwidthKb ?? 0);
-          },
+          onClick: handleSave,
           disabled: isActionPending || bandwidthKb === null,
         },
       ]}
@@ -68,9 +83,10 @@ export default function SetBandwidthModal({
         </p>
         <BandwidthInput
           valueKb={bandwidthKb}
-          onChange={setBandwidthKb}
+          onChange={handleChange}
           label={t('Bandwidth limit')}
           helpText={t('The bandwidth limit that should be applied. Enter 0 for no limit.')}
+          error={fieldError}
         />
       </div>
     </Modal>

--- a/frontend/src/schema/display.ts
+++ b/frontend/src/schema/display.ts
@@ -22,6 +22,22 @@
 import type { TFunction } from 'i18next';
 import z from 'zod';
 
+const BANDWIDTH_LIMIT_MAX_KB = 2147483647;
+const BANDWIDTH_LIMIT_MAX_TIB = Math.round(BANDWIDTH_LIMIT_MAX_KB / (1024 * 1024 * 1024));
+
+export const getBandwidthLimitSchema = (t: TFunction) =>
+  z
+    .number()
+    .int()
+    .min(0, t('Bandwidth limit must be 0 or greater'))
+    .max(
+      BANDWIDTH_LIMIT_MAX_KB,
+      t('Bandwidth limit must be {{max}} KiB (~{{maxTib}} TiB) or less', {
+        max: BANDWIDTH_LIMIT_MAX_KB.toLocaleString(),
+        maxTib: BANDWIDTH_LIMIT_MAX_TIB,
+      }),
+    );
+
 export const getEditDisplaySchema = (t: TFunction) =>
   z.object({
     display: z
@@ -39,7 +55,7 @@ export const getEditDisplaySchema = (t: TFunction) =>
       .min(-180, t('Longitude must be between -180 and 180'))
       .max(180, t('Longitude must be between -180 and 180'))
       .optional(),
-    bandwidthLimit: z.number().int().min(0, t('Bandwidth limit must be 0 or greater')).optional(),
+    bandwidthLimit: getBandwidthLimitSchema(t).optional(),
     screenSize: z.number().min(0, t('Value must be greater than or equal to 0.')).optional(),
     costPerPlay: z.number().min(0, t('Value must be greater than or equal to 0.')).optional(),
     impressionsPerPlay: z

--- a/lib/Factory/DisplayGroupFactory.php
+++ b/lib/Factory/DisplayGroupFactory.php
@@ -275,9 +275,8 @@ class DisplayGroupFactory extends BaseFactory
      * Set Bandwidth limit
      * @param int $bandwidthLimit
      * @param array $displayGroupIds
-     * @return DisplayGroup[]
      */
-    public function setBandwidth(int $bandwidthLimit, array $displayGroupIds): array
+    public function setBandwidth(int $bandwidthLimit, array $displayGroupIds): void
     {
         $sql = 'UPDATE `displaygroup` SET bandwidthLimit = :bandwidthLimit WHERE displayGroupId IN (0';
         $params['bandwidthLimit'] = $bandwidthLimit;
@@ -291,8 +290,6 @@ class DisplayGroupFactory extends BaseFactory
         $sql .= ')';
 
         $this->getStore()->update($sql, $params);
-
-        return $this->query(null, ['disableUserCheck' => 1, 'displayGroupIds' => $displayGroupIds]);
     }
 
     /**

--- a/lib/Factory/DisplayGroupFactory.php
+++ b/lib/Factory/DisplayGroupFactory.php
@@ -291,6 +291,8 @@ class DisplayGroupFactory extends BaseFactory
         $sql .= ')';
 
         $this->getStore()->update($sql, $params);
+
+        return $this->query(null, ['disableUserCheck' => 1, 'displayGroupIds' => $displayGroupIds]);
     }
 
     /**


### PR DESCRIPTION
relates to xibosignageltd/xibo-private#1471

- Prevent negative bandwidth limit values
- Highlight the Bandwidth Limit field on validation error
- Add client-side validation to Set Bandwidth modal
- Cap bandwidth limit at the DB column's max
- Fix DisplayGroupFactory::setBandwidth() TypeError