### PR TITLE
Fix: Menu Board create throws HTTP 500 during audit logging

### DIFF
--- a/lib/Entity/EntityTrait.php
+++ b/lib/Entity/EntityTrait.php
@@ -307,7 +307,7 @@ trait EntityTrait
         $objectAsJson = $this->jsonSerialize();
 
         foreach ($objectAsJson as $key => $value) {
-            if (isset($this->datesToFormat) && in_array($key, $this->datesToFormat)) {
+            if (isset($this->datesToFormat) && in_array($key, $this->datesToFormat) && !empty($value)) {
                 $objectAsJson[$key] = DateFormatHelper::createFromTimestamp($value)
                     ->format(DateFormatHelper::getSystemFormat());
             }

--- a/lib/Entity/MenuBoard.php
+++ b/lib/Entity/MenuBoard.php
@@ -269,15 +269,17 @@ class MenuBoard implements \JsonSerializable
 
     private function add(): void
     {
+        $this->modifiedDt = Carbon::now()->format('U');
+
         $this->menuId = $this->getStore()->insert(
-            'INSERT INTO `menu_board` (name, description, code, userId, modifiedDt, folderId, permissionsFolderId) 
+            'INSERT INTO `menu_board` (name, description, code, userId, modifiedDt, folderId, permissionsFolderId)
                     VALUES (:name, :description, :code, :userId, :modifiedDt, :folderId, :permissionsFolderId)',
             [
                 'name' => $this->name,
                 'description' => $this->description,
                 'code' => $this->code,
                 'userId' => $this->userId,
-                'modifiedDt' => Carbon::now()->format('U'),
+                'modifiedDt' => $this->modifiedDt,
                 'folderId' => ($this->folderId == null) ? 1 : $this->folderId,
                 'permissionsFolderId' => ($this->permissionsFolderId == null) ? 1 : $this->permissionsFolderId
             ]


### PR DESCRIPTION
relates to xibosignageltd/xibo-private#1823

- MenuBoard::add() bound modifiedDt only as a SQL param, never assigning it back onto the entity, so the in-memory value stayed null after insert

- save()'s audit-on-create call falls back to toArray() when there are no originalValues, which unconditionally formatted datesToFormat fields, crashing Carbon::createFromTimestamp() on the null value

- Also guard EntityTrait::toArray() against empty date values, matching the check already in getChangedProperties(), to close the same failure mode for any other entity