### PR TITLE
Modules: Render default settings

### DIFF
--- a/frontend/src/pages/Administration/Modules/components/ConfigureModuleModal.tsx
+++ b/frontend/src/pages/Administration/Modules/components/ConfigureModuleModal.tsx
@@ -44,7 +44,7 @@ type DraftSettings = Record<string, string | number>;
 function buildInitialDraft(module: Module): DraftSettings {
   const draft: DraftSettings = {};
   (module.settings ?? []).forEach((setting) => {
-    draft[setting.id] = setting.value ?? '';
+    draft[setting.id] = setting.value ?? setting.default ?? '';
   });
   return draft;
 }

--- a/frontend/src/types/module.ts
+++ b/frontend/src/types/module.ts
@@ -30,6 +30,7 @@ export interface ModuleSetting {
   title: string;
   helpText?: string;
   value?: string | number;
+  default?: string | number | null;
   options?: ModuleSettingOption[];
 }
 


### PR DESCRIPTION
 ### Frontend Changes
- The Configure Module dialog now falls back to a setting's declared default when no saved value exists, so a module's settings display correctly before it has ever been saved.


-------
Relates to https://github.com/xibosignage/xibo/issues/3941