### PR TITLE
Applications: Added auditing

### DIFF
--- a/lib/Controller/Applications.php
+++ b/lib/Controller/Applications.php
@@ -447,10 +447,6 @@ class Applications extends Base
         // Delete all the redirect urls and add them again
         $client->load();
 
-        // Snapshot the pre-change redirect URIs so the entity can audit what changed -
-        // the loop below deletes them before save() runs, so this is the only chance to see the "before" state.
-        $client->setOriginalValue('redirectUris', array_map(fn($uri) => $uri->redirectUri, $client->redirectUris));
-
         foreach ($client->redirectUris as $uri) {
             $uri->delete();
         }
@@ -469,10 +465,6 @@ class Applications extends Base
             $redirect->redirectUri = $redirectUri;
             $client->assignRedirectUri($redirect);
         }
-
-        // Snapshot the pre-change scope IDs so the entity can audit what changed, without
-        // needing a second DB round-trip - $client->scopes was already loaded above.
-        $client->setOriginalValue('scopeIds', array_map(fn($scope) => $scope->id, $client->scopes));
 
         // clear scopes
         $client->scopes = [];

--- a/lib/Controller/Applications.php
+++ b/lib/Controller/Applications.php
@@ -447,6 +447,10 @@ class Applications extends Base
         // Delete all the redirect urls and add them again
         $client->load();
 
+        // Snapshot the pre-change redirect URIs so the entity can audit what changed -
+        // the loop below deletes them before save() runs, so this is the only chance to see the "before" state.
+        $client->setOriginalValue('redirectUris', array_map(fn($uri) => $uri->redirectUri, $client->redirectUris));
+
         foreach ($client->redirectUris as $uri) {
             $uri->delete();
         }
@@ -465,6 +469,10 @@ class Applications extends Base
             $redirect->redirectUri = $redirectUri;
             $client->assignRedirectUri($redirect);
         }
+
+        // Snapshot the pre-change scope IDs so the entity can audit what changed, without
+        // needing a second DB round-trip - $client->scopes was already loaded above.
+        $client->setOriginalValue('scopeIds', array_map(fn($scope) => $scope->id, $client->scopes));
 
         // clear scopes
         $client->scopes = [];

--- a/lib/Entity/Application.php
+++ b/lib/Entity/Application.php
@@ -183,13 +183,16 @@ class Application implements \JsonSerializable, ClientEntityInterface
         // Get scopes
         $this->scopes = $this->applicationScopeFactory->getByClientId($this->key);
 
+        // Snapshot so save() can audit what changed, regardless of caller.
+        $this->setOriginalValue('redirectUris', array_map(fn($uri) => $uri->redirectUri, $this->redirectUris));
+        $this->setOriginalValue('scopeIds', array_map(fn($scope) => $scope->id, $this->scopes));
+
         $this->loaded = true;
         return $this;
     }
 
     /**
      * @return $this
-     * @note Redirect-URI/scope "assigned" audits need setOriginalValue('redirectUris'/'scopeIds', ...) snapshotted first (see Applications::edit()), or they're silently skipped.
      * @throws NotFoundException
      */
     public function save(): static
@@ -202,7 +205,7 @@ class Application implements \JsonSerializable, ClientEntityInterface
 
             // Add
             $this->add();
-            $this->audit(0, 'Added', ['name' => $this->name]);
+            $this->audit(0, 'Added', $this->auditContext());
         } else {
             // Work out what's changed before we overwrite the row - strip the secret out
             // immediately so it never sits in a loggable array any longer than necessary.
@@ -214,10 +217,13 @@ class Application implements \JsonSerializable, ClientEntityInterface
             $this->edit();
 
             if ($keyChanged) {
-                $this->audit(0, 'Key changed', ['name' => $this->name]);
+                $this->audit(0, 'Key changed', $this->auditContext());
             }
             if (count($changedProperties) > 0) {
-                $this->audit(0, 'Saved', $changedProperties);
+                $this->audit(0, 'Saved', array_merge(
+                    $this->auditContext(),
+                    $changedProperties
+                ));
             }
         }
 
@@ -241,10 +247,13 @@ class Application implements \JsonSerializable, ClientEntityInterface
             sort($currentSorted);
 
             if ($currentSorted != $originalSorted) {
-                $this->audit(0, 'Redirect URIs updated', [
-                    'from' => implode(', ', $originalRedirectUris),
-                    'to' => implode(', ', $currentRedirectUris),
-                ]);
+                $this->audit(0, 'Redirect URIs updated', array_merge(
+                    $this->auditContext(),
+                    [
+                        'from' => implode(', ', $originalRedirectUris),
+                        'to' => implode(', ', $currentRedirectUris),
+                    ]
+                ));
             }
         }
 
@@ -271,7 +280,19 @@ class Application implements \JsonSerializable, ClientEntityInterface
         $this->getStore()->update('DELETE FROM `oauth_client_scopes` WHERE `clientId` = :id', ['id' => $this->key]);
         $this->getStore()->update('DELETE FROM `oauth_clients` WHERE `id` = :id', ['id' => $this->key]);
 
-        $this->audit(0, 'Deleted', ['name' => $this->name]);
+        $this->audit(0, 'Deleted', $this->auditContext());
+    }
+
+    /**
+     * Identifying context for audit log entries
+     * @return array
+     */
+    private function auditContext(): array
+    {
+        return [
+            'Application identifier ends with' => substr($this->key, -8),
+            'Application Name' => $this->name,
+        ];
     }
 
     /**
@@ -383,10 +404,16 @@ class Application implements \JsonSerializable, ClientEntityInterface
             $unassigned = array_diff($existingScopeIds, $newScopeIds);
 
             if (count($assigned) > 0) {
-                $this->audit(0, 'Scopes assigned', ['scopeIds' => implode(',', $assigned)]);
+                $this->audit(0, 'Scopes assigned', array_merge(
+                    $this->auditContext(),
+                    ['scopeIds' => implode(',', $assigned)]
+                ));
             }
             if (count($unassigned) > 0) {
-                $this->audit(0, 'Scopes unassigned', ['scopeIds' => implode(',', $unassigned)]);
+                $this->audit(0, 'Scopes unassigned', array_merge(
+                    $this->auditContext(),
+                    ['scopeIds' => implode(',', $unassigned)]
+                ));
             }
         }
     }

--- a/lib/Entity/Application.php
+++ b/lib/Entity/Application.php
@@ -32,6 +32,7 @@ use Xibo\Helper\Random;
 use Xibo\OAuth\ScopeEntity;
 use Xibo\Service\LogServiceInterface;
 use Xibo\Storage\StorageServiceInterface;
+use Xibo\Support\Exception\NotFoundException;
 
 /**
  * Class Application
@@ -188,24 +189,63 @@ class Application implements \JsonSerializable, ClientEntityInterface
 
     /**
      * @return $this
+     * @note Redirect-URI/scope "assigned" audits need setOriginalValue('redirectUris'/'scopeIds', ...) snapshotted first (see Applications::edit()), or they're silently skipped.
+     * @throws NotFoundException
      */
     public function save(): static
     {
-        if ($this->key == null || $this->key == '') {
+        $isNew = ($this->key == null || $this->key == '');
+
+        if ($isNew) {
             // Make a new secret.
             $this->resetSecret();
 
             // Add
             $this->add();
+            $this->audit(0, 'Added', ['name' => $this->name]);
         } else {
+            // Work out what's changed before we overwrite the row - strip the secret out
+            // immediately so it never sits in a loggable array any longer than necessary.
+            $keyChanged = $this->hasPropertyChanged('secret');
+            $changedProperties = $this->getChangedProperties();
+            unset($changedProperties['secret']);
+
             // Edit
             $this->edit();
+
+            if ($keyChanged) {
+                $this->audit(0, 'Key changed', ['name' => $this->name]);
+            }
+            if (count($changedProperties) > 0) {
+                $this->audit(0, 'Saved', $changedProperties);
+            }
         }
 
         $this->getLog()->debug('Saving redirect uris: ' . json_encode($this->redirectUris));
 
         foreach ($this->redirectUris as $redirectUri) {
             $redirectUri->save();
+        }
+
+        // originalRedirectUris is only populated by the controller ahead of an edit,
+        // via setOriginalValue(), so this is null (and skipped) on a fresh add().
+        $originalRedirectUris = $this->getOriginalValue('redirectUris');
+        if ($originalRedirectUris !== null) {
+            $currentRedirectUris = array_map(fn($uri) => $uri->redirectUri, $this->redirectUris);
+
+            // Compare as sets, not sequences - re-saving the same URIs in a different order
+            // shouldn't be reported as a change.
+            $originalSorted = $originalRedirectUris;
+            $currentSorted = $currentRedirectUris;
+            sort($originalSorted);
+            sort($currentSorted);
+
+            if ($currentSorted != $originalSorted) {
+                $this->audit(0, 'Redirect URIs updated', [
+                    'from' => implode(', ', $originalRedirectUris),
+                    'to' => implode(', ', $currentRedirectUris),
+                ]);
+            }
         }
 
         $this->manageScopeAssignments();
@@ -230,6 +270,8 @@ class Application implements \JsonSerializable, ClientEntityInterface
         // Clear out everything owned by this client
         $this->getStore()->update('DELETE FROM `oauth_client_scopes` WHERE `clientId` = :id', ['id' => $this->key]);
         $this->getStore()->update('DELETE FROM `oauth_clients` WHERE `id` = :id', ['id' => $this->key]);
+
+        $this->audit(0, 'Deleted', ['name' => $this->name]);
     }
 
     /**
@@ -303,6 +345,7 @@ class Application implements \JsonSerializable, ClientEntityInterface
 
     /**
      * Compare the original assignments with the current assignments and delete any that are missing, add any new ones
+     * @throws NotFoundException
      */
     private function manageScopeAssignments(): void
     {
@@ -325,11 +368,27 @@ class Application implements \JsonSerializable, ClientEntityInterface
 
         // Unlink any NOT in the collection
         $sql = 'DELETE FROM `oauth_client_scopes`
-                    WHERE clientId = :clientId 
+                    WHERE clientId = :clientId
                       AND scopeId NOT IN (\'0\'' . $unassignIn . ')
         ';
 
         $this->getStore()->update($sql, $params);
+
+        // existingScopeIds is only populated by the controller ahead of an edit, via
+        // setOriginalValue('scopeIds', ...), so this is null (and skipped) on a fresh add().
+        $existingScopeIds = $this->getOriginalValue('scopeIds');
+        if ($existingScopeIds !== null) {
+            $newScopeIds = array_map(fn($scope) => $scope->id, $this->scopes);
+            $assigned = array_diff($newScopeIds, $existingScopeIds);
+            $unassigned = array_diff($existingScopeIds, $newScopeIds);
+
+            if (count($assigned) > 0) {
+                $this->audit(0, 'Scopes assigned', ['scopeIds' => implode(',', $assigned)]);
+            }
+            if (count($unassigned) > 0) {
+                $this->audit(0, 'Scopes unassigned', ['scopeIds' => implode(',', $unassigned)]);
+            }
+        }
     }
 
     /** @inheritDoc */


### PR DESCRIPTION
### Backend Changes  
- Adds audit logging to the OAuth Application entity's add/edit/delete lifecycle (Added, Saved, Key changed, Deleted)
- Adds set-based audit diffing for scope and redirect-URI changes, sourced from pre-change snapshots the controller captures via setOriginalValue() to avoid an extra DB query.


-------
Relates to https://github.com/xibosignageltd/xibo-private/issues/1368