### PR TITLE
Bulk move to folder fixes

### DIFF
--- a/frontend/src/pages/Design/Campaigns/hooks/useCampaignActions.ts
+++ b/frontend/src/pages/Design/Campaigns/hooks/useCampaignActions.ts
@@ -28,7 +28,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { notify } from '@/components/ui/Notification';
 import { copyCampaign, deleteCampaign } from '@/services/campaignApi';
-import { selectFolder } from '@/services/folderApi';
+import { selectFolder, type ApiResult } from '@/services/folderApi';
 import type { Campaign } from '@/types/campaign';
 
 interface UseCampaignActionsProps {
@@ -119,16 +119,17 @@ export function useCampaignActions({
   const handleConfirmMove = async (itemsToMove: Campaign[], newFolderId: number) => {
     if (!itemsToMove || itemsToMove.length === 0) return;
 
-    const movePromises = itemsToMove.map((item) =>
-      selectFolder({
-        folderId: newFolderId,
-        targetId: item.campaignId,
-        targetType: 'campaign',
-      }),
-    );
-
     try {
-      const results = await Promise.all(movePromises);
+      const results: ApiResult[] = [];
+      for (const item of itemsToMove) {
+        results.push(
+          await selectFolder({
+            folderId: newFolderId,
+            targetId: item.campaignId,
+            targetType: 'campaign',
+          }),
+        );
+      }
       const failures = results.filter((res) => !res.success);
 
       if (failures.length === 0) {

--- a/frontend/src/pages/Design/Layouts/hooks/useLayoutActions.ts
+++ b/frontend/src/pages/Design/Layouts/hooks/useLayoutActions.ts
@@ -28,7 +28,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { notify } from '@/components/ui/Notification';
 import type { PublishValue } from '@/components/ui/forms/PublishDateSelect';
-import { selectFolder } from '@/services/folderApi';
+import { selectFolder, type ApiResult } from '@/services/folderApi';
 import {
   assignLayoutToCampaign,
   checkoutLayout,
@@ -138,16 +138,17 @@ export function useLayoutActions({
       return;
     }
 
-    const movePromises = itemsToMove.map((item) =>
-      selectFolder({
-        folderId: newFolderId,
-        targetId: item.campaignId,
-        targetType: 'campaign',
-      }),
-    );
-
     try {
-      const results = await Promise.all(movePromises);
+      const results: ApiResult[] = [];
+      for (const item of itemsToMove) {
+        results.push(
+          await selectFolder({
+            folderId: newFolderId,
+            targetId: item.campaignId,
+            targetType: 'campaign',
+          }),
+        );
+      }
       const failures = results.filter((res) => !res.success);
 
       if (failures.length === 0) {

--- a/frontend/src/pages/Design/Templates/hooks/useTemplateActions.ts
+++ b/frontend/src/pages/Design/Templates/hooks/useTemplateActions.ts
@@ -28,7 +28,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { notify } from '@/components/ui/Notification';
 import type { PublishValue } from '@/components/ui/forms/PublishDateSelect';
-import { selectFolder } from '@/services/folderApi';
+import { selectFolder, type ApiResult } from '@/services/folderApi';
 import {
   copyLayout,
   deleteLayout,
@@ -138,16 +138,17 @@ export function useTemplateActions({
       return;
     }
 
-    const movePromises = itemsToMove.map((item) =>
-      selectFolder({
-        folderId: newFolderId,
-        targetId: item.campaignId,
-        targetType: 'campaign',
-      }),
-    );
-
     try {
-      const results = await Promise.all(movePromises);
+      const results: ApiResult[] = [];
+      for (const item of itemsToMove) {
+        results.push(
+          await selectFolder({
+            folderId: newFolderId,
+            targetId: item.campaignId,
+            targetType: 'campaign',
+          }),
+        );
+      }
       const failures = results.filter((res) => !res.success);
 
       if (failures.length === 0) {

--- a/frontend/src/pages/Displays/DisplayGroup/DisplayGroupConfig.tsx
+++ b/frontend/src/pages/Displays/DisplayGroup/DisplayGroupConfig.tsx
@@ -25,7 +25,7 @@ import {
   Calendar,
   Copy,
   Edit,
-  Folder,
+  FolderInput,
   Terminal,
   Tags,
   Trash2,
@@ -240,7 +240,7 @@ export const getDisplayGroupItemActions = ({
     if (canModify && canEdit && openMoveModal) {
       actions.push({
         label: t('Move'),
-        icon: Folder,
+        icon: FolderInput,
         onClick: () => openMoveModal(displayGroup),
       });
     }
@@ -344,7 +344,7 @@ export const getBulkActions = ({
   if (canModify) {
     actions.push({
       label: t('Move'),
-      icon: Folder,
+      icon: FolderInput,
       onClick: onMove,
     });
   }

--- a/frontend/src/pages/Displays/DisplayGroup/hooks/useDisplayGroupActions.ts
+++ b/frontend/src/pages/Displays/DisplayGroup/hooks/useDisplayGroupActions.ts
@@ -28,7 +28,7 @@ import { useState } from 'react';
 import { notify } from '@/components/ui/Notification';
 import { collectNow, copyDisplayGroup, deleteDisplayGroup } from '@/services/displayGroupApi';
 import { sendCommand, triggerWebhook } from '@/services/displaysApi';
-import { selectFolder } from '@/services/folderApi';
+import { selectFolder, type ApiResult } from '@/services/folderApi';
 import type { DisplayGroup } from '@/types/displayGroup';
 
 export interface CopyDisplayGroupFormData {
@@ -148,15 +148,16 @@ export function useDisplayGroupActions({
 
     setIsMoving(true);
     try {
-      const results = await Promise.all(
-        itemsToMove.map((item) =>
-          selectFolder({
+      const results: ApiResult[] = [];
+      for (const item of itemsToMove) {
+        results.push(
+          await selectFolder({
             folderId: newFolderId,
             targetId: item.displayGroupId,
             targetType: 'displaygroup',
           }),
-        ),
-      );
+        );
+      }
 
       const failures = results.filter((res) => !res.success);
 

--- a/frontend/src/pages/Displays/Displays/hooks/useDisplaysActions.ts
+++ b/frontend/src/pages/Displays/Displays/hooks/useDisplaysActions.ts
@@ -43,7 +43,7 @@ import {
   wakeOnLan,
 } from '@/services/displaysApi';
 import type { MoveCmsData } from '@/services/displaysApi';
-import { selectFolder } from '@/services/folderApi';
+import { selectFolder, type ApiResult } from '@/services/folderApi';
 import type { Display, DisplayCommandTarget } from '@/types/display';
 
 interface UseDisplaysActionsProps {
@@ -106,14 +106,32 @@ export function useDisplaysActions({
     }
 
     try {
-      const movePromises = itemsToMove.map((item) =>
-        selectFolder({
-          folderId: newFolderId,
-          targetId: item.displayGroupId,
-          targetType: 'displaygroup',
-        }),
-      );
-      await Promise.all(movePromises);
+      const results: ApiResult[] = [];
+      for (const item of itemsToMove) {
+        results.push(
+          await selectFolder({
+            folderId: newFolderId,
+            targetId: item.displayGroupId,
+            targetType: 'displaygroup',
+          }),
+        );
+      }
+      const failures = results.filter((res) => !res.success);
+
+      if (failures.length === 0) {
+        notify.info(t('{{count}} items moved successfully!', { count: itemsToMove.length }));
+      } else if (failures.length === itemsToMove.length) {
+        notify.error(t('Failed to move items.'));
+      } else {
+        notify.warning(
+          t('Moved {{success}} items, but {{fail}} failed.', {
+            success: itemsToMove.length - failures.length,
+            fail: failures.length,
+          }),
+        );
+      }
+
+      setRowSelection({});
       handleRefresh();
       closeModal();
     } catch (error) {

--- a/frontend/src/pages/Library/Dataset/hooks/useDatasetActions.ts
+++ b/frontend/src/pages/Library/Dataset/hooks/useDatasetActions.ts
@@ -27,7 +27,7 @@ import { useState } from 'react';
 
 import { notify } from '@/components/ui/Notification';
 import { clearDatasetCache, cloneDataset, deleteDataset } from '@/services/datasetApi';
-import { selectFolder } from '@/services/folderApi';
+import { selectFolder, type ApiResult } from '@/services/folderApi';
 import type { Dataset } from '@/types/dataset';
 
 interface UseDatasetActionsProps {
@@ -148,16 +148,17 @@ export function useDatasetActions({
       return;
     }
 
-    const movePromises = itemsToMove.map((item) =>
-      selectFolder({
-        folderId: newFolderId,
-        targetId: item.dataSetId,
-        targetType: 'dataset',
-      }),
-    );
-
     try {
-      const results = await Promise.all(movePromises);
+      const results: ApiResult[] = [];
+      for (const item of itemsToMove) {
+        results.push(
+          await selectFolder({
+            folderId: newFolderId,
+            targetId: item.dataSetId,
+            targetType: 'dataset',
+          }),
+        );
+      }
       const failures = results.filter((res) => !res.success);
 
       if (failures.length === 0) {

--- a/frontend/src/pages/Library/Media/hooks/useMediaActions.ts
+++ b/frontend/src/pages/Library/Media/hooks/useMediaActions.ts
@@ -26,7 +26,7 @@ import type { Dispatch, SetStateAction } from 'react';
 import { useState } from 'react';
 
 import { notify } from '@/components/ui/Notification';
-import { selectFolder } from '@/services/folderApi';
+import { selectFolder, type ApiResult } from '@/services/folderApi';
 import { cloneMedia, deleteMedia, tidyLibrary, updateMedia } from '@/services/mediaApi';
 import type { Media } from '@/types/media';
 import type { Tag } from '@/types/tag';
@@ -129,16 +129,17 @@ export function useMediaActions({
       return;
     }
 
-    const movePromises = itemsToMove.map((item) =>
-      selectFolder({
-        folderId: newFolderId,
-        targetId: item.mediaId,
-        targetType: 'library',
-      }),
-    );
-
     try {
-      const results = await Promise.all(movePromises);
+      const results: ApiResult[] = [];
+      for (const item of itemsToMove) {
+        results.push(
+          await selectFolder({
+            folderId: newFolderId,
+            targetId: item.mediaId,
+            targetType: 'library',
+          }),
+        );
+      }
       const failures = results.filter((res) => !res.success);
 
       if (failures.length === 0) {

--- a/frontend/src/pages/Library/MenuBoard/hooks/useMenuBoardActions.ts
+++ b/frontend/src/pages/Library/MenuBoard/hooks/useMenuBoardActions.ts
@@ -26,7 +26,7 @@ import type { Dispatch, SetStateAction } from 'react';
 import { useState } from 'react';
 
 import { notify } from '@/components/ui/Notification';
-import { selectFolder } from '@/services/folderApi';
+import { selectFolder, type ApiResult } from '@/services/folderApi';
 import { copyMenuBoard, deleteMenuBoard } from '@/services/menuBoardApi';
 import type { MenuBoard } from '@/types/menuBoard';
 
@@ -112,16 +112,17 @@ export function useMenuBoardActions({
       return;
     }
 
-    const movePromises = itemsToMove.map((item) =>
-      selectFolder({
-        folderId: newFolderId,
-        targetId: item.menuId,
-        targetType: 'menuboard',
-      }),
-    );
-
     try {
-      const results = await Promise.all(movePromises);
+      const results: ApiResult[] = [];
+      for (const item of itemsToMove) {
+        results.push(
+          await selectFolder({
+            folderId: newFolderId,
+            targetId: item.menuId,
+            targetType: 'menuboard',
+          }),
+        );
+      }
       const failures = results.filter((res) => !res.success);
 
       if (failures.length === 0) {

--- a/frontend/src/pages/Library/Playlists/hooks/usePlaylistActions.ts
+++ b/frontend/src/pages/Library/Playlists/hooks/usePlaylistActions.ts
@@ -26,7 +26,7 @@ import type { Dispatch, SetStateAction } from 'react';
 import { useState } from 'react';
 
 import { notify } from '@/components/ui/Notification';
-import { selectFolder } from '@/services/folderApi';
+import { selectFolder, type ApiResult } from '@/services/folderApi';
 import { clonePlaylist, deletePlaylist, updatePlaylist } from '@/services/playlistApi';
 import type { Playlist } from '@/types/playlist';
 
@@ -116,16 +116,17 @@ export function usePlaylistActions({
       return;
     }
 
-    const movePromises = itemsToMove.map((item) =>
-      selectFolder({
-        folderId: newFolderId,
-        targetId: item.playlistId,
-        targetType: 'playlist',
-      }),
-    );
-
     try {
-      const results = await Promise.all(movePromises);
+      const results: ApiResult[] = [];
+      for (const item of itemsToMove) {
+        results.push(
+          await selectFolder({
+            folderId: newFolderId,
+            targetId: item.playlistId,
+            targetType: 'playlist',
+          }),
+        );
+      }
       const failures = results.filter((res) => !res.success);
 
       if (failures.length === 0) {

--- a/lib/Entity/Folder.php
+++ b/lib/Entity/Folder.php
@@ -263,8 +263,12 @@ class Folder implements \JsonSerializable
 
     public function touch(): void
     {
+        // touch() commonly runs in the same transaction as a preceding write (e.g. selectFolder's
+        // entity save) - a deadlock here means InnoDB has already rolled back that whole transaction,
+        // so we must let it propagate rather than swallow it, or the caller's earlier write would be
+        // silently lost while the request still reports success.
         $this->modifiedDt = Carbon::now()->format(DateFormatHelper::getSystemFormat());
-        $this->getStore()->update(
+        $this->getStore()->updateWithDeadlockLoop(
             'UPDATE `folder` SET modifiedDt = :modifiedDt WHERE folderId = :folderId',
             ['modifiedDt' => $this->modifiedDt, 'folderId' => $this->id]
         );


### PR DESCRIPTION
relates to xibosignageltd/xibo-private#1650

- Fix inconsistent Move icon on Display Groups (Folder → FolderInput)
- Fix bulk move across multiple pages sending concurrent requests, causing DB deadlocks
- Fix deadlock retries being swallowed, causing silent partial failures
- Fix Displays bulk move missing row selection reset