### PR TITLE
Dependencies: force nanoid to patched versions via overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3588,9 +3588,9 @@
       }
     },
     "node_modules/@xibosignage/xibo-layout-renderer/node_modules/nanoid": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.9.tgz",
-      "integrity": "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw==",
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
+      "integrity": "sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==",
       "funding": [
         {
           "type": "github",
@@ -8182,9 +8182,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -134,6 +134,10 @@
     "flatted": "^3.4.2",
     "brace-expansion": "^1.1.18",
     "picomatch": "^2.3.2",
-    "fast-uri": "^3.1.5"
+    "fast-uri": "^3.1.5",
+    "nanoid": "3.3.18",
+    "@xibosignage/xibo-layout-renderer": {
+      "nanoid": "5.1.16"
+    }
   }
 }


### PR DESCRIPTION
`nanoid` was pinned at vulnerable 3.3.16 (via `autoprefixer > postcss`) and 5.1.9 (via `xibo-layout-renderer`). Dependabot couldn't auto-fix this because the reported patch version (5.1.16) would've required downgrading autoprefixer - but a patched legacy 3.x release (3.3.18) also exists and satisfies postcss's existing range, so both paths are pinned via overrides instead.