### PR TITLE
fix: Carbon upgrade causes regressions in multiple places

### DIFF
--- a/lib/Controller/Stats.php
+++ b/lib/Controller/Stats.php
@@ -894,7 +894,7 @@ class Stats extends Base
             }
             $entry['start'] = $start->format($returnDateFormat);
             $entry['end'] = $end->format($returnDateFormat);
-            $entry['duration'] = (int) $end->diffInSeconds($start);
+            $entry['duration'] = (int) $end->diffInSeconds($start, true);
             $rows[] = $entry;
         }
 

--- a/lib/Entity/Campaign.php
+++ b/lib/Entity/Campaign.php
@@ -375,7 +375,7 @@ class Campaign implements \JsonSerializable
 
         // if start and end date are the same
         // set the daysTotal to 1, to avoid potential division by 0 later on.
-        $progress->daysTotal = ($this->startDt === $this->endDt) ? 1 : (int) $endDt->diffInDays($startDt);
+        $progress->daysTotal = ($this->startDt === $this->endDt) ? 1 : (int) $endDt->diffInDays($startDt, true);
 
         $progress->targetPerDay = $this->target / $progress->daysTotal;
 
@@ -388,11 +388,11 @@ class Campaign implements \JsonSerializable
                 $progress->daysIn = $progress->daysTotal;
                 $progress->progressTime = 100;
             } else {
-                $progress->daysIn = (int) $testDate->diffInDays($startDt);
+                $progress->daysIn = (int) $testDate->diffInDays($startDt, true);
 
                 // Use hours to calculate more accurate progress
                 $hoursTotal = $progress->daysTotal * 24;
-                $hoursIn = (int) $testDate->diffInHours($startDt);
+                $hoursIn = (int) $testDate->diffInHours($startDt, true);
                 $progress->progressTime = $hoursIn / $hoursTotal * 100;
             }
 

--- a/lib/Report/DistributionReport.php
+++ b/lib/Report/DistributionReport.php
@@ -632,7 +632,7 @@ class DistributionReport implements ReportInterface
             $filterRangeStart = new UTCDateTime($fromDt->format('U') * 1000);
             $filterRangeEnd = new UTCDateTime($toDt->format('U') * 1000);
 
-            $diffInDays = (int) $toDt->diffInDays($fromDt);
+            $diffInDays = (int) $toDt->diffInDays($fromDt, true);
             if ($groupByFilter == 'byhour') {
                 $hour = 1;
                 $input = range(0, 24 * $diffInDays - 1); // subtract 1 as we start from 0

--- a/lib/Report/SummaryReport.php
+++ b/lib/Report/SummaryReport.php
@@ -628,7 +628,7 @@ class SummaryReport implements ReportInterface
         $reportFilter
     ) {
 
-        $diffInDays = (int) $toDt->diffInDays($fromDt);
+        $diffInDays = (int) $toDt->diffInDays($fromDt, true);
         if ($groupByFilter == 'byhour') {
             $hour = 1;
             $input = range(0, 23);

--- a/lib/Widget/IcsProvider.php
+++ b/lib/Widget/IcsProvider.php
@@ -101,7 +101,7 @@ class IcsProvider implements WidgetProviderInterface
         // Set up fuzzy filtering supported by the ICal library. This is included for performance.
         // https://github.com/u01jmg3/ics-parser?tab=readme-ov-file#variables
         $iCalConfig['filterDaysBefore'] = (int) $rangeStart->diffInDays(Carbon::now(), false) + 2;
-        $iCalConfig['filterDaysAfter'] = (int) $rangeEnd->diffInDays(Carbon::now()) + 2;
+        $iCalConfig['filterDaysAfter'] = (int) $rangeEnd->diffInDays(Carbon::now(), true) + 2;
 
         $this->getLog()->debug('Range start: ' . $rangeStart->toDateTimeString()
             . ', range end: ' . $rangeEnd->toDateTimeString()
@@ -178,7 +178,8 @@ class IcsProvider implements WidgetProviderInterface
                         $startAtMidnight = $entry->startDate->isStartOfDay();
                         $endsAtMidnight = $entry->endDate->isStartOfDay();
                         $diffDays = $entry->endDate->copy()->startOfDay()->diffInDays(
-                            $entry->startDate->copy()->startOfDay()
+                            $entry->startDate->copy()->startOfDay(),
+                            true
                         );
 
                         $isAllDay = $startAtMidnight && $endsAtMidnight && $diffDays >= 1;

--- a/lib/XTR/RemoveOldScreenshotsTask.php
+++ b/lib/XTR/RemoveOldScreenshotsTask.php
@@ -57,7 +57,7 @@ class RemoveOldScreenshotsTask implements TaskInterface
 
                 $lastModified = DateFormatHelper::createFromTimestamp(filemtime($fileLocation));
                 $now = Carbon::now();
-                $diff = $now->diffInDays($lastModified);
+                $diff = $now->diffInDays($lastModified, true);
 
                 if ($diff > $screenshotTTL) {
                     unlink($fileLocation);

--- a/lib/XTR/StatsMigrationTask.php
+++ b/lib/XTR/StatsMigrationTask.php
@@ -521,7 +521,7 @@ class StatsMigrationTask implements TaskInterface
                 $entry['mediaId'] = (int) $stat['mediaId'];
                 $entry['tag'] = $stat['tag'];
                 $entry['widgetId'] = (int) $stat['widgetId'];
-                $entry['duration'] = (int) $end->diffInSeconds($start);
+                $entry['duration'] = (int) $end->diffInSeconds($start, true);
                 $entry['count'] = isset($stat['count']) ? (int) $stat['count'] : 1;
 
                 // Add stats in store $this->stats

--- a/lib/Xmds/Soap.php
+++ b/lib/Xmds/Soap.php
@@ -2053,7 +2053,7 @@ class Soap
 
                 // Do we need to set the duration of this record (we will do for older individually collected stats)
                 if ($duration == '') {
-                    $duration = (int) $toDt->diffInSeconds($fromDt);
+                    $duration = (int) $toDt->diffInSeconds($fromDt, true);
                 }
             } catch (\Exception $e) {
                 // Protect against the date format being unreadable


### PR DESCRIPTION
Anywhere we calculate the difference between two dates. 

```
┌─────────────────────────────────────────┬──────────────────────────────────────────────────────────────┬──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│                File:line                │                        Call (before)                         │                                                            Impact                                                            │
├─────────────────────────────────────────┼──────────────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│                                         │                                                              │ The reported failure. Negative daysTotal → negative targetPerDay → negative playsNeededPerLayout → negative shareOfVoice, so │
│ lib/Entity/Campaign.php:378             │ $endDt->diffInDays($startDt)                                 │  task 20 throws "Share of Voice must be a whole number between 0 and 3600" for every ad campaign and no interrupt schedules  │
│                                         │                                                              │ are created at all                                                                                                           │
├─────────────────────────────────────────┼──────────────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ lib/Entity/Campaign.php:391             │ $testDate->diffInDays($startDt)                              │ Negative daysIn on the returned CampaignProgress                                                                             │
├─────────────────────────────────────────┼──────────────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│                                         │                                                              │ Negative hoursIn. Cancelled against the negative hoursTotal, so progressTime was accidentally correct — which is why fixing  │
│ lib/Entity/Campaign.php:395             │ $testDate->diffInHours($startDt)                             │ :378 alone would have flipped progressTime negative and broken the ahead-of-schedule / catch-up ratio logic in               │
│                                         │                                                              │ CampaignSchedulerTask.php:208-225                                                                                            │
├─────────────────────────────────────────┼──────────────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ lib/Report/SummaryReport.php:631        │ $toDt->diffInDays($fromDt)                                   │ Negative $diffInDays → range(0, $diffInDays - 1) builds a descending range → wrong buckets for byday/byweek/bymonth          │
│                                         │                                                              │ groupings                                                                                                                    │
├─────────────────────────────────────────┼──────────────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ lib/Report/DistributionReport.php:635   │ $toDt->diffInDays($fromDt)                                   │ Same descending-range problem across byhour/bydayofweek/bydayofmonth groupings (MongoDB path)                                │
├─────────────────────────────────────────┼──────────────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ lib/Controller/Stats.php:897            │ $end->diffInSeconds($start)                                  │ Negative duration shown in the stats grid                                                                                    │
├─────────────────────────────────────────┼──────────────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ lib/XTR/StatsMigrationTask.php:524      │ $end->diffInSeconds($start)                                  │ Negative duration persisted into the migrated stat records                                                                   │
├─────────────────────────────────────────┼──────────────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ lib/Xmds/Soap.php:2056                  │ $toDt->diffInSeconds($fromDt)                                │ Negative duration recorded for player-submitted stats that arrive without one; also slips past the $duration > 86400 * 365   │
│                                         │                                                              │ "dates too far apart" sanity check, so bad records are stored rather than rejected                                           │
├─────────────────────────────────────────┼──────────────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ lib/XTR/RemoveOldScreenshotsTask.php:60 │ $now->diffInDays($lastModified)                              │ $diff > $screenshotTTL can never be true → old display screenshots are never purged, library grows unbounded                 │
├─────────────────────────────────────────┼──────────────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ lib/Widget/IcsProvider.php:104          │ $rangeEnd->diffInDays(Carbon::now())                         │ Negative filterDaysAfter → the ICS parser's fuzzy filter drops calendar events after "now"                                   │
├─────────────────────────────────────────┼──────────────────────────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ lib/Widget/IcsProvider.php:180          │ $endDate->startOfDay()->diffInDays($startDate->startOfDay()) │ $diffDays >= 1 can never be true → multi-day all-day event detection silently fails                                          │
└─────────────────────────────────────────┴──────────────────────────────────────────────────────────────┴──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

fixes xibosignage/xibo#3925