### PR TITLE
Bulk action: Fixed generic 'Not Found' error during concurrent bulk deletion

### DIFF
--- a/frontend/src/pages/Administration/Applications/hooks/useApplicationsActions.ts
+++ b/frontend/src/pages/Administration/Applications/hooks/useApplicationsActions.ts
@@ -28,6 +28,7 @@ import { useState } from 'react';
 import { notify } from '@/components/ui/Notification';
 import { deleteApplication } from '@/services/applicationApi';
 import type { Application } from '@/types/application';
+import { isAlreadyDeletedError } from '@/utils/errors';
 
 interface UseApplicationActionsProps {
   t: TFunction;
@@ -56,23 +57,33 @@ export function useApplicationActions({
         itemsToDelete.map((item) => deleteApplication(item.key)),
       );
 
-      const failed = results.filter((r) => r.status === 'rejected');
-      if (failed.length > 0) {
-        const firstRejected = failed[0] as PromiseRejectedResult;
+      const trueFailed = results.filter(
+        (r) => r.status === 'rejected' && !isAlreadyDeletedError(r.reason),
+      );
+      const deletedCount = itemsToDelete.length - trueFailed.length;
+
+      if (trueFailed.length > 0) {
+        const firstRejected = trueFailed[0] as PromiseRejectedResult;
         const reason = firstRejected.reason;
-        const message =
+        const specificMessage =
           isAxiosError(reason) && reason.response?.data?.message
             ? reason.response.data.message
-            : t('{{count}} item(s) could not be deleted.', { count: failed.length });
-        setDeleteError(message);
+            : undefined;
+        const failurePart =
+          specificMessage ??
+          t('{{count}} application(s) could not be deleted.', { count: trueFailed.length });
+        const successPart =
+          deletedCount > 0
+            ? t('{{count}} application(s) deleted successfully.', { count: deletedCount })
+            : '';
+
+        setDeleteError([successPart, failurePart].filter(Boolean).join(' '));
         setRowSelection({});
         handleRefresh();
         return;
       }
 
-      notify.success(
-        t('{{count}} application(s) deleted successfully.', { count: itemsToDelete.length }),
-      );
+      notify.success(t('{{count}} application(s) deleted successfully.', { count: deletedCount }));
       setRowSelection({});
       handleRefresh();
       closeModal();

--- a/frontend/src/pages/Administration/Fonts/hooks/useFontActions.ts
+++ b/frontend/src/pages/Administration/Fonts/hooks/useFontActions.ts
@@ -28,6 +28,7 @@ import { useState } from 'react';
 import { notify } from '@/components/ui/Notification';
 import { deleteFont } from '@/services/fontApi';
 import type { Font } from '@/types/font';
+import { isAlreadyDeletedError } from '@/utils/errors';
 
 interface UseFontActionsProps {
   t: TFunction;
@@ -54,21 +55,33 @@ export function useFontActions({
       setIsDeleting(true);
       const results = await Promise.allSettled(itemsToDelete.map((item) => deleteFont(item.id)));
 
-      const failed = results.filter((r) => r.status === 'rejected');
-      if (failed.length > 0) {
-        const firstRejected = failed[0] as PromiseRejectedResult;
+      const trueFailed = results.filter(
+        (r) => r.status === 'rejected' && !isAlreadyDeletedError(r.reason),
+      );
+      const deletedCount = itemsToDelete.length - trueFailed.length;
+
+      if (trueFailed.length > 0) {
+        const firstRejected = trueFailed[0] as PromiseRejectedResult;
         const reason = firstRejected.reason;
-        const message =
+        const specificMessage =
           isAxiosError(reason) && reason.response?.data?.message
             ? reason.response.data.message
-            : t('{{count}} item(s) could not be deleted.', { count: failed.length });
-        setDeleteError(message);
+            : undefined;
+        const failurePart =
+          specificMessage ??
+          t('{{count}} font(s) could not be deleted.', { count: trueFailed.length });
+        const successPart =
+          deletedCount > 0
+            ? t('{{count}} font(s) deleted successfully.', { count: deletedCount })
+            : '';
+
+        setDeleteError([successPart, failurePart].filter(Boolean).join(' '));
         setRowSelection({});
         handleRefresh();
         return;
       }
 
-      notify.success(t('{{count}} font(s) deleted successfully.', { count: itemsToDelete.length }));
+      notify.success(t('{{count}} font(s) deleted successfully.', { count: deletedCount }));
       setRowSelection({});
       handleRefresh();
       closeModal();

--- a/frontend/src/pages/Administration/Tags/__tests__/Tags.delete.test.tsx
+++ b/frontend/src/pages/Administration/Tags/__tests__/Tags.delete.test.tsx
@@ -240,7 +240,7 @@ describe('Tags page - bulk delete', () => {
     await screen.findByRole('heading', { name: /delete tags\?/i });
     await user.click(screen.getByRole('button', { name: /yes, delete/i }));
 
-    await screen.findByText('Tag 2 is in use.');
+    await screen.findByText('1 tag(s) deleted successfully. Tag 2 is in use.');
     expect(screen.getByRole('heading', { name: /delete tags\?/i })).toBeInTheDocument();
     expect(deleteTag).toHaveBeenCalledTimes(2);
   });

--- a/frontend/src/pages/Administration/Tags/hooks/useTagsActions.ts
+++ b/frontend/src/pages/Administration/Tags/hooks/useTagsActions.ts
@@ -28,6 +28,7 @@ import { useState } from 'react';
 import { notify } from '@/components/ui/Notification';
 import { deleteTag } from '@/services/tagApi';
 import type { Tag } from '@/types/tag';
+import { isAlreadyDeletedError } from '@/utils/errors';
 
 interface UseTagsActionsProps {
   t: TFunction;
@@ -54,21 +55,33 @@ export function useTagsActions({
       setIsDeleting(true);
       const results = await Promise.allSettled(itemsToDelete.map((item) => deleteTag(item.tagId)));
 
-      const failed = results.filter((r) => r.status === 'rejected');
-      if (failed.length > 0) {
-        const firstRejected = failed[0] as PromiseRejectedResult;
+      const trueFailed = results.filter(
+        (r) => r.status === 'rejected' && !isAlreadyDeletedError(r.reason),
+      );
+      const deletedCount = itemsToDelete.length - trueFailed.length;
+
+      if (trueFailed.length > 0) {
+        const firstRejected = trueFailed[0] as PromiseRejectedResult;
         const reason = firstRejected.reason;
-        const message =
+        const specificMessage =
           isAxiosError(reason) && reason.response?.data?.message
             ? reason.response.data.message
-            : t('{{count}} item(s) could not be deleted.', { count: failed.length });
-        setDeleteError(message);
+            : undefined;
+        const failurePart =
+          specificMessage ??
+          t('{{count}} tag(s) could not be deleted.', { count: trueFailed.length });
+        const successPart =
+          deletedCount > 0
+            ? t('{{count}} tag(s) deleted successfully.', { count: deletedCount })
+            : '';
+
+        setDeleteError([successPart, failurePart].filter(Boolean).join(' '));
         setRowSelection({});
         handleRefresh();
         return;
       }
 
-      notify.success(t('{{count}} tag(s) deleted successfully.', { count: itemsToDelete.length }));
+      notify.success(t('{{count}} tag(s) deleted successfully.', { count: deletedCount }));
       setRowSelection({});
       handleRefresh();
       closeModal();

--- a/frontend/src/pages/Administration/Tasks/__tests__/Tasks.delete.test.tsx
+++ b/frontend/src/pages/Administration/Tasks/__tests__/Tasks.delete.test.tsx
@@ -234,7 +234,9 @@ describe('Tasks page - bulk delete', () => {
     await user.click(screen.getByRole('button', { name: /yes, delete/i }));
 
     // Error surfaces and the modal stays open.
-    expect(await screen.findByText('Task 2 is in use.')).toBeInTheDocument();
+    expect(
+      await screen.findByText('1 task(s) deleted successfully. Task 2 is in use.'),
+    ).toBeInTheDocument();
     expect(screen.getByText('Delete Tasks?')).toBeInTheDocument();
 
     // Both rows were attempted and the table was refreshed.

--- a/frontend/src/pages/Administration/Tasks/hooks/useTasksActions.ts
+++ b/frontend/src/pages/Administration/Tasks/hooks/useTasksActions.ts
@@ -28,6 +28,7 @@ import { useState } from 'react';
 import { notify } from '@/components/ui/Notification';
 import { deleteTask, runTaskNow } from '@/services/taskApi';
 import type { Task } from '@/types/task';
+import { isAlreadyDeletedError } from '@/utils/errors';
 
 interface UseTasksActionsProps {
   t: TFunction;
@@ -59,21 +60,33 @@ export function useTasksActions({
         itemsToDelete.map((item) => deleteTask(item.taskId)),
       );
 
-      const failed = results.filter((r) => r.status === 'rejected');
-      if (failed.length > 0) {
-        const firstRejected = failed[0] as PromiseRejectedResult;
+      const trueFailed = results.filter(
+        (r) => r.status === 'rejected' && !isAlreadyDeletedError(r.reason),
+      );
+      const deletedCount = itemsToDelete.length - trueFailed.length;
+
+      if (trueFailed.length > 0) {
+        const firstRejected = trueFailed[0] as PromiseRejectedResult;
         const reason = firstRejected.reason;
-        const message =
+        const specificMessage =
           isAxiosError(reason) && reason.response?.data?.message
             ? reason.response.data.message
-            : t('{{count}} item(s) could not be deleted.', { count: failed.length });
-        setDeleteError(message);
+            : undefined;
+        const failurePart =
+          specificMessage ??
+          t('{{count}} task(s) could not be deleted.', { count: trueFailed.length });
+        const successPart =
+          deletedCount > 0
+            ? t('{{count}} task(s) deleted successfully.', { count: deletedCount })
+            : '';
+
+        setDeleteError([successPart, failurePart].filter(Boolean).join(' '));
         setRowSelection({});
         handleRefresh();
         return;
       }
 
-      notify.success(t('{{count}} task(s) deleted successfully.', { count: itemsToDelete.length }));
+      notify.success(t('{{count}} task(s) deleted successfully.', { count: deletedCount }));
       setRowSelection({});
       handleRefresh();
       closeModal();

--- a/frontend/src/pages/Administration/UserGroups/hooks/useUserGroupActions.ts
+++ b/frontend/src/pages/Administration/UserGroups/hooks/useUserGroupActions.ts
@@ -28,6 +28,7 @@ import { useState } from 'react';
 import { notify } from '@/components/ui/Notification';
 import { deleteUserGroup } from '@/services/userGroupApi';
 import type { UserGroup } from '@/types/userGroup';
+import { isAlreadyDeletedError } from '@/utils/errors';
 
 interface UseUserGroupActionsProps {
   t: TFunction;
@@ -56,23 +57,33 @@ export function useUserGroupActions({
         itemsToDelete.map((item) => deleteUserGroup(item.groupId)),
       );
 
-      const failed = results.filter((r) => r.status === 'rejected');
-      if (failed.length > 0) {
-        const firstRejected = failed[0] as PromiseRejectedResult;
+      const trueFailed = results.filter(
+        (r) => r.status === 'rejected' && !isAlreadyDeletedError(r.reason),
+      );
+      const deletedCount = itemsToDelete.length - trueFailed.length;
+
+      if (trueFailed.length > 0) {
+        const firstRejected = trueFailed[0] as PromiseRejectedResult;
         const reason = firstRejected.reason;
-        const message =
+        const specificMessage =
           isAxiosError(reason) && reason.response?.data?.message
             ? reason.response.data.message
-            : t('{{count}} item(s) could not be deleted.', { count: failed.length });
-        setDeleteError(message);
+            : undefined;
+        const failurePart =
+          specificMessage ??
+          t('{{count}} user group(s) could not be deleted.', { count: trueFailed.length });
+        const successPart =
+          deletedCount > 0
+            ? t('{{count}} user group(s) deleted successfully.', { count: deletedCount })
+            : '';
+
+        setDeleteError([successPart, failurePart].filter(Boolean).join(' '));
         setRowSelection({});
         handleRefresh();
         return;
       }
 
-      notify.success(
-        t('{{count}} user group(s) deleted successfully.', { count: itemsToDelete.length }),
-      );
+      notify.success(t('{{count}} user group(s) deleted successfully.', { count: deletedCount }));
       setRowSelection({});
       handleRefresh();
       closeModal();

--- a/frontend/src/pages/Design/Campaigns/hooks/useCampaignActions.ts
+++ b/frontend/src/pages/Design/Campaigns/hooks/useCampaignActions.ts
@@ -30,6 +30,7 @@ import { notify } from '@/components/ui/Notification';
 import { copyCampaign, deleteCampaign } from '@/services/campaignApi';
 import { selectFolder, type ApiResult } from '@/services/folderApi';
 import type { Campaign } from '@/types/campaign';
+import { isAlreadyDeletedError } from '@/utils/errors';
 
 interface UseCampaignActionsProps {
   t: TFunction;
@@ -61,20 +62,30 @@ export function useCampaignActions({
         itemsToDelete.map((item) => deleteCampaign(item.campaignId)),
       );
 
-      const failed = results.filter((r) => r.status === 'rejected');
+      const trueFailed = results.filter(
+        (r) => r.status === 'rejected' && !isAlreadyDeletedError(r.reason),
+      );
+      const deletedCount = itemsToDelete.length - trueFailed.length;
 
-      if (failed.length > 0) {
-        const firstRejected = failed[0] as PromiseRejectedResult;
+      if (trueFailed.length > 0) {
+        const firstRejected = trueFailed[0] as PromiseRejectedResult;
         const reason = firstRejected.reason;
 
-        const message =
+        const specificMessage =
           isAxiosError(reason) && reason.response?.data?.message
             ? reason.response.data.message
-            : t('{{count}} campaign(s) could not be deleted.', {
-                count: failed.length,
-              });
+            : undefined;
+        const failurePart =
+          specificMessage ??
+          t('{{count}} campaign(s) could not be deleted.', {
+            count: trueFailed.length,
+          });
+        const successPart =
+          deletedCount > 0
+            ? t('{{count}} campaign(s) deleted successfully.', { count: deletedCount })
+            : '';
 
-        setDeleteError(message);
+        setDeleteError([successPart, failurePart].filter(Boolean).join(' '));
 
         setRowSelection({});
         handleRefresh();
@@ -82,8 +93,8 @@ export function useCampaignActions({
       }
 
       notify.success(
-        t('{{count}} campaign(s) deleted successfully', {
-          count: itemsToDelete.length,
+        t('{{count}} campaign(s) deleted successfully.', {
+          count: deletedCount,
         }),
       );
 

--- a/frontend/src/pages/Design/Layouts/__tests__/Layouts.delete.test.tsx
+++ b/frontend/src/pages/Design/Layouts/__tests__/Layouts.delete.test.tsx
@@ -137,6 +137,6 @@ describe('Delete Layout', () => {
     await waitFor(() => {
       expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
-    expect(screen.getByText('1 item(s) could not be deleted.')).toBeInTheDocument();
+    expect(screen.getByText('1 layout(s) could not be deleted.')).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/Design/Layouts/hooks/useLayoutActions.ts
+++ b/frontend/src/pages/Design/Layouts/hooks/useLayoutActions.ts
@@ -41,6 +41,7 @@ import {
 } from '@/services/layoutsApi';
 import type { Layout } from '@/types/layout';
 import { formatDateTime } from '@/utils/date';
+import { isAlreadyDeletedError } from '@/utils/errors';
 
 interface UsePlaylistActionsProps {
   t: TFunction;
@@ -84,23 +85,33 @@ export function useLayoutActions({
         itemsToDelete.map((item) => deleteLayout(item.layoutId)),
       );
 
-      const failed = results.filter((r) => r.status === 'rejected');
-      if (failed.length > 0) {
-        const firstRejected = failed[0] as PromiseRejectedResult;
+      const trueFailed = results.filter(
+        (r) => r.status === 'rejected' && !isAlreadyDeletedError(r.reason),
+      );
+      const deletedCount = itemsToDelete.length - trueFailed.length;
+
+      if (trueFailed.length > 0) {
+        const firstRejected = trueFailed[0] as PromiseRejectedResult;
         const reason = firstRejected.reason;
-        const message =
+        const specificMessage =
           isAxiosError(reason) && reason.response?.data?.message
             ? reason.response.data.message
-            : t('{{count}} item(s) could not be deleted.', { count: failed.length });
-        setDeleteError(message);
+            : undefined;
+        const failurePart =
+          specificMessage ??
+          t('{{count}} layout(s) could not be deleted.', { count: trueFailed.length });
+        const successPart =
+          deletedCount > 0
+            ? t('{{count}} layout(s) deleted successfully.', { count: deletedCount })
+            : '';
+
+        setDeleteError([successPart, failurePart].filter(Boolean).join(' '));
         setRowSelection({});
         handleRefresh();
         return;
       }
 
-      notify.success(
-        t('{{count}} layout(s) deleted successfully.', { count: itemsToDelete.length }),
-      );
+      notify.success(t('{{count}} layout(s) deleted successfully.', { count: deletedCount }));
       setRowSelection({});
       handleRefresh();
       closeModal();

--- a/frontend/src/pages/Design/Resolutions/hooks/useResolutionActions.ts
+++ b/frontend/src/pages/Design/Resolutions/hooks/useResolutionActions.ts
@@ -28,6 +28,7 @@ import { useState } from 'react';
 import { notify } from '@/components/ui/Notification';
 import { deleteResolution } from '@/services/resolutionApi';
 import type { Resolution } from '@/types/resolution';
+import { isAlreadyDeletedError } from '@/utils/errors';
 
 interface UseResolutionActionsProps {
   t: TFunction;
@@ -56,23 +57,33 @@ export function useResolutionActions({
         itemsToDelete.map((item) => deleteResolution(item.resolutionId)),
       );
 
-      const failed = results.filter((r) => r.status === 'rejected');
-      if (failed.length > 0) {
-        const firstRejected = failed[0] as PromiseRejectedResult;
+      const trueFailed = results.filter(
+        (r) => r.status === 'rejected' && !isAlreadyDeletedError(r.reason),
+      );
+      const deletedCount = itemsToDelete.length - trueFailed.length;
+
+      if (trueFailed.length > 0) {
+        const firstRejected = trueFailed[0] as PromiseRejectedResult;
         const reason = firstRejected.reason;
-        const message =
+        const specificMessage =
           isAxiosError(reason) && reason.response?.data?.message
             ? reason.response.data.message
-            : t('{{count}} item(s) could not be deleted.', { count: failed.length });
-        setDeleteError(message);
+            : undefined;
+        const failurePart =
+          specificMessage ??
+          t('{{count}} resolution(s) could not be deleted.', { count: trueFailed.length });
+        const successPart =
+          deletedCount > 0
+            ? t('{{count}} resolution(s) deleted successfully.', { count: deletedCount })
+            : '';
+
+        setDeleteError([successPart, failurePart].filter(Boolean).join(' '));
         setRowSelection({});
         handleRefresh();
         return;
       }
 
-      notify.success(
-        t('{{count}} resolution(s) deleted successfully.', { count: itemsToDelete.length }),
-      );
+      notify.success(t('{{count}} resolution(s) deleted successfully.', { count: deletedCount }));
       setRowSelection({});
       handleRefresh();
       closeModal();

--- a/frontend/src/pages/Design/Templates/hooks/useTemplateActions.ts
+++ b/frontend/src/pages/Design/Templates/hooks/useTemplateActions.ts
@@ -38,6 +38,7 @@ import {
 } from '@/services/layoutsApi';
 import type { Template } from '@/types/templates';
 import { formatDateTime } from '@/utils/date';
+import { isAlreadyDeletedError } from '@/utils/errors';
 
 interface UseTemplateActionsProps {
   t: TFunction;
@@ -76,29 +77,37 @@ export function useTemplateActions({
         itemsToDelete.map((item) => deleteLayout(item.layoutId)),
       );
 
-      const failed = results.filter((r) => r.status === 'rejected');
+      const trueFailed = results.filter(
+        (r) => r.status === 'rejected' && !isAlreadyDeletedError(r.reason),
+      );
+      const deletedCount = itemsToDelete.length - trueFailed.length;
 
-      if (failed.length > 0) {
-        const firstRejected = failed[0] as PromiseRejectedResult;
+      if (trueFailed.length > 0) {
+        const firstRejected = trueFailed[0] as PromiseRejectedResult;
         const reason = firstRejected.reason;
 
-        const message =
+        const specificMessage =
           isAxiosError(reason) && reason.response?.data?.message
             ? reason.response.data.message
-            : t('{{count}} item(s) could not be deleted because they are in use.', {
-                count: failed.length,
-              });
+            : undefined;
+        const failurePart =
+          specificMessage ??
+          t('{{count}} item(s) could not be deleted because they are in use.', {
+            count: trueFailed.length,
+          });
+        const successPart =
+          deletedCount > 0
+            ? t('{{count}} template(s) deleted successfully.', { count: deletedCount })
+            : '';
 
-        setDeleteError(message);
+        setDeleteError([successPart, failurePart].filter(Boolean).join(' '));
 
         setRowSelection({});
         handleRefresh();
         return;
       }
 
-      notify.success(
-        t('{{count}} template(s) deleted successfully.', { count: itemsToDelete.length }),
-      );
+      notify.success(t('{{count}} template(s) deleted successfully.', { count: deletedCount }));
       setRowSelection({});
       handleRefresh();
       closeModal();

--- a/frontend/src/pages/Developer/ModuleTemplates/components/ModuleTemplateModals.tsx
+++ b/frontend/src/pages/Developer/ModuleTemplates/components/ModuleTemplateModals.tsx
@@ -41,6 +41,7 @@ import {
   fetchTemplatesByDataType,
 } from '@/services/moduleTemplatesApi';
 import type { ModuleTemplate } from '@/types/moduleTemplates';
+import { isAlreadyDeletedError } from '@/utils/errors';
 
 interface ModuleTemplateModalsProps {
   activeModal: ModalType;
@@ -275,28 +276,48 @@ function DeleteModal({
       const results = await Promise.allSettled(
         templates.map((template) => deleteModuleTemplate(template.id)),
       );
-      const failed = results.filter((r) => r.status === 'rejected');
-      if (failed.length > 0) {
+      const trueFailed = results.filter(
+        (r) => r.status === 'rejected' && !isAlreadyDeletedError(r.reason),
+      );
+      // A 404 means the template was already deleted (e.g. by another user/tab) — that
+      // counts as deleted here too, same as a fulfilled result.
+      const deletedIds = templates
+        .filter((_, i) => {
+          const r = results[i];
+          return (
+            r?.status === 'fulfilled' ||
+            (r?.status === 'rejected' && isAlreadyDeletedError(r.reason))
+          );
+        })
+        .map((template) => template.id);
+
+      if (trueFailed.length > 0) {
         // Deleted templates are already gone server-side even though the batch as a
         // whole "failed" — reflect that in the table/selection now, rather than only
         // on the next full onSuccess (which never fires until every item succeeds).
-        const deletedIds = templates
-          .filter((_, i) => results[i]?.status === 'fulfilled')
-          .map((template) => template.id);
         if (deletedIds.length > 0) {
           onPartialSuccess?.(deletedIds);
         }
 
-        const firstRejected = failed[0] as PromiseRejectedResult;
+        const firstRejected = trueFailed[0] as PromiseRejectedResult;
         const reason = firstRejected.reason;
-        setError(
+        const specificMessage =
           (isAxiosError(reason) && reason.response?.data?.message) ||
-            (reason instanceof Error && reason.message) ||
-            t('{{count}} template(s) could not be deleted.', { count: failed.length }),
-        );
+          (reason instanceof Error && reason.message);
+        const failurePart =
+          specificMessage ||
+          t('{{count}} template(s) could not be deleted.', { count: trueFailed.length });
+        const successPart =
+          deletedIds.length > 0
+            ? t('{{count}} template(s) deleted successfully.', { count: deletedIds.length })
+            : '';
+
+        setError([successPart, failurePart].filter(Boolean).join(' '));
         return;
       }
-      notify.success(t('{{count}} template(s) deleted successfully.', { count: templates.length }));
+      notify.success(
+        t('{{count}} template(s) deleted successfully.', { count: deletedIds.length }),
+      );
       onSuccess();
     } finally {
       setIsPending(false);

--- a/frontend/src/pages/Displays/Commands/__tests__/Commands.delete.test.tsx
+++ b/frontend/src/pages/Displays/Commands/__tests__/Commands.delete.test.tsx
@@ -239,7 +239,9 @@ describe('Commands page - bulk delete', () => {
     await user.click(screen.getByRole('button', { name: /yes, delete/i }));
 
     // Error surfaces and the modal stays open.
-    expect(await screen.findByText('Command 2 is in use.')).toBeInTheDocument();
+    expect(
+      await screen.findByText('1 command(s) deleted successfully. Command 2 is in use.'),
+    ).toBeInTheDocument();
     expect(screen.getByText('Delete Commands?')).toBeInTheDocument();
 
     // Both rows were attempted and the table was refreshed.

--- a/frontend/src/pages/Displays/Commands/hooks/useCommandActions.ts
+++ b/frontend/src/pages/Displays/Commands/hooks/useCommandActions.ts
@@ -28,6 +28,7 @@ import { useState } from 'react';
 import { notify } from '@/components/ui/Notification';
 import { deleteCommand } from '@/services/commandApi';
 import type { Command } from '@/types/command';
+import { isAlreadyDeletedError } from '@/utils/errors';
 
 interface UseCommandActionsProps {
   t: TFunction;
@@ -56,23 +57,33 @@ export function useCommandActions({
         itemsToDelete.map((item) => deleteCommand(item.commandId)),
       );
 
-      const failed = results.filter((r) => r.status === 'rejected');
-      if (failed.length > 0) {
-        const firstRejected = failed[0] as PromiseRejectedResult;
+      const trueFailed = results.filter(
+        (r) => r.status === 'rejected' && !isAlreadyDeletedError(r.reason),
+      );
+      const deletedCount = itemsToDelete.length - trueFailed.length;
+
+      if (trueFailed.length > 0) {
+        const firstRejected = trueFailed[0] as PromiseRejectedResult;
         const reason = firstRejected.reason;
-        const message =
+        const specificMessage =
           isAxiosError(reason) && reason.response?.data?.message
             ? reason.response.data.message
-            : t('{{count}} item(s) could not be deleted.', { count: failed.length });
-        setDeleteError(message);
+            : undefined;
+        const failurePart =
+          specificMessage ??
+          t('{{count}} command(s) could not be deleted.', { count: trueFailed.length });
+        const successPart =
+          deletedCount > 0
+            ? t('{{count}} command(s) deleted successfully.', { count: deletedCount })
+            : '';
+
+        setDeleteError([successPart, failurePart].filter(Boolean).join(' '));
         setRowSelection({});
         handleRefresh();
         return;
       }
 
-      notify.success(
-        t('{{count}} command(s) deleted successfully.', { count: itemsToDelete.length }),
-      );
+      notify.success(t('{{count}} command(s) deleted successfully.', { count: deletedCount }));
       setRowSelection({});
       handleRefresh();
       closeModal();

--- a/frontend/src/pages/Displays/DisplayGroup/hooks/useDisplayGroupActions.ts
+++ b/frontend/src/pages/Displays/DisplayGroup/hooks/useDisplayGroupActions.ts
@@ -30,6 +30,7 @@ import { collectNow, copyDisplayGroup, deleteDisplayGroup } from '@/services/dis
 import { sendCommand, triggerWebhook } from '@/services/displaysApi';
 import { selectFolder, type ApiResult } from '@/services/folderApi';
 import type { DisplayGroup } from '@/types/displayGroup';
+import { isAlreadyDeletedError } from '@/utils/errors';
 
 export interface CopyDisplayGroupFormData {
   name: string;
@@ -99,21 +100,33 @@ export function useDisplayGroupActions({
         itemsToDelete.map((item) => deleteDisplayGroup(item.displayGroupId)),
       );
 
-      const failed = results.filter((r) => r.status === 'rejected');
-      if (failed.length > 0) {
-        const firstRejected = failed[0] as PromiseRejectedResult;
+      const trueFailed = results.filter(
+        (r) => r.status === 'rejected' && !isAlreadyDeletedError(r.reason),
+      );
+      const deletedCount = itemsToDelete.length - trueFailed.length;
+
+      if (trueFailed.length > 0) {
+        const firstRejected = trueFailed[0] as PromiseRejectedResult;
         const reason = firstRejected.reason;
-        const message =
+        const specificMessage =
           isAxiosError(reason) && reason.response?.data?.message
             ? reason.response.data.message
-            : t('{{count}} item(s) could not be deleted.', { count: failed.length });
-        setDeleteError(message);
+            : undefined;
+        const failurePart =
+          specificMessage ??
+          t('{{count}} item(s) could not be deleted.', { count: trueFailed.length });
+        const successPart =
+          deletedCount > 0
+            ? t('{{count}} item(s) deleted successfully.', { count: deletedCount })
+            : '';
+
+        setDeleteError([successPart, failurePart].filter(Boolean).join(' '));
         setRowSelection({});
         handleRefresh();
         return;
       }
 
-      notify.success(t('{{count}} item(s) deleted successfully.', { count: itemsToDelete.length }));
+      notify.success(t('{{count}} item(s) deleted successfully.', { count: deletedCount }));
       setRowSelection({});
       handleRefresh();
       closeModal();

--- a/frontend/src/pages/Displays/DisplayProfile/__tests__/DisplayProfile.delete.test.tsx
+++ b/frontend/src/pages/Displays/DisplayProfile/__tests__/DisplayProfile.delete.test.tsx
@@ -160,7 +160,7 @@ describe('DisplayProfile page - delete', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Yes, Delete' }));
 
     await waitFor(() => {
-      expect(screen.getByText('1 item(s) could not be deleted.')).toBeInTheDocument();
+      expect(screen.getByText('1 display profile(s) could not be deleted.')).toBeInTheDocument();
     });
     expect(screen.getByRole('dialog')).toBeInTheDocument();
   });
@@ -251,7 +251,11 @@ describe('DisplayProfile page - delete', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Yes, Delete' }));
 
     await waitFor(() => {
-      expect(screen.getByText('1 item(s) could not be deleted.')).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          '1 display profile(s) deleted successfully. 1 display profile(s) could not be deleted.',
+        ),
+      ).toBeInTheDocument();
     });
     expect(screen.getByRole('dialog')).toBeInTheDocument();
 

--- a/frontend/src/pages/Displays/DisplayProfile/hooks/useDisplayProfileActions.ts
+++ b/frontend/src/pages/Displays/DisplayProfile/hooks/useDisplayProfileActions.ts
@@ -28,6 +28,7 @@ import { useState } from 'react';
 import { notify } from '@/components/ui/Notification';
 import { copyDisplayProfile, deleteDisplayProfile } from '@/services/displayProfileApi';
 import type { DisplayProfile } from '@/types/displayProfile';
+import { isAlreadyDeletedError } from '@/utils/errors';
 
 interface UseDisplayProfileActionsProps {
   t: TFunction;
@@ -57,20 +58,27 @@ export function useDisplayProfileActions({
         itemsToDelete.map((item) => deleteDisplayProfile(item.displayProfileId)),
       );
 
-      // A 404 means the item was already deleted (e.g. by another user/tab) — that's the
-      // outcome we wanted anyway, so treat it as success rather than a hard failure.
-      const failed = results.filter(
-        (r) =>
-          r.status === 'rejected' && !(isAxiosError(r.reason) && r.reason.response?.status === 404),
+      const trueFailed = results.filter(
+        (r) => r.status === 'rejected' && !isAlreadyDeletedError(r.reason),
       );
-      if (failed.length > 0) {
-        const firstRejected = failed[0] as PromiseRejectedResult;
+      const deletedCount = itemsToDelete.length - trueFailed.length;
+
+      if (trueFailed.length > 0) {
+        const firstRejected = trueFailed[0] as PromiseRejectedResult;
         const reason = firstRejected.reason;
-        const message =
+        const specificMessage =
           isAxiosError(reason) && reason.response?.data?.message
             ? reason.response.data.message
-            : t('{{count}} item(s) could not be deleted.', { count: failed.length });
-        setDeleteError(message);
+            : undefined;
+        const failurePart =
+          specificMessage ??
+          t('{{count}} display profile(s) could not be deleted.', { count: trueFailed.length });
+        const successPart =
+          deletedCount > 0
+            ? t('{{count}} display profile(s) deleted successfully.', { count: deletedCount })
+            : '';
+
+        setDeleteError([successPart, failurePart].filter(Boolean).join(' '));
         setRowSelection({});
         handleRefresh();
         return;
@@ -78,7 +86,7 @@ export function useDisplayProfileActions({
 
       notify.success(
         t('{{count}} display profile(s) deleted successfully.', {
-          count: itemsToDelete.length,
+          count: deletedCount,
         }),
       );
       setRowSelection({});

--- a/frontend/src/pages/Displays/Displays/hooks/useDisplaysActions.ts
+++ b/frontend/src/pages/Displays/Displays/hooks/useDisplaysActions.ts
@@ -45,6 +45,7 @@ import {
 import type { MoveCmsData } from '@/services/displaysApi';
 import { selectFolder, type ApiResult } from '@/services/folderApi';
 import type { Display, DisplayCommandTarget } from '@/types/display';
+import { isAlreadyDeletedError } from '@/utils/errors';
 
 interface UseDisplaysActionsProps {
   t: TFunction;
@@ -82,23 +83,33 @@ export function useDisplaysActions({
         itemsToDelete.map((item) => deleteDisplay(item.displayId)),
       );
 
-      const failed = results.filter((r) => r.status === 'rejected');
-      if (failed.length > 0) {
-        const firstRejected = failed[0] as PromiseRejectedResult;
+      const trueFailed = results.filter(
+        (r) => r.status === 'rejected' && !isAlreadyDeletedError(r.reason),
+      );
+      const deletedCount = itemsToDelete.length - trueFailed.length;
+
+      if (trueFailed.length > 0) {
+        const firstRejected = trueFailed[0] as PromiseRejectedResult;
         const reason = firstRejected.reason;
-        const message =
+        const specificMessage =
           isAxiosError(reason) && reason.response?.data?.message
             ? reason.response.data.message
-            : t('{{count}} item(s) could not be deleted.', { count: failed.length });
-        setDeleteError(message);
+            : undefined;
+        const failurePart =
+          specificMessage ??
+          t('{{count}} display(s) could not be deleted.', { count: trueFailed.length });
+        const successPart =
+          deletedCount > 0
+            ? t('{{count}} display(s) deleted successfully.', { count: deletedCount })
+            : '';
+
+        setDeleteError([successPart, failurePart].filter(Boolean).join(' '));
         setRowSelection({});
         handleRefresh();
         return;
       }
 
-      notify.success(
-        t('{{count}} display(s) deleted successfully.', { count: itemsToDelete.length }),
-      );
+      notify.success(t('{{count}} display(s) deleted successfully.', { count: deletedCount }));
       setRowSelection({});
       handleRefresh();
       closeModal();

--- a/frontend/src/pages/Displays/PlayerVersions/__tests__/PlayerVersions.delete.test.tsx
+++ b/frontend/src/pages/Displays/PlayerVersions/__tests__/PlayerVersions.delete.test.tsx
@@ -275,7 +275,9 @@ describe('Player Versions page - bulk delete', () => {
     await user.click(screen.getByRole('button', { name: /yes, delete/i }));
 
     // Error surfaces and the modal stays open.
-    expect(await screen.findByText('Version 2 is in use.')).toBeInTheDocument();
+    expect(
+      await screen.findByText('1 player version(s) deleted successfully. Version 2 is in use.'),
+    ).toBeInTheDocument();
     expect(screen.getByText('Delete Player Versions?')).toBeInTheDocument();
 
     // Both rows were attempted and the table was refreshed.

--- a/frontend/src/pages/Displays/PlayerVersions/hooks/usePlayerVersionsActions.ts
+++ b/frontend/src/pages/Displays/PlayerVersions/hooks/usePlayerVersionsActions.ts
@@ -28,6 +28,7 @@ import { useState } from 'react';
 import { notify } from '@/components/ui/Notification';
 import { deletePlayerVersion } from '@/services/playerVersionApi';
 import type { PlayerVersion } from '@/types/playerVersion';
+import { isAlreadyDeletedError } from '@/utils/errors';
 
 interface UsePlayerVersionActionsProps {
   t: TFunction;
@@ -56,22 +57,34 @@ export function usePlayerVersionActions({
         itemsToDelete.map((item) => deletePlayerVersion(item.versionId)),
       );
 
-      const failed = results.filter((r) => r.status === 'rejected');
-      if (failed.length > 0) {
-        const firstRejected = failed[0] as PromiseRejectedResult;
+      const trueFailed = results.filter(
+        (r) => r.status === 'rejected' && !isAlreadyDeletedError(r.reason),
+      );
+      const deletedCount = itemsToDelete.length - trueFailed.length;
+
+      if (trueFailed.length > 0) {
+        const firstRejected = trueFailed[0] as PromiseRejectedResult;
         const reason = firstRejected.reason;
-        const message =
+        const specificMessage =
           isAxiosError(reason) && reason.response?.data?.message
             ? reason.response.data.message
-            : t('{{count}} item(s) could not be deleted.', { count: failed.length });
-        setDeleteError(message);
+            : undefined;
+        const failurePart =
+          specificMessage ??
+          t('{{count}} player version(s) could not be deleted.', { count: trueFailed.length });
+        const successPart =
+          deletedCount > 0
+            ? t('{{count}} player version(s) deleted successfully.', { count: deletedCount })
+            : '';
+
+        setDeleteError([successPart, failurePart].filter(Boolean).join(' '));
         setRowSelection({});
         handleRefresh();
         return;
       }
 
       notify.success(
-        t('{{count}} player version(s) deleted successfully.', { count: itemsToDelete.length }),
+        t('{{count}} player version(s) deleted successfully.', { count: deletedCount }),
       );
       setRowSelection({});
       handleRefresh();

--- a/frontend/src/pages/Displays/SyncGroups/__tests__/SyncGroups.delete.test.tsx
+++ b/frontend/src/pages/Displays/SyncGroups/__tests__/SyncGroups.delete.test.tsx
@@ -284,7 +284,9 @@ describe('Sync Groups page - bulk delete', () => {
     await user.click(screen.getByRole('button', { name: /yes, delete/i }));
 
     // Error surfaces in the modal and the modal stays open.
-    expect(await screen.findByText('Sync group 2 is in use.')).toBeInTheDocument();
+    expect(
+      await screen.findByText('1 sync group(s) deleted successfully. Sync group 2 is in use.'),
+    ).toBeInTheDocument();
     expect(screen.getByText('Delete Sync Groups?')).toBeInTheDocument();
 
     // Both rows were attempted and the table was refreshed (handleRefresh

--- a/frontend/src/pages/Displays/SyncGroups/hooks/useSyncGroupActions.ts
+++ b/frontend/src/pages/Displays/SyncGroups/hooks/useSyncGroupActions.ts
@@ -28,6 +28,7 @@ import { useState } from 'react';
 import { notify } from '@/components/ui/Notification';
 import { deleteSyncGroup } from '@/services/syncGroupApi';
 import type { SyncGroup } from '@/types/syncGroup';
+import { isAlreadyDeletedError } from '@/utils/errors';
 
 interface UseSyncGroupActionsProps {
   t: TFunction;
@@ -56,23 +57,33 @@ export function useSyncGroupActions({
         itemsToDelete.map((item) => deleteSyncGroup(item.syncGroupId)),
       );
 
-      const failed = results.filter((r) => r.status === 'rejected');
-      if (failed.length > 0) {
-        const firstRejected = failed[0] as PromiseRejectedResult;
+      const trueFailed = results.filter(
+        (r) => r.status === 'rejected' && !isAlreadyDeletedError(r.reason),
+      );
+      const deletedCount = itemsToDelete.length - trueFailed.length;
+
+      if (trueFailed.length > 0) {
+        const firstRejected = trueFailed[0] as PromiseRejectedResult;
         const reason = firstRejected.reason;
-        const message =
+        const specificMessage =
           isAxiosError(reason) && reason.response?.data?.message
             ? reason.response.data.message
-            : t('{{count}} item(s) could not be deleted.', { count: failed.length });
-        setDeleteError(message);
+            : undefined;
+        const failurePart =
+          specificMessage ??
+          t('{{count}} sync group(s) could not be deleted.', { count: trueFailed.length });
+        const successPart =
+          deletedCount > 0
+            ? t('{{count}} sync group(s) deleted successfully.', { count: deletedCount })
+            : '';
+
+        setDeleteError([successPart, failurePart].filter(Boolean).join(' '));
         setRowSelection({});
         handleRefresh();
         return;
       }
 
-      notify.success(
-        t('{{count}} sync group(s) deleted successfully.', { count: itemsToDelete.length }),
-      );
+      notify.success(t('{{count}} sync group(s) deleted successfully.', { count: deletedCount }));
       setRowSelection({});
       handleRefresh();
       closeModal();

--- a/frontend/src/pages/Library/Dataset/__tests__/useDatasetActions.test.tsx
+++ b/frontend/src/pages/Library/Dataset/__tests__/useDatasetActions.test.tsx
@@ -107,7 +107,9 @@ describe('useDatasetActions', () => {
         );
       });
 
-      expect(result.current.deleteError).toBe('{{count}} item(s) could not be deleted.');
+      expect(result.current.deleteError).toBe(
+        '{{count}} dataset(s) deleted successfully. {{count}} dataset(s) could not be deleted.',
+      );
       expect(mockHandleRefresh).toHaveBeenCalled();
       expect(mockCloseModal).not.toHaveBeenCalled();
     });

--- a/frontend/src/pages/Library/Dataset/hooks/useDatasetActions.ts
+++ b/frontend/src/pages/Library/Dataset/hooks/useDatasetActions.ts
@@ -29,6 +29,7 @@ import { notify } from '@/components/ui/Notification';
 import { clearDatasetCache, cloneDataset, deleteDataset } from '@/services/datasetApi';
 import { selectFolder, type ApiResult } from '@/services/folderApi';
 import type { Dataset } from '@/types/dataset';
+import { isAlreadyDeletedError } from '@/utils/errors';
 
 interface UseDatasetActionsProps {
   t: TFunction;
@@ -88,24 +89,33 @@ export function useDatasetActions({
         ),
       );
 
-      const failed = results.filter((r) => r.status === 'rejected');
+      const trueFailed = results.filter(
+        (r) => r.status === 'rejected' && !isAlreadyDeletedError(r.reason),
+      );
+      const deletedCount = itemsToDelete.length - trueFailed.length;
 
-      if (failed.length > 0) {
-        const firstRejected = failed[0] as PromiseRejectedResult;
+      if (trueFailed.length > 0) {
+        const firstRejected = trueFailed[0] as PromiseRejectedResult;
         const reason = firstRejected.reason;
-        const message =
+        const specificMessage =
           isAxiosError(reason) && reason.response?.data?.message
             ? reason.response.data.message
-            : t('{{count}} item(s) could not be deleted.', { count: failed.length });
-        setDeleteError(message);
+            : undefined;
+        const failurePart =
+          specificMessage ??
+          t('{{count}} dataset(s) could not be deleted.', { count: trueFailed.length });
+        const successPart =
+          deletedCount > 0
+            ? t('{{count}} dataset(s) deleted successfully.', { count: deletedCount })
+            : '';
+
+        setDeleteError([successPart, failurePart].filter(Boolean).join(' '));
         setRowSelection({});
         handleRefresh();
         return;
       }
 
-      notify.success(
-        t('{{count}} dataset(s) deleted successfully.', { count: itemsToDelete.length }),
-      );
+      notify.success(t('{{count}} dataset(s) deleted successfully.', { count: deletedCount }));
       setRowSelection({});
       handleRefresh();
       closeModal();

--- a/frontend/src/pages/Library/Dataset/subPages/Columns/DatasetColumns.tsx
+++ b/frontend/src/pages/Library/Dataset/subPages/Columns/DatasetColumns.tsx
@@ -40,6 +40,7 @@ import { useFilteredTabs } from '@/hooks/useFilteredTabs';
 import { useTableState } from '@/hooks/useTableState';
 import { createDatasetColumn, deleteDatasetColumn, getDatasetById } from '@/services/datasetApi';
 import type { DatasetColumn } from '@/types/datasetColumn';
+import { isAlreadyDeletedError } from '@/utils/errors';
 import { hasFeature } from '@/utils/permissions';
 
 type ColumnModalType = 'edit' | 'delete' | 'copy' | null;
@@ -171,15 +172,44 @@ export default function DatasetColumns() {
 
   const deleteMutation = useMutation({
     mutationFn: async (items: DatasetColumn[]) => {
-      for (const item of items) {
-        await deleteDatasetColumn(datasetId!, item.dataSetColumnId);
-      }
-      return items;
+      const results = await Promise.allSettled(
+        items.map((item) => deleteDatasetColumn(datasetId!, item.dataSetColumnId)),
+      );
+      return { items, results };
     },
-    onSuccess: (deletedItems) => {
+    onSuccess: ({ items, results }) => {
+      const deletedItems = items.filter((_, i) => {
+        const r = results[i];
+        if (!r) return false;
+        return r.status === 'fulfilled' || isAlreadyDeletedError(r.reason);
+      });
+      const trueFailed = results.filter(
+        (r) => r.status === 'rejected' && !isAlreadyDeletedError(r.reason),
+      );
+
       const newSelection = { ...rowSelection };
       deletedItems.forEach((item) => delete newSelection[item.dataSetColumnId.toString()]);
       setRowSelection(newSelection);
+
+      if (trueFailed.length > 0) {
+        const firstRejected = trueFailed[0] as PromiseRejectedResult;
+        const reason = firstRejected.reason;
+        const specificMessage =
+          isAxiosError(reason) && reason.response?.data?.message
+            ? reason.response.data.message
+            : undefined;
+        const failurePart =
+          specificMessage ??
+          t('{{count}} column(s) could not be deleted.', { count: trueFailed.length });
+        const successPart =
+          deletedItems.length > 0
+            ? t('{{count}} column(s) deleted successfully.', { count: deletedItems.length })
+            : '';
+
+        setDeleteError([successPart, failurePart].filter(Boolean).join(' '));
+        handleRefresh();
+        return;
+      }
 
       closeModal();
       handleRefresh();

--- a/frontend/src/pages/Library/Dataset/subPages/Data/DatasetData.tsx
+++ b/frontend/src/pages/Library/Dataset/subPages/Data/DatasetData.tsx
@@ -49,6 +49,7 @@ import {
   getDatasetById,
   type DynamicRowData,
 } from '@/services/datasetApi';
+import { isAlreadyDeletedError } from '@/utils/errors';
 import { countActiveFilters } from '@/utils/filters';
 import { hasFeature } from '@/utils/permissions';
 
@@ -218,19 +219,48 @@ export default function DatasetData() {
 
   const deleteMutation = useMutation({
     mutationFn: async (items: DynamicRowData[]) => {
-      for (const item of items) {
-        const rowId = getRowId(item);
-        if (rowId) await deleteDatasetRow(datasetId!, rowId);
-      }
-      return items;
+      const deletable = items.filter((item) => !!getRowId(item));
+      const results = await Promise.allSettled(
+        deletable.map((item) => deleteDatasetRow(datasetId!, getRowId(item))),
+      );
+      return { items: deletable, results };
     },
-    onSuccess: (deletedItems) => {
+    onSuccess: ({ items, results }) => {
+      const deletedItems = items.filter((_, i) => {
+        const r = results[i];
+        if (!r) return false;
+        return r.status === 'fulfilled' || isAlreadyDeletedError(r.reason);
+      });
+      const trueFailed = results.filter(
+        (r) => r.status === 'rejected' && !isAlreadyDeletedError(r.reason),
+      );
+
       const newSelection = { ...rowSelection };
       deletedItems.forEach((item) => {
         const rowId = getRowId(item);
         if (rowId) delete newSelection[rowId];
       });
       setRowSelection(newSelection);
+
+      if (trueFailed.length > 0) {
+        const firstRejected = trueFailed[0] as PromiseRejectedResult;
+        const reason = firstRejected.reason;
+        const specificMessage =
+          isAxiosError(reason) && reason.response?.data?.message
+            ? reason.response.data.message
+            : undefined;
+        const failurePart =
+          specificMessage ??
+          t('{{count}} row(s) could not be deleted.', { count: trueFailed.length });
+        const successPart =
+          deletedItems.length > 0
+            ? t('{{count}} row(s) deleted successfully.', { count: deletedItems.length })
+            : '';
+
+        setDeleteError([successPart, failurePart].filter(Boolean).join(' '));
+        handleRefresh();
+        return;
+      }
 
       closeModal();
       handleRefresh();

--- a/frontend/src/pages/Library/Dataset/subPages/Rss/DatasetRss.tsx
+++ b/frontend/src/pages/Library/Dataset/subPages/Rss/DatasetRss.tsx
@@ -39,6 +39,7 @@ import { useFilteredTabs } from '@/hooks/useFilteredTabs';
 import { useTableState } from '@/hooks/useTableState';
 import { createDatasetRss, deleteDatasetRss, getDatasetById } from '@/services/datasetApi';
 import type { DatasetRss } from '@/types/datasetRss';
+import { isAlreadyDeletedError } from '@/utils/errors';
 
 type RssModalType = 'edit' | 'delete' | 'copy' | null;
 
@@ -161,15 +162,44 @@ export default function DatasetRss() {
 
   const deleteMutation = useMutation({
     mutationFn: async (items: DatasetRss[]) => {
-      for (const item of items) {
-        await deleteDatasetRss(datasetId!, item.id);
-      }
-      return items;
+      const results = await Promise.allSettled(
+        items.map((item) => deleteDatasetRss(datasetId!, item.id)),
+      );
+      return { items, results };
     },
-    onSuccess: (deletedItems) => {
+    onSuccess: ({ items, results }) => {
+      const deletedItems = items.filter((_, i) => {
+        const r = results[i];
+        if (!r) return false;
+        return r.status === 'fulfilled' || isAlreadyDeletedError(r.reason);
+      });
+      const trueFailed = results.filter(
+        (r) => r.status === 'rejected' && !isAlreadyDeletedError(r.reason),
+      );
+
       const newSelection = { ...rowSelection };
       deletedItems.forEach((item) => delete newSelection[item.id.toString()]);
       setRowSelection(newSelection);
+
+      if (trueFailed.length > 0) {
+        const firstRejected = trueFailed[0] as PromiseRejectedResult;
+        const reason = firstRejected.reason;
+        const specificMessage =
+          isAxiosError(reason) && reason.response?.data?.message
+            ? reason.response.data.message
+            : undefined;
+        const failurePart =
+          specificMessage ??
+          t('{{count}} RSS feed(s) could not be deleted.', { count: trueFailed.length });
+        const successPart =
+          deletedItems.length > 0
+            ? t('{{count}} RSS feed(s) deleted successfully.', { count: deletedItems.length })
+            : '';
+
+        setDeleteError([successPart, failurePart].filter(Boolean).join(' '));
+        handleRefresh();
+        return;
+      }
 
       closeModal();
       handleRefresh();

--- a/frontend/src/pages/Library/Media/hooks/useMediaActions.ts
+++ b/frontend/src/pages/Library/Media/hooks/useMediaActions.ts
@@ -30,6 +30,7 @@ import { selectFolder, type ApiResult } from '@/services/folderApi';
 import { cloneMedia, deleteMedia, tidyLibrary, updateMedia } from '@/services/mediaApi';
 import type { Media } from '@/types/media';
 import type { Tag } from '@/types/tag';
+import { isAlreadyDeletedError } from '@/utils/errors';
 
 interface UseMediaActionsProps {
   t: TFunction;
@@ -75,25 +76,37 @@ export function useMediaActions({
         ),
       );
 
-      const stillFailed = itemsToDelete.filter((_, index) => results[index]?.status === 'rejected');
+      const stillFailed = itemsToDelete.filter((_, index) => {
+        const result = results[index];
+        return result?.status === 'rejected' && !isAlreadyDeletedError(result.reason);
+      });
+      const deletedCount = itemsToDelete.length - stillFailed.length;
 
       if (stillFailed.length > 0) {
-        const firstRejected = results.find((r) => r.status === 'rejected') as PromiseRejectedResult;
+        const firstRejected = results.find(
+          (r) => r.status === 'rejected' && !isAlreadyDeletedError(r.reason),
+        ) as PromiseRejectedResult;
         const reason = firstRejected.reason;
-        const message =
+        const specificMessage =
           isAxiosError(reason) && reason.response?.data?.message
             ? reason.response.data.message
-            : t('{{count}} item(s) could not be deleted.', { count: stillFailed.length });
-        setDeleteError(message);
+            : undefined;
+        const failurePart =
+          specificMessage ??
+          t('{{count}} item(s) could not be deleted.', { count: stillFailed.length });
+        const successPart =
+          deletedCount > 0
+            ? t('{{count}} media item(s) deleted successfully.', { count: deletedCount })
+            : '';
+
+        setDeleteError([successPart, failurePart].filter(Boolean).join(' '));
         setItemsToDelete(stillFailed);
         setRowSelection({});
         handleRefresh();
         return;
       }
 
-      notify.success(
-        t('{{count}} media item(s) deleted successfully.', { count: itemsToDelete.length }),
-      );
+      notify.success(t('{{count}} media item(s) deleted successfully.', { count: deletedCount }));
       setRowSelection({});
       handleRefresh();
       closeModal();

--- a/frontend/src/pages/Library/MenuBoard/hooks/useMenuBoardActions.ts
+++ b/frontend/src/pages/Library/MenuBoard/hooks/useMenuBoardActions.ts
@@ -29,6 +29,7 @@ import { notify } from '@/components/ui/Notification';
 import { selectFolder, type ApiResult } from '@/services/folderApi';
 import { copyMenuBoard, deleteMenuBoard } from '@/services/menuBoardApi';
 import type { MenuBoard } from '@/types/menuBoard';
+import { isAlreadyDeletedError } from '@/utils/errors';
 
 interface UseMenuBoardActionsProps {
   t: TFunction;
@@ -60,24 +61,33 @@ export function useMenuBoardActions({
         itemsToDelete.map((item) => deleteMenuBoard(item.menuId)),
       );
 
-      const failed = results.filter((r) => r.status === 'rejected');
+      const trueFailed = results.filter(
+        (r) => r.status === 'rejected' && !isAlreadyDeletedError(r.reason),
+      );
+      const deletedCount = itemsToDelete.length - trueFailed.length;
 
-      if (failed.length > 0) {
-        const firstRejected = failed[0] as PromiseRejectedResult;
+      if (trueFailed.length > 0) {
+        const firstRejected = trueFailed[0] as PromiseRejectedResult;
         const reason = firstRejected.reason;
-        const message =
+        const specificMessage =
           isAxiosError(reason) && reason.response?.data?.message
             ? reason.response.data.message
-            : t('{{count}} item(s) could not be deleted.', { count: failed.length });
-        setDeleteError(message);
+            : undefined;
+        const failurePart =
+          specificMessage ??
+          t('{{count}} menu board(s) could not be deleted.', { count: trueFailed.length });
+        const successPart =
+          deletedCount > 0
+            ? t('{{count}} menu board(s) deleted successfully.', { count: deletedCount })
+            : '';
+
+        setDeleteError([successPart, failurePart].filter(Boolean).join(' '));
         setRowSelection({});
         handleRefresh();
         return;
       }
 
-      notify.success(
-        t('{{count}} menu board(s) deleted successfully.', { count: itemsToDelete.length }),
-      );
+      notify.success(t('{{count}} menu board(s) deleted successfully.', { count: deletedCount }));
       setRowSelection({});
       handleRefresh();
       closeModal();

--- a/frontend/src/pages/Library/MenuBoard/subPages/Categories/MenuBoardCategories.tsx
+++ b/frontend/src/pages/Library/MenuBoard/subPages/Categories/MenuBoardCategories.tsx
@@ -56,6 +56,7 @@ import {
   deleteMenuBoardCategory,
 } from '@/services/menuBoardApi';
 import type { MenuBoardCategory } from '@/types/menuBoardCategory';
+import { isAlreadyDeletedError } from '@/utils/errors';
 import { countActiveFilters } from '@/utils/filters';
 
 type CategoryModalType = 'edit' | 'copy' | 'delete' | null;
@@ -188,16 +189,27 @@ export default function MenuBoardCategories() {
         itemsToDelete.map((item) => deleteMenuBoardCategory(item.menuCategoryId)),
       );
 
-      const failed = results.filter((r) => r.status === 'rejected');
+      const trueFailed = results.filter(
+        (r) => r.status === 'rejected' && !isAlreadyDeletedError(r.reason),
+      );
+      const deletedCount = itemsToDelete.length - trueFailed.length;
 
-      if (failed.length > 0) {
-        const firstRejected = failed[0] as PromiseRejectedResult;
+      if (trueFailed.length > 0) {
+        const firstRejected = trueFailed[0] as PromiseRejectedResult;
         const reason = firstRejected.reason;
-        const message =
+        const specificMessage =
           isAxiosError(reason) && reason.response?.data?.message
             ? reason.response.data.message
-            : t('{{count}} item(s) could not be deleted.', { count: failed.length });
-        setDeleteError(message);
+            : undefined;
+        const failurePart =
+          specificMessage ??
+          t('{{count}} item(s) could not be deleted.', { count: trueFailed.length });
+        const successPart =
+          deletedCount > 0
+            ? t('{{count}} item(s) deleted successfully.', { count: deletedCount })
+            : '';
+
+        setDeleteError([successPart, failurePart].filter(Boolean).join(' '));
         setRowSelection({});
         handleRefresh();
         return;
@@ -205,7 +217,7 @@ export default function MenuBoardCategories() {
 
       notify.success(
         t('{{count}} item(s) deleted successfully.', {
-          count: itemsToDelete.length,
+          count: deletedCount,
         }),
       );
       setRowSelection({});

--- a/frontend/src/pages/Library/MenuBoard/subPages/Products/MenuBoardProducts.tsx
+++ b/frontend/src/pages/Library/MenuBoard/subPages/Products/MenuBoardProducts.tsx
@@ -58,6 +58,7 @@ import {
   getMenuBoardById,
 } from '@/services/menuBoardApi';
 import type { MenuBoardProduct } from '@/types/menuBoardProduct';
+import { isAlreadyDeletedError } from '@/utils/errors';
 import { countActiveFilters } from '@/utils/filters';
 
 type ProductModalType = 'edit' | 'copy' | 'delete' | null;
@@ -190,24 +191,33 @@ export default function MenuBoardProducts() {
         itemsToDelete.map((item) => deleteMenuBoardProduct(item.menuProductId)),
       );
 
-      const failed = results.filter((r) => r.status === 'rejected');
+      const trueFailed = results.filter(
+        (r) => r.status === 'rejected' && !isAlreadyDeletedError(r.reason),
+      );
+      const deletedCount = itemsToDelete.length - trueFailed.length;
 
-      if (failed.length > 0) {
-        const firstRejected = failed[0] as PromiseRejectedResult;
+      if (trueFailed.length > 0) {
+        const firstRejected = trueFailed[0] as PromiseRejectedResult;
         const reason = firstRejected.reason;
-        const message =
+        const specificMessage =
           isAxiosError(reason) && reason.response?.data?.message
             ? reason.response.data.message
-            : t('{{count}} item(s) could not be deleted.', { count: failed.length });
-        setDeleteError(message);
+            : undefined;
+        const failurePart =
+          specificMessage ??
+          t('{{count}} product(s) could not be deleted.', { count: trueFailed.length });
+        const successPart =
+          deletedCount > 0
+            ? t('{{count}} product(s) deleted successfully.', { count: deletedCount })
+            : '';
+
+        setDeleteError([successPart, failurePart].filter(Boolean).join(' '));
         setRowSelection({});
         handleRefresh();
         return;
       }
 
-      notify.success(
-        t('{{count}} product(s) deleted successfully.', { count: itemsToDelete.length }),
-      );
+      notify.success(t('{{count}} product(s) deleted successfully.', { count: deletedCount }));
       setRowSelection({});
       handleRefresh();
       closeModal();

--- a/frontend/src/pages/Library/Playlists/__tests__/Playlists.delete.test.tsx
+++ b/frontend/src/pages/Library/Playlists/__tests__/Playlists.delete.test.tsx
@@ -138,6 +138,6 @@ describe('Delete Playlist', () => {
     await waitFor(() => {
       expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
-    expect(screen.getByText('1 item(s) could not be deleted.')).toBeInTheDocument();
+    expect(screen.getByText('1 playlist(s) could not be deleted.')).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/Library/Playlists/hooks/usePlaylistActions.ts
+++ b/frontend/src/pages/Library/Playlists/hooks/usePlaylistActions.ts
@@ -29,6 +29,7 @@ import { notify } from '@/components/ui/Notification';
 import { selectFolder, type ApiResult } from '@/services/folderApi';
 import { clonePlaylist, deletePlaylist, updatePlaylist } from '@/services/playlistApi';
 import type { Playlist } from '@/types/playlist';
+import { isAlreadyDeletedError } from '@/utils/errors';
 
 interface UsePlaylistActionsProps {
   t: TFunction;
@@ -61,23 +62,33 @@ export function usePlaylistActions({
         itemsToDelete.map((item) => deletePlaylist(item.playlistId)),
       );
 
-      const failed = results.filter((r) => r.status === 'rejected');
-      if (failed.length > 0) {
-        const firstRejected = failed[0] as PromiseRejectedResult;
+      const trueFailed = results.filter(
+        (r) => r.status === 'rejected' && !isAlreadyDeletedError(r.reason),
+      );
+      const deletedCount = itemsToDelete.length - trueFailed.length;
+
+      if (trueFailed.length > 0) {
+        const firstRejected = trueFailed[0] as PromiseRejectedResult;
         const reason = firstRejected.reason;
-        const message =
+        const specificMessage =
           isAxiosError(reason) && reason.response?.data?.message
             ? reason.response.data.message
-            : t('{{count}} item(s) could not be deleted.', { count: failed.length });
-        setDeleteError(message);
+            : undefined;
+        const failurePart =
+          specificMessage ??
+          t('{{count}} playlist(s) could not be deleted.', { count: trueFailed.length });
+        const successPart =
+          deletedCount > 0
+            ? t('{{count}} playlist(s) deleted successfully.', { count: deletedCount })
+            : '';
+
+        setDeleteError([successPart, failurePart].filter(Boolean).join(' '));
         setRowSelection({});
         handleRefresh();
         return;
       }
 
-      notify.success(
-        t('{{count}} playlist(s) deleted successfully.', { count: itemsToDelete.length }),
-      );
+      notify.success(t('{{count}} playlist(s) deleted successfully.', { count: deletedCount }));
       setRowSelection({});
       handleRefresh();
       closeModal();

--- a/frontend/src/pages/Notification/hooks/useNotificationActions.ts
+++ b/frontend/src/pages/Notification/hooks/useNotificationActions.ts
@@ -28,6 +28,7 @@ import { useState } from 'react';
 import { notify } from '@/components/ui/Notification';
 import { deleteNotification } from '@/services/notificationApi';
 import type { Notification } from '@/types/notification';
+import { isAlreadyDeletedError } from '@/utils/errors';
 
 interface UseNotificationActionsProps {
   t: TFunction;
@@ -56,23 +57,33 @@ export function useNotificationActions({
         itemsToDelete.map((item) => deleteNotification(item.notificationId!)),
       );
 
-      const failed = results.filter((r) => r.status === 'rejected');
-      if (failed.length > 0) {
-        const firstRejected = failed[0] as PromiseRejectedResult;
+      const trueFailed = results.filter(
+        (r) => r.status === 'rejected' && !isAlreadyDeletedError(r.reason),
+      );
+      const deletedCount = itemsToDelete.length - trueFailed.length;
+
+      if (trueFailed.length > 0) {
+        const firstRejected = trueFailed[0] as PromiseRejectedResult;
         const reason = firstRejected.reason;
-        const message =
+        const specificMessage =
           isAxiosError(reason) && reason.response?.data?.message
             ? reason.response.data.message
-            : t('{{count}} item(s) could not be deleted.', { count: failed.length });
-        setDeleteError(message);
+            : undefined;
+        const failurePart =
+          specificMessage ??
+          t('{{count}} notification(s) could not be deleted.', { count: trueFailed.length });
+        const successPart =
+          deletedCount > 0
+            ? t('{{count}} notification(s) deleted successfully.', { count: deletedCount })
+            : '';
+
+        setDeleteError([successPart, failurePart].filter(Boolean).join(' '));
         setRowSelection({});
         handleRefresh();
         return;
       }
 
-      notify.success(
-        t('{{count}} notification(s) deleted successfully.', { count: itemsToDelete.length }),
-      );
+      notify.success(t('{{count}} notification(s) deleted successfully.', { count: deletedCount }));
       setRowSelection({});
       handleRefresh();
       closeModal();

--- a/frontend/src/pages/Reporting/ReportSchedules/hooks/useReportScheduleActions.ts
+++ b/frontend/src/pages/Reporting/ReportSchedules/hooks/useReportScheduleActions.ts
@@ -32,6 +32,7 @@ import {
   resetReportSchedule,
 } from '@/services/reportScheduleApi';
 import type { ReportSchedule } from '@/types/reportSchedule';
+import { isAlreadyDeletedError } from '@/utils/errors';
 
 interface UseReportScheduleActionsProps {
   t: TFunction;
@@ -66,22 +67,34 @@ export function useReportScheduleActions({
         itemsToDelete.map((item) => deleteReportSchedule(item.reportScheduleId)),
       );
 
-      const failed = results.filter((r) => r.status === 'rejected');
-      if (failed.length > 0) {
-        const firstRejected = failed[0] as PromiseRejectedResult;
+      const trueFailed = results.filter(
+        (r) => r.status === 'rejected' && !isAlreadyDeletedError(r.reason),
+      );
+      const deletedCount = itemsToDelete.length - trueFailed.length;
+
+      if (trueFailed.length > 0) {
+        const firstRejected = trueFailed[0] as PromiseRejectedResult;
         const reason = firstRejected.reason;
-        const message =
+        const specificMessage =
           isAxiosError(reason) && reason.response?.data?.message
             ? reason.response.data.message
-            : t('{{count}} item(s) could not be deleted.', { count: failed.length });
-        setDeleteError(message);
+            : undefined;
+        const failurePart =
+          specificMessage ??
+          t('{{count}} report schedule(s) could not be deleted.', { count: trueFailed.length });
+        const successPart =
+          deletedCount > 0
+            ? t('{{count}} report schedule(s) deleted successfully.', { count: deletedCount })
+            : '';
+
+        setDeleteError([successPart, failurePart].filter(Boolean).join(' '));
         setRowSelection({});
         handleRefresh();
         return;
       }
 
       notify.success(
-        t('{{count}} report schedule(s) deleted successfully.', { count: itemsToDelete.length }),
+        t('{{count}} report schedule(s) deleted successfully.', { count: deletedCount }),
       );
       setRowSelection({});
       handleRefresh();

--- a/frontend/src/pages/Reporting/SavedReports/hooks/useSavedReportActions.ts
+++ b/frontend/src/pages/Reporting/SavedReports/hooks/useSavedReportActions.ts
@@ -28,6 +28,7 @@ import { useState } from 'react';
 import { notify } from '@/components/ui/Notification';
 import { deleteSavedReport } from '@/services/savedReportApi';
 import type { SavedReport } from '@/types/savedReport';
+import { isAlreadyDeletedError } from '@/utils/errors';
 
 interface UseSavedReportActionsProps {
   t: TFunction;
@@ -56,23 +57,33 @@ export function useSavedReportActions({
         itemsToDelete.map((item) => deleteSavedReport(item.savedReportId)),
       );
 
-      const failed = results.filter((r) => r.status === 'rejected');
-      if (failed.length > 0) {
-        const firstRejected = failed[0] as PromiseRejectedResult;
+      const trueFailed = results.filter(
+        (r) => r.status === 'rejected' && !isAlreadyDeletedError(r.reason),
+      );
+      const deletedCount = itemsToDelete.length - trueFailed.length;
+
+      if (trueFailed.length > 0) {
+        const firstRejected = trueFailed[0] as PromiseRejectedResult;
         const reason = firstRejected.reason;
-        const message =
+        const specificMessage =
           isAxiosError(reason) && reason.response?.data?.message
             ? reason.response.data.message
-            : t('{{count}} item(s) could not be deleted.', { count: failed.length });
-        setDeleteError(message);
+            : undefined;
+        const failurePart =
+          specificMessage ??
+          t('{{count}} saved report(s) could not be deleted.', { count: trueFailed.length });
+        const successPart =
+          deletedCount > 0
+            ? t('{{count}} saved report(s) deleted successfully.', { count: deletedCount })
+            : '';
+
+        setDeleteError([successPart, failurePart].filter(Boolean).join(' '));
         setRowSelection({});
         handleRefresh();
         return;
       }
 
-      notify.success(
-        t('{{count}} saved report(s) deleted successfully.', { count: itemsToDelete.length }),
-      );
+      notify.success(t('{{count}} saved report(s) deleted successfully.', { count: deletedCount }));
       setRowSelection({});
       handleRefresh();
       closeModal();

--- a/frontend/src/pages/Schedule/Daypart/__tests__/Daypart.delete.test.tsx
+++ b/frontend/src/pages/Schedule/Daypart/__tests__/Daypart.delete.test.tsx
@@ -228,7 +228,9 @@ describe('Dayparting page - bulk delete', () => {
     await screen.findByText('Delete Dayparts?');
     await user.click(screen.getByRole('button', { name: /yes, delete/i }));
 
-    expect(await screen.findByText('Daypart 2 is in use.')).toBeInTheDocument();
+    expect(
+      await screen.findByText('1 daypart(s) deleted successfully. Daypart 2 is in use.'),
+    ).toBeInTheDocument();
     expect(screen.getByText('Delete Dayparts?')).toBeInTheDocument();
 
     expect(deleteDaypart).toHaveBeenCalledTimes(2);

--- a/frontend/src/pages/Schedule/Daypart/hooks/useDaypartActions.ts
+++ b/frontend/src/pages/Schedule/Daypart/hooks/useDaypartActions.ts
@@ -28,6 +28,7 @@ import { useState } from 'react';
 import { notify } from '@/components/ui/Notification';
 import { deleteDaypart } from '@/services/daypartApi';
 import type { Daypart } from '@/types/daypart';
+import { isAlreadyDeletedError } from '@/utils/errors';
 
 interface UseDaypartActionsProps {
   t: TFunction;
@@ -56,23 +57,33 @@ export function useDaypartActions({
         itemsToDelete.map((item) => deleteDaypart(item.dayPartId)),
       );
 
-      const failed = results.filter((r) => r.status === 'rejected');
-      if (failed.length > 0) {
-        const firstRejected = failed[0] as PromiseRejectedResult;
+      const trueFailed = results.filter(
+        (r) => r.status === 'rejected' && !isAlreadyDeletedError(r.reason),
+      );
+      const deletedCount = itemsToDelete.length - trueFailed.length;
+
+      if (trueFailed.length > 0) {
+        const firstRejected = trueFailed[0] as PromiseRejectedResult;
         const reason = firstRejected.reason;
-        const message =
+        const specificMessage =
           isAxiosError(reason) && reason.response?.data?.message
             ? reason.response.data.message
-            : t('{{count}} item(s) could not be deleted.', { count: failed.length });
-        setDeleteError(message);
+            : undefined;
+        const failurePart =
+          specificMessage ??
+          t('{{count}} daypart(s) could not be deleted.', { count: trueFailed.length });
+        const successPart =
+          deletedCount > 0
+            ? t('{{count}} daypart(s) deleted successfully.', { count: deletedCount })
+            : '';
+
+        setDeleteError([successPart, failurePart].filter(Boolean).join(' '));
         setRowSelection({});
         handleRefresh();
         return;
       }
 
-      notify.success(
-        t('{{count}} daypart(s) deleted successfully.', { count: itemsToDelete.length }),
-      );
+      notify.success(t('{{count}} daypart(s) deleted successfully.', { count: deletedCount }));
       setRowSelection({});
       handleRefresh();
       closeModal();

--- a/frontend/src/pages/Schedule/Schedule/hooks/useEventActions.ts
+++ b/frontend/src/pages/Schedule/Schedule/hooks/useEventActions.ts
@@ -29,6 +29,7 @@ import { notify } from '@/components/ui/Notification';
 import { useDateFormatter } from '@/hooks/useDateFormatter';
 import { cloneEvent, deleteEvent, deleteEventOccurrence } from '@/services/eventApi';
 import type { Event } from '@/types/event';
+import { isAlreadyDeletedError } from '@/utils/errors';
 
 interface UseEventActionsProps {
   t: TFunction;
@@ -59,15 +60,27 @@ export function useEventActions({
         itemsToDelete.map((item) => deleteEvent(item.eventId)),
       );
 
-      const failed = results.filter((r) => r.status === 'rejected');
-      if (failed.length > 0) {
-        const firstRejected = failed[0] as PromiseRejectedResult;
+      const trueFailed = results.filter(
+        (r) => r.status === 'rejected' && !isAlreadyDeletedError(r.reason),
+      );
+      const deletedCount = itemsToDelete.length - trueFailed.length;
+
+      if (trueFailed.length > 0) {
+        const firstRejected = trueFailed[0] as PromiseRejectedResult;
         const reason = firstRejected.reason;
-        const message =
+        const specificMessage =
           isAxiosError(reason) && reason.response?.data?.message
             ? reason.response.data.message
-            : t('{{count}} item(s) could not be deleted.', { count: failed.length });
-        setDeleteError(message);
+            : undefined;
+        const failurePart =
+          specificMessage ??
+          t('{{count}} event(s) could not be deleted.', { count: trueFailed.length });
+        const successPart =
+          deletedCount > 0
+            ? t('{{count}} event(s) deleted successfully.', { count: deletedCount })
+            : '';
+
+        setDeleteError([successPart, failurePart].filter(Boolean).join(' '));
         setRowSelection({});
         handleRefresh();
         return;
@@ -79,7 +92,7 @@ export function useEventActions({
       notify.success(
         isSingleRecurringSeries
           ? t('The entire recurring event series was deleted successfully.')
-          : t('{{count}} event(s) deleted successfully.', { count: itemsToDelete.length }),
+          : t('{{count}} event(s) deleted successfully.', { count: deletedCount }),
       );
       setRowSelection({});
       handleRefresh();

--- a/frontend/src/utils/errors.ts
+++ b/frontend/src/utils/errors.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2026 Xibo Signage Ltd
+ *
+ * Xibo - Digital Signage - https://xibosignage.com
+ *
+ * This file is part of Xibo.
+ *
+ * Xibo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * Xibo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Xibo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { isAxiosError } from 'axios';
+
+/**
+ * A 404 from a delete request means the item was already gone by the time this
+ * request reached the server - e.g. another tab/user deleted it first in a
+ * concurrent bulk-delete. Bulk-delete flows treat this as an implicit success
+ * rather than a failure to report to the user.
+ */
+export function isAlreadyDeletedError(reason: unknown): boolean {
+  return isAxiosError(reason) && reason.response?.status === 404;
+}


### PR DESCRIPTION
### Frontend Changes
- Fixed a generic "Not Found" error appearing during concurrent bulk deletion when one of the selected items had already been deleted in another tab/session
- Fixed bulk deletion on Dataset Columns/Data/RSS pages aborting the remaining items in a batch when one item's delete request failed

-------
Relates to https://github.com/xibosignage/xibo/issues/3907
