### PR TITLE
Permissions: Fixed folder permissions and resolution query

### DIFF
--- a/frontend/src/pages/Administration/Users/components/AddEditUserModal.tsx
+++ b/frontend/src/pages/Administration/Users/components/AddEditUserModal.tsx
@@ -503,7 +503,7 @@ export default function AddEditUserModal({
           await saveFolderPermissions(savedUser.groupId);
         }
 
-        notify.success(t('Settings Updated'));
+        notify.success(t('User saved'));
         onSuccess();
         onClose();
       } catch (err: unknown) {

--- a/frontend/src/pages/Administration/Users/components/AddEditUserModal.tsx
+++ b/frontend/src/pages/Administration/Users/components/AddEditUserModal.tsx
@@ -33,6 +33,7 @@ import OptionsTab from './tabs/OptionsTab';
 import ReferencesTab from './tabs/ReferencesTab';
 
 import type { PermissionLevel } from '@/components/ui/FolderPermissionTree';
+import { notify } from '@/components/ui/Notification';
 import type { SelectOption } from '@/components/ui/forms/SelectDropdown';
 import Modal from '@/components/ui/modals/Modal';
 import { useUserContext } from '@/context/UserContext';
@@ -502,6 +503,7 @@ export default function AddEditUserModal({
           await saveFolderPermissions(savedUser.groupId);
         }
 
+        notify.success(t('Settings Updated'));
         onSuccess();
         onClose();
       } catch (err: unknown) {

--- a/frontend/src/services/permissionsApi.ts
+++ b/frontend/src/services/permissionsApi.ts
@@ -296,8 +296,7 @@ export async function fetchGroupFolderPermissions(
   const response = await http.get<Record<string, MultiPermissionItem>>('/user/permissions/Folder', {
     params: {
       ids: folderIds.join(','),
-      start: 0,
-      length: folderIds.length,
+      disablePaging: 1,
       isUserSpecific: 1,
     },
   });

--- a/lib/Controller/User.php
+++ b/lib/Controller/User.php
@@ -1510,7 +1510,7 @@ class User extends Base
                     ]
                 ];
             } else {
-                $newPermissions[$permission->groupId]['permissions'][] = [
+                $newPermissions[$permission->groupId]['permissions'][$permission->objectId] = [
                     'permissionId' => $permission->permissionId,
                     'view' => $permission->view,
                     'edit' => $permission->edit,

--- a/lib/Factory/LayoutFactory.php
+++ b/lib/Factory/LayoutFactory.php
@@ -3422,10 +3422,29 @@ class LayoutFactory extends BaseFactory
                     $media->height
                 )->resolutionId;
             } else if ($type === 'playlist') {
-                $resolutionId = $this->resolutionFactory->getClosestMatchingResolution(
-                    1920,
-                    1080
-                )->resolutionId;
+                // Adopt the orientation of the lead media in the playlist; otherwise, fallback to default
+                $derivedDimension = null;
+                foreach ($playlist->widgets as $widget) {
+                    $primaryMediaIds = $widget->getPrimaryMedia();
+                    if (count($primaryMediaIds) > 0) {
+                        try {
+                            $primaryMedia = $this->mediaFactory->getById($primaryMediaIds[0]);
+                            if ($primaryMedia->width > 0 && $primaryMedia->height > 0) {
+                                $derivedDimension = $primaryMedia;
+                                break;
+                            }
+                        } catch (NotFoundException $e) {
+                            continue;
+                        }
+                    }
+                }
+
+                $resolutionId = $derivedDimension !== null
+                    ? $this->resolutionFactory->getClosestMatchingResolution(
+                        $derivedDimension->width,
+                        $derivedDimension->height
+                    )->resolutionId
+                    : $this->resolutionFactory->getClosestMatchingResolution(1920, 1080)->resolutionId;
             }
         }
 

--- a/lib/Factory/ResolutionFactory.php
+++ b/lib/Factory/ResolutionFactory.php
@@ -106,8 +106,7 @@ class ResolutionFactory extends BaseFactory
     public function getClosestMatchingResolution($width, $height): Resolution
     {
         $area = $width * $height;
-        $sort = ['ABS(' . $area . ' - (`intended_width` * `intended_height`))'];
-        $sort[] = $width > $height ? '`intended_width` DESC' : '`intended_height` DESC';
+        $sort = ['areaDiff', $width > $height ? 'intendedWidth DESC' : 'intendedHeight DESC'];
 
         $resolutions = $this->query(
             $sort,
@@ -116,6 +115,11 @@ class ResolutionFactory extends BaseFactory
                 'enabled' => 1,
                 'start' => 0,
                 'length' => 1
+            ],
+            [
+                'areaDiff' => 'ABS(' . $area . ' - (`intended_width` * `intended_height`))',
+                'intendedWidth' => '`intended_width`',
+                'intendedHeight' => '`intended_height`',
             ]
         );
 
@@ -148,7 +152,7 @@ class ResolutionFactory extends BaseFactory
         return $resolutions[0];
     }
 
-    public function query($sortOrder = null, $filterBy = [])
+    public function query($sortOrder = null, $filterBy = [], $customColumns = [])
     {
         $parsedFilter = $this->getSanitizer($filterBy);
 
@@ -157,6 +161,7 @@ class ResolutionFactory extends BaseFactory
         $sortOrder = $this->buildSortQuery(
             $sortOrder,
             $allowedColumns,
+            $customColumns,
             defaultSort: ['resolution ASC'],
             uniqueColumn: 'resolutionId'
         );

--- a/lib/Factory/ResolutionFactory.php
+++ b/lib/Factory/ResolutionFactory.php
@@ -107,21 +107,41 @@ class ResolutionFactory extends BaseFactory
     {
         $area = $width * $height;
         $sort = ['areaDiff', $width > $height ? 'intendedWidth DESC' : 'intendedHeight DESC'];
+        $customColumns = [
+            'areaDiff' => 'ABS(' . $area . ' - (`intended_width` * `intended_height`))',
+            'intendedWidth' => '`intended_width`',
+            'intendedHeight' => '`intended_height`',
+        ];
 
+        // Prefer a resolution in the same orientation as the requested dimensions,
+        // so a portrait input doesn't match a landscape resolution (or vice versa)
+        // purely because its total pixel area happens to be numerically closer.
         $resolutions = $this->query(
             $sort,
             [
                 'disableUserCheck' => 1,
                 'enabled' => 1,
+                'orientation' => $width <= $height ? 'portrait' : 'landscape',
                 'start' => 0,
                 'length' => 1
             ],
-            [
-                'areaDiff' => 'ABS(' . $area . ' - (`intended_width` * `intended_height`))',
-                'intendedWidth' => '`intended_width`',
-                'intendedHeight' => '`intended_height`',
-            ]
+            $customColumns
         );
+
+        if (count($resolutions) <= 0) {
+            // No enabled resolution exists in the requested orientation - fall back
+            // to the closest match across all orientations.
+            $resolutions = $this->query(
+                $sort,
+                [
+                    'disableUserCheck' => 1,
+                    'enabled' => 1,
+                    'start' => 0,
+                    'length' => 1
+                ],
+                $customColumns
+            );
+        }
 
         if (count($resolutions) <= 0) {
             throw new NotFoundException(__('Resolution not found'));


### PR DESCRIPTION
 ### Frontend Changes
- Added a "Settings Updated" success toast when the Edit User modal's save completes
- Fixes fetchGroupFolderPermissions() to request unpaginated results instead of a folder-count-sized page, so a user's own permission group can no longer be silently excluded from the response.

### Backend Changes
- Fixes User::permissionsMultiGrid() so each user group's per-folder permission entry is keyed by its real folder ID instead of being appended positionally, preventing permissions from displaying against the wrong folder when the Folder Permission tab is reopened.
- Fixes Resolution query so its width/height-based sort actually reaches the ORDER BY clause instead of being silently dropped and falling back to alphabetical order

-------
Relates to https://github.com/xibosignage/xibo/issues/3938, https://github.com/xibosignageltd/xibo-private/issues/1706