### PR TITLE
Display: Fix register with invalid default folderId.

### DIFF
--- a/lib/Controller/Settings.php
+++ b/lib/Controller/Settings.php
@@ -640,12 +640,12 @@ class Settings extends Base
         if ($this->getConfig()->isSettingEditable('DISPLAY_DEFAULT_FOLDER')) {
             $this->handleChangedSettings(
                 'DISPLAY_DEFAULT_FOLDER',
-                $sanitizedParams->getInt('DISPLAY_DEFAULT_FOLDER'),
+                $sanitizedParams->getInt('DISPLAY_DEFAULT_FOLDER', ['default' => 1]),
                 $changedSettings
             );
             $this->getConfig()->changeSetting(
                 'DISPLAY_DEFAULT_FOLDER',
-                $sanitizedParams->getInt('DISPLAY_DEFAULT_FOLDER'),
+                $sanitizedParams->getInt('DISPLAY_DEFAULT_FOLDER', ['default' => 1]),
                 1
             );
         }

--- a/lib/Xmds/Soap5.php
+++ b/lib/Xmds/Soap5.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright (C) 2025 Xibo Signage Ltd
+ * Copyright (C) 2026 Xibo Signage Ltd
  *
  * Xibo - Digital Signage - https://xibosignage.com
  *
@@ -438,7 +438,7 @@ class Soap5 extends Soap4
                 $display->clientAddress = $this->getIp();
                 $display->xmrChannel = $xmrChannel;
                 $display->xmrPubKey = $xmrPubKey;
-                $display->folderId = $this->getConfig()->getSetting('DISPLAY_DEFAULT_FOLDER', 1);
+                $display->folderId = intval($this->getConfig()->getSetting('DISPLAY_DEFAULT_FOLDER', 1));
 
                 if (!$display->isDisplaySlotAvailable()) {
                     $display->licensed = 0;
@@ -539,7 +539,13 @@ class Soap5 extends Soap4
             }
         }
 
-        $display->save(Display::$saveOptionsMinimum);
+        try {
+            $display->save(Display::$saveOptionsMinimum);
+        } catch (\Throwable $e) {
+            $this->getLog()->error('RegisterDisplay: unexpected error saving display - ' . $e->getMessage());
+            $this->getLog()->debug($e->getTraceAsString());
+            return new \SoapFault('Receiver', __('Unexpected error, please contact your administrator.'));
+        }
 
         // cache checks
         $cacheSchedule = $this->getPool()->getItem($this->display->getCacheKey() . '/schedule');


### PR DESCRIPTION
fixes xibosignage/xibo#3890

Not many lines changed, but couple of fixes here:
- By default `DISPLAY_DEFAULT_FOLDER` is not in settings table, make it so on first save it's set to 1 (root folder) not an empty string
- Protect the `DISPLAY_DEFAULT_FOLDER` getSetting() in register wrap it in intval ( would fix empty string here, cast to 0, then on save it would get folderId 1 )
- Wrapped display save() in try/catch to ensure we do not return raw response to the player.