### PR TITLE
Fix: Display Group copy ignores option toggles for dynamic groups

### DIFF
--- a/lib/Controller/DisplayGroup.php
+++ b/lib/Controller/DisplayGroup.php
@@ -2207,7 +2207,9 @@ class DisplayGroup extends Base
             $new->updateTagLinks($displayGroup->tags);
         }
 
-        $new->save();
+        $new->save([
+            'manageDynamicDisplayLinks' => $copyMembers,
+        ]);
 
         // Return
         $this->getState()->hydrate([


### PR DESCRIPTION
relates to: https://github.com/xibosignageltd/xibo-private/issues/1653

Description:

- The frontend correctly sends `copyMembers=0`, `copyAssignments=0`, `copyTags=0` via the toggle checkboxes, and the backend `getCheckbox()` sanitizer correctly interprets `"0"` as false — no frontend changes needed
- The bug was in `DisplayGroup::copy()` in the controller: after cloning and clearing members via` clearDisplays()`, the call to `$new->save()` triggered `manageDisplayLinks()` which re-evaluates `dynamicCriteria` for dynamic display groups, repopulating `$this->displays` and effectively undoing the clear
- Fix: pass `manageDynamicDisplayLinks => $copyMember`s to `save()` so dynamic member re-evaluation only runs when the user opts to copy members