### PR TITLE
Users: Added groups in API response

### DIFF
--- a/lib/Controller/User.php
+++ b/lib/Controller/User.php
@@ -368,6 +368,8 @@ class User extends Base
     public function searchById(Request $request, Response $response, $id): Response|ResponseInterface
     {
         $user = $this->userFactory->getById($id, false);
+        $user->setChildAclDependencies($this->userGroupFactory);
+        $user->load();
         $this->decorateUserProperties($user);
 
         return $response


### PR DESCRIPTION
### Backend Changes  
- Fixes GET /user/{id} (UserController::searchById()) always returning an empty groups array by loading the user's group memberships before serializing the response, matching the behavior of GET /user/me.

-------
Relates to https://github.com/xibosignage/xibo/issues/3943