### PR TITLE
Settings: Added a default display folder settings

### DIFF
--- a/lib/Service/ConfigService.php
+++ b/lib/Service/ConfigService.php
@@ -637,6 +637,17 @@ class ConfigService implements ConfigServiceInterface
                 'userChange' => intval($setting['userChange']),
             ];
         }
+
+        // Synthesise a default so the field is visible/editable from the first login;
+        // changeSetting() already inserts the row the first time it's actually saved.
+        if (!isset($result['DISPLAY_DEFAULT_FOLDER'])) {
+            $result['DISPLAY_DEFAULT_FOLDER'] = [
+                'value' => 1,
+                'userSee' => 1,
+                'userChange' => 1,
+            ];
+        }
+
         return $result;
     }
 


### PR DESCRIPTION
### Backend Changes  
- Fixes DISPLAY_DEFAULT_FOLDER never appearing on Settings > Displays for fresh installs to create a default entry when no seed row exists.

-------
Relates to https://github.com/xibosignage/xibo/issues/3929