### PR TITLE
Fix: Media Manager Dashboard chart responsiveness

### DIFF
--- a/frontend/src/pages/Dashboard/MediaDashboard/components/MediaTypeChart.tsx
+++ b/frontend/src/pages/Dashboard/MediaDashboard/components/MediaTypeChart.tsx
@@ -101,7 +101,7 @@ export default function MediaTypeChart({
           <p className="ml-2 text-gray-600">{t('Loading...')}</p>
         </div>
       ) : (
-        <div className="flex flex-row sm:flex-col xl:flex-row items-center gap-5">
+        <div className="flex flex-col xl:flex-row items-center gap-5">
           <div className="relative shrink-0" onMouseMove={onMouseMove} onMouseLeave={onMouseLeave}>
             <ResponsiveContainer width={200} height={200}>
               <PieChart accessibilityLayer={false}>


### PR DESCRIPTION
relates to: https://github.com/xibosignageltd/xibo-private/issues/1756

Fix: Keep the column view on smaller screen for the `MediaTypeChart`