### PR TITLE
Fix: Layout Code dropdown only showing first 10 results

### DIFF
--- a/frontend/src/components/ui/modals/ScheduleEventModal.tsx
+++ b/frontend/src/components/ui/modals/ScheduleEventModal.tsx
@@ -167,6 +167,8 @@ export default function ScheduleEventModal({
     daypart: { totalCount: 0, isLoading: false, isLoadingMore: false },
     command: { totalCount: 0, isLoading: false, isLoadingMore: false },
     layoutCode: { totalCount: 0, isLoading: false, isLoadingMore: false },
+    resolution: { totalCount: 0, isLoading: false, isLoadingMore: false },
+    syncLayout: { totalCount: 0, isLoading: false, isLoadingMore: false },
   });
 
   const loadingMoreRef = useRef<Record<string, boolean>>({});
@@ -210,6 +212,36 @@ export default function ScheduleEventModal({
     clearTimeout(daypartSearchTimerRef.current);
     daypartSearchTimerRef.current = setTimeout(() => {
       setDaypartDebouncedSearch(term);
+    }, 300);
+  };
+
+  const [layoutCodeDebouncedSearch, setLayoutCodeDebouncedSearch] = useState('');
+  const layoutCodeSearchTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  const handleLayoutCodeSearch = (term: string) => {
+    clearTimeout(layoutCodeSearchTimerRef.current);
+    layoutCodeSearchTimerRef.current = setTimeout(() => {
+      setLayoutCodeDebouncedSearch(term);
+    }, 300);
+  };
+
+  const [resolutionDebouncedSearch, setResolutionDebouncedSearch] = useState('');
+  const resolutionSearchTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  const handleResolutionSearch = (term: string) => {
+    clearTimeout(resolutionSearchTimerRef.current);
+    resolutionSearchTimerRef.current = setTimeout(() => {
+      setResolutionDebouncedSearch(term);
+    }, 300);
+  };
+
+  const [syncLayoutDebouncedSearch, setSyncLayoutDebouncedSearch] = useState('');
+  const syncLayoutSearchTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  const handleSyncLayoutSearch = (term: string) => {
+    clearTimeout(syncLayoutSearchTimerRef.current);
+    syncLayoutSearchTimerRef.current = setTimeout(() => {
+      setSyncLayoutDebouncedSearch(term);
     }, 300);
   };
 
@@ -295,12 +327,37 @@ export default function ScheduleEventModal({
     if (!isOpen) {
       return;
     }
-    fetchResolution({ start: 0, length: 100 }).then(({ rows }) => {
-      setResolutionOptions(
-        rows.map((r) => ({ value: String(r.resolutionId), label: r.resolution })),
-      );
-    });
-  }, [isOpen]);
+
+    let cancelled = false;
+    setPagination((prev) => ({ ...prev, resolution: { ...prev.resolution, isLoading: true } }));
+
+    fetchResolution({
+      start: 0,
+      length: DROPDOWN_PAGE_SIZE,
+      resolution: resolutionDebouncedSearch || undefined,
+    })
+      .then(({ rows, totalCount }) => {
+        if (cancelled) {
+          return;
+        }
+        setResolutionOptions(
+          rows.map((r) => ({ value: String(r.resolutionId), label: r.resolution })),
+        );
+        setPagination((prev) => ({ ...prev, resolution: { ...prev.resolution, totalCount } }));
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setPagination((prev) => ({
+            ...prev,
+            resolution: { ...prev.resolution, isLoading: false },
+          }));
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, resolutionDebouncedSearch]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -542,6 +599,9 @@ export default function ScheduleEventModal({
   const hasMoreContent = contentOptions.length < pagination.content.totalCount;
   const hasMoreDayparts = daypartOptions.length < pagination.daypart.totalCount;
   const hasMoreCommands = commandOptions.length < pagination.command.totalCount;
+  const hasMoreLayoutCodes = layoutCodeOptions.length < pagination.layoutCode.totalCount;
+  const hasMoreResolutions = resolutionOptions.length < pagination.resolution.totalCount;
+  const hasMoreSyncLayouts = syncLayoutOptions.length < pagination.syncLayout.totalCount;
 
   const loadMoreContent = () => {
     if (!draft.eventTypeId || isLoadingContent) return;
@@ -583,6 +643,49 @@ export default function ScheduleEventModal({
     );
   };
 
+  const loadMoreLayoutCodes = () => {
+    loadMore(
+      'layoutCode',
+      () =>
+        fetchLayoutCodes({
+          start: layoutCodeOptions.length,
+          length: DROPDOWN_PAGE_SIZE,
+          code: layoutCodeDebouncedSearch || undefined,
+        }).then(({ rows }) =>
+          rows.map((c) => ({ value: c.code, label: `${c.layout} (${c.code})` })),
+        ),
+      setLayoutCodeOptions,
+    );
+  };
+
+  const loadMoreResolutions = () => {
+    loadMore(
+      'resolution',
+      () =>
+        fetchResolution({
+          start: resolutionOptions.length,
+          length: DROPDOWN_PAGE_SIZE,
+          resolution: resolutionDebouncedSearch || undefined,
+        }).then(({ rows }) =>
+          rows.map((r) => ({ value: String(r.resolutionId), label: r.resolution })),
+        ),
+      setResolutionOptions,
+    );
+  };
+
+  const loadMoreSyncLayouts = () => {
+    loadMore(
+      'syncLayout',
+      () =>
+        fetchLayouts({
+          start: syncLayoutOptions.length,
+          length: DROPDOWN_PAGE_SIZE,
+          layout: syncLayoutDebouncedSearch || undefined,
+        }).then(({ rows }) => rows.map((l) => ({ value: String(l.layoutId), label: l.layout }))),
+      setSyncLayoutOptions,
+    );
+  };
+
   useEffect(() => {
     if (!isOpen || draft.eventTypeId !== EventTypeId.Action) {
       setLayoutCodeOptions([]);
@@ -590,31 +693,45 @@ export default function ScheduleEventModal({
       return;
     }
 
+    let cancelled = false;
     setPagination((prev) => ({
       ...prev,
       layoutCode: { ...prev.layoutCode, isLoading: true },
     }));
 
-    fetchLayoutCodes()
-      .then((codes) => {
+    fetchLayoutCodes({
+      start: 0,
+      length: DROPDOWN_PAGE_SIZE,
+      code: layoutCodeDebouncedSearch || undefined,
+    })
+      .then(({ rows: codes, totalCount }) => {
+        if (cancelled) {
+          return;
+        }
         setLayoutCodeOptions(
           codes.map((c) => ({ value: c.code, label: `${c.layout} (${c.code})` })),
         );
         setPagination((prev) => ({
           ...prev,
-          layoutCode: { ...prev.layoutCode, totalCount: codes.length },
+          layoutCode: { ...prev.layoutCode, totalCount },
         }));
       })
       .catch((err) => {
         console.error('fetchLayoutCodes failed:', err);
       })
       .finally(() => {
-        setPagination((prev) => ({
-          ...prev,
-          layoutCode: { ...prev.layoutCode, isLoading: false },
-        }));
+        if (!cancelled) {
+          setPagination((prev) => ({
+            ...prev,
+            layoutCode: { ...prev.layoutCode, isLoading: false },
+          }));
+        }
       });
-  }, [isOpen, draft.eventTypeId]);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, draft.eventTypeId, layoutCodeDebouncedSearch]);
 
   useEffect(() => {
     if (!isOpen || draft.eventTypeId !== EventTypeId.Action) {
@@ -657,21 +774,16 @@ export default function ScheduleEventModal({
   useEffect(() => {
     if (!isOpen || !isSyncType || !draft.syncGroupId) {
       setSyncDisplays([]);
-      setSyncLayoutOptions([]);
       return;
     }
 
     let cancelled = false;
     setIsLoadingSyncDisplays(true);
 
-    Promise.all([
-      fetchSyncGroupDisplays(draft.syncGroupId, isEditMode ? event?.eventId : undefined),
-      fetchLayouts({ start: 0, length: 100 }),
-    ])
-      .then(([displays, { rows: layouts }]) => {
+    fetchSyncGroupDisplays(draft.syncGroupId, isEditMode ? event?.eventId : undefined)
+      .then((displays) => {
         if (cancelled) return;
         setSyncDisplays(displays);
-        setSyncLayoutOptions(layouts.map((l) => ({ value: String(l.layoutId), label: l.layout })));
         // Pre-populate syncDisplayLayouts from fetched data (edit mode)
         const layoutMap: Record<number, number | null> = {};
         displays.forEach((d) => {
@@ -697,6 +809,40 @@ export default function ScheduleEventModal({
       cancelled = true;
     };
   }, [isOpen, isSyncType, draft.syncGroupId]);
+
+  // Fetch layout options for the sync group per-display layout dropdowns
+  useEffect(() => {
+    if (!isOpen || !isSyncType || !draft.syncGroupId) {
+      setSyncLayoutOptions([]);
+      return;
+    }
+
+    let cancelled = false;
+    setPagination((prev) => ({ ...prev, syncLayout: { ...prev.syncLayout, isLoading: true } }));
+
+    fetchLayouts({
+      start: 0,
+      length: DROPDOWN_PAGE_SIZE,
+      layout: syncLayoutDebouncedSearch || undefined,
+    })
+      .then(({ rows: layouts, totalCount }) => {
+        if (cancelled) return;
+        setSyncLayoutOptions(layouts.map((l) => ({ value: String(l.layoutId), label: l.layout })));
+        setPagination((prev) => ({ ...prev, syncLayout: { ...prev.syncLayout, totalCount } }));
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setPagination((prev) => ({
+            ...prev,
+            syncLayout: { ...prev.syncLayout, isLoading: false },
+          }));
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, isSyncType, draft.syncGroupId, syncLayoutDebouncedSearch]);
 
   const updateDraft = <K extends keyof ScheduleEventDraft>(
     key: K,
@@ -1020,6 +1166,11 @@ export default function ScheduleEventModal({
           }}
           placeholder={t('Select Layout')}
           searchable
+          onSearch={handleSyncLayoutSearch}
+          isLoading={pagination.syncLayout.isLoading}
+          onLoadMore={loadMoreSyncLayouts}
+          hasMore={hasMoreSyncLayouts}
+          isLoadingMore={pagination.syncLayout.isLoadingMore}
         />
       ),
     },
@@ -1313,7 +1464,11 @@ export default function ScheduleEventModal({
                         'Please select the Code identifier for the Layout that Player should navigate to when this Action is triggered.',
                       )}
                       searchable
+                      onSearch={handleLayoutCodeSearch}
                       isLoading={pagination.layoutCode.isLoading}
+                      onLoadMore={loadMoreLayoutCodes}
+                      hasMore={hasMoreLayoutCodes}
+                      isLoadingMore={pagination.layoutCode.isLoadingMore}
                       error={formErrors.actionLayoutCode}
                     />
                   )}
@@ -1618,6 +1773,12 @@ export default function ScheduleEventModal({
                           'Optionally select a Resolution to use for the selected Media. Leave blank to match with an existing Resolution closest in size to the selected media.',
                         )}
                         clearable
+                        searchable
+                        onSearch={handleResolutionSearch}
+                        isLoading={pagination.resolution.isLoading}
+                        onLoadMore={loadMoreResolutions}
+                        hasMore={hasMoreResolutions}
+                        isLoadingMore={pagination.resolution.isLoadingMore}
                       />
                       <div className="flex flex-col gap-1.5">
                         <label className="text-sm font-semibold text-gray-500">

--- a/frontend/src/pages/Schedule/Schedule/__tests__/mocks/api.ts
+++ b/frontend/src/pages/Schedule/Schedule/__tests__/mocks/api.ts
@@ -91,7 +91,7 @@ export const mockFetchEventById = (event: Event): void => {
 // Layouts
 export const setupLayoutsMocks = (): void => {
   vi.mocked(fetchLayouts).mockResolvedValue({ rows: [], totalCount: 0 });
-  vi.mocked(fetchLayoutCodes).mockResolvedValue([]);
+  vi.mocked(fetchLayoutCodes).mockResolvedValue({ rows: [], totalCount: 0 });
 };
 
 // Media

--- a/frontend/src/services/layoutsApi.ts
+++ b/frontend/src/services/layoutsApi.ts
@@ -371,10 +371,30 @@ export interface LayoutCode {
   layout: string;
 }
 
-export async function fetchLayoutCodes(code?: string): Promise<LayoutCode[]> {
+export interface FetchLayoutCodesRequest {
+  start: number;
+  length: number;
+  code?: string;
+}
+
+export interface FetchLayoutCodesResponse {
+  rows: LayoutCode[];
+  totalCount: number;
+}
+
+export async function fetchLayoutCodes(
+  options: FetchLayoutCodesRequest = { start: 0, length: 10 },
+): Promise<FetchLayoutCodesResponse> {
   const response = await http.get('/layout/codes', {
-    params: code ? { code } : undefined,
+    params: options,
   });
 
-  return response.data;
+  const rows = response.data;
+  const totalCountHeader = response.headers['x-total-count'];
+  const totalCount = totalCountHeader ? parseInt(totalCountHeader, 10) : 0;
+
+  return {
+    rows,
+    totalCount,
+  };
 }


### PR DESCRIPTION
relates to xibosignage/xibo#3888

- fetchLayoutCodes() never sent start/length or read x-total-count, so the backend silently capped results at 10 with no search/load-more
- Resolution and Sync Group per-display Layout dropdowns had the same cap-with-no-pagination bug (capped at 100), fixed the same way