### PR TITLE
Sync Group Edit form clips off fields on smaller viewports

### DIFF
--- a/frontend/src/pages/Advanced/AuditTrail/components/AuditTrailExportModal.tsx
+++ b/frontend/src/pages/Advanced/AuditTrail/components/AuditTrailExportModal.tsx
@@ -62,9 +62,6 @@ export default function AuditTrailExportModal({ onClose }: AuditTrailExportModal
       onClose={onClose}
       title={t('Output Audit Trail as CSV')}
       size="sm"
-      scrollable={false}
-      className="overflow-visible"
-      contentClassName="overflow-visible"
       actions={[
         {
           label: t('Cancel'),

--- a/frontend/src/pages/Advanced/Logs/components/TruncateLogsModal.tsx
+++ b/frontend/src/pages/Advanced/Logs/components/TruncateLogsModal.tsx
@@ -65,7 +65,6 @@ export default function TruncateLogsModal({ onClose, onSuccess }: TruncateLogsMo
       onClose={onClose}
       size="sm"
       variant="confirmation"
-      scrollable={false}
       autoSubmitFormId={AUTO_SUBMIT_FORMS.logTruncate}
       isPending={isTruncating}
       error={error ?? undefined}

--- a/frontend/src/pages/Displays/DisplayProfile/components/AddDisplayProfileModal.tsx
+++ b/frontend/src/pages/Displays/DisplayProfile/components/AddDisplayProfileModal.tsx
@@ -114,7 +114,6 @@ export default function AddDisplayProfileModal({
       onClose={onClose}
       isOpen={isOpen}
       isPending={isPending}
-      scrollable={false}
       error={apiError}
       actions={[
         { label: t('Cancel'), onClick: onClose, variant: 'secondary', disabled: isPending },

--- a/frontend/src/pages/Displays/Displays/components/AddDisplayModal.tsx
+++ b/frontend/src/pages/Displays/Displays/components/AddDisplayModal.tsx
@@ -73,7 +73,6 @@ export default function AddDisplayModal({ isOpen = true, onClose, onAdded }: Add
       onClose={onClose}
       isOpen={isOpen}
       isPending={isPending}
-      scrollable={false}
       error={apiError}
       actions={[
         { label: t('Cancel'), onClick: onClose, variant: 'secondary', disabled: isPending },

--- a/frontend/src/pages/Displays/PlayerVersions/components/EditPlayerVersionModal.tsx
+++ b/frontend/src/pages/Displays/PlayerVersions/components/EditPlayerVersionModal.tsx
@@ -120,7 +120,6 @@ export default function EditPlayerVersionModal({
       onClose={onClose}
       isOpen={isOpen}
       isPending={isPending}
-      scrollable={false}
       error={apiError}
       actions={[
         { label: t('Cancel'), onClick: onClose, variant: 'secondary', disabled: isPending },

--- a/frontend/src/pages/Displays/SyncGroups/SyncGroups.tsx
+++ b/frontend/src/pages/Displays/SyncGroups/SyncGroups.tsx
@@ -385,6 +385,7 @@ export default function SyncGroups() {
             setSelectedSyncGroupId(syncGroup.syncGroupId);
             openModal('members');
           },
+          openEditForSyncGroup: () => openModal('edit'),
           deleteError,
           isDeleting,
         }}

--- a/frontend/src/pages/Displays/SyncGroups/components/AddAndEditSyncGroupModal.tsx
+++ b/frontend/src/pages/Displays/SyncGroups/components/AddAndEditSyncGroupModal.tsx
@@ -23,6 +23,7 @@ import { isAxiosError } from 'axios';
 import { useEffect, useState, useTransition } from 'react';
 import { useTranslation } from 'react-i18next';
 
+import { notify } from '@/components/ui/Notification';
 import NumberInput from '@/components/ui/forms/NumberInput';
 import SelectDropdown from '@/components/ui/forms/SelectDropdown';
 import type { SelectOption } from '@/components/ui/forms/SelectDropdown';
@@ -76,6 +77,7 @@ export default function AddAndEditSyncGroupModal({
   const [apiError, setApiError] = useState<string | undefined>();
   const [draft, setDraft] = useState<SyncGroupDraft>({ ...DEFAULT_DRAFT });
   const [memberDisplayOptions, setMemberDisplayOptions] = useState<SelectOption[]>([]);
+  const [isLoadingMembers, setIsLoadingMembers] = useState(false);
 
   const isEdit = mode === 'edit';
 
@@ -91,11 +93,18 @@ export default function AddAndEditSyncGroupModal({
           folderId: syncGroup.folderId || null,
         });
 
-        fetchSyncGroupDisplays(syncGroup.syncGroupId).then((displays) => {
-          setMemberDisplayOptions(
-            displays.map((d) => ({ value: String(d.displayId), label: d.display })),
-          );
-        });
+        setMemberDisplayOptions([]);
+        setIsLoadingMembers(true);
+        fetchSyncGroupDisplays(syncGroup.syncGroupId)
+          .then((displays) => {
+            setMemberDisplayOptions(
+              displays.map((d) => ({ value: String(d.displayId), label: d.display })),
+            );
+          })
+          .catch(() => {
+            notify.error(t("Failed to load this sync group's member displays."));
+          })
+          .finally(() => setIsLoadingMembers(false));
       } else {
         setDraft({ ...DEFAULT_DRAFT });
         setMemberDisplayOptions([]);
@@ -107,7 +116,7 @@ export default function AddAndEditSyncGroupModal({
 
   const handleSave = () => {
     startTransition(async () => {
-      const schema = getSyncGroupSchema(t);
+      const schema = getSyncGroupSchema(t, isEdit);
       const result = schema.safeParse(draft);
 
       if (!result.success) {
@@ -117,6 +126,11 @@ export default function AddAndEditSyncGroupModal({
         Object.entries(fieldErrors).forEach(([key, value]) => {
           if (value?.[0]) mappedErrors[key as keyof FormErrors] = value[0];
         });
+        if (mappedErrors.leadDisplayId && memberDisplayOptions.length === 0) {
+          mappedErrors.leadDisplayId = t(
+            'This sync group has no members yet. Assign members before choosing a lead display.',
+          );
+        }
         setFormErrors(mappedErrors);
         return;
       }
@@ -172,7 +186,6 @@ export default function AddAndEditSyncGroupModal({
       onClose={onClose}
       isOpen={isOpen}
       isPending={isPending}
-      scrollable={false}
       size="lg"
       error={apiError}
       actions={modalActions}
@@ -227,12 +240,20 @@ export default function AddAndEditSyncGroupModal({
         {isEdit && (
           <SelectDropdown
             label={t('Lead Display')}
-            helpText={t('Select Lead Display for this sync group')}
+            helpText={
+              !isLoadingMembers && memberDisplayOptions.length === 0
+                ? t(
+                    'This sync group has no members yet. Assign members before choosing a lead display.',
+                  )
+                : t('Select Lead Display for this sync group')
+            }
             value={draft.leadDisplayId ? String(draft.leadDisplayId) : ''}
             options={memberDisplayOptions}
             onSelect={(val) =>
               setDraft((prev) => ({ ...prev, leadDisplayId: val ? Number(val) : null }))
             }
+            error={formErrors.leadDisplayId}
+            isLoading={isLoadingMembers}
             clearable
             searchable
           />

--- a/frontend/src/pages/Displays/SyncGroups/components/ManageMembersModal.tsx
+++ b/frontend/src/pages/Displays/SyncGroups/components/ManageMembersModal.tsx
@@ -39,6 +39,7 @@ interface ManageMembersModalProps {
   syncGroup: SyncGroup | null;
   onClose: () => void;
   onSuccess: () => void;
+  onNeedsLeadDisplay?: () => void;
 }
 
 export default function ManageMembersModal({
@@ -46,6 +47,7 @@ export default function ManageMembersModal({
   syncGroup,
   onClose,
   onSuccess,
+  onNeedsLeadDisplay,
 }: ManageMembersModalProps) {
   const { t } = useTranslation();
   const syncGroupId = syncGroup?.syncGroupId;
@@ -163,7 +165,16 @@ export default function ManageMembersModal({
       await assignSyncGroupMembers(syncGroupId, displaysToAdd, displaysToRemove);
 
       onSuccess();
-      onClose();
+
+      const leadDisplayId = syncGroup?.leadDisplayId;
+      const leadWasRemoved = !!leadDisplayId && displaysToRemove.includes(leadDisplayId);
+      const needsLeadDisplay = !leadDisplayId || leadWasRemoved || assignedDisplays.length === 0;
+
+      if (needsLeadDisplay && onNeedsLeadDisplay) {
+        onNeedsLeadDisplay();
+      } else {
+        onClose();
+      }
     } catch (error) {
       const message =
         isAxiosError(error) && error.response?.data?.message

--- a/frontend/src/pages/Displays/SyncGroups/components/SyncGroupModals.tsx
+++ b/frontend/src/pages/Displays/SyncGroups/components/SyncGroupModals.tsx
@@ -34,6 +34,7 @@ interface SyncGroupModalsProps {
     handleRefresh: () => void;
     setSyncGroupList: React.Dispatch<React.SetStateAction<SyncGroup[]>>;
     openMembersForSyncGroup: (syncGroup: SyncGroup) => void;
+    openEditForSyncGroup: () => void;
     deleteError: string | null;
     isDeleting: boolean;
   };
@@ -85,6 +86,7 @@ export function SyncGroupModals({ actions, selection, handlers }: SyncGroupModal
           syncGroup={selection.selectedSyncGroup}
           onClose={actions.closeModal}
           onSuccess={actions.handleRefresh}
+          onNeedsLeadDisplay={actions.openEditForSyncGroup}
         />
       )}
 

--- a/frontend/src/schema/syncGroup.ts
+++ b/frontend/src/schema/syncGroup.ts
@@ -22,10 +22,21 @@
 import type { TFunction } from 'i18next';
 import z from 'zod';
 
-export const getSyncGroupSchema = (t: TFunction) =>
-  z.object({
-    name: z.string().min(1, t('Name is required')),
-    syncPublisherPort: z.number().min(1, t('Publisher Port must be greater than 0')),
-    syncSwitchDelay: z.number().min(0, t('Switch Delay cannot be negative')),
-    syncVideoPauseDelay: z.number().min(0, t('Video Pause Delay cannot be negative')),
-  });
+export const getSyncGroupSchema = (t: TFunction, isEdit: boolean) =>
+  z
+    .object({
+      name: z.string().min(1, t('Name is required')),
+      syncPublisherPort: z.number().min(1, t('Publisher Port must be greater than 0')),
+      syncSwitchDelay: z.number().min(0, t('Switch Delay cannot be negative')),
+      syncVideoPauseDelay: z.number().min(0, t('Video Pause Delay cannot be negative')),
+      leadDisplayId: z.number().nullable(),
+    })
+    .superRefine((data, ctx) => {
+      if (isEdit && !data.leadDisplayId) {
+        ctx.addIssue({
+          path: ['leadDisplayId'],
+          code: z.ZodIssueCode.custom,
+          message: t('Please select a Lead Display for this sync group'),
+        });
+      }
+    });


### PR DESCRIPTION
relates to xibosignageltd/xibo-private#1758

- Add/Edit Sync Group (and a few other modals) now scroll properly instead of cutting off fields on short screens
- Fixed the Lead Display field failing silently and showing a confusing error when saving a group with no members
- Added a hint explaining why Lead Display is empty when a group has no members yet