### PR TITLE
Campaigns: Fixed incorrect help text in add modal

### DIFF
--- a/frontend/src/components/ui/forms/SelectDropdown.tsx
+++ b/frontend/src/components/ui/forms/SelectDropdown.tsx
@@ -231,11 +231,11 @@ export default function SelectDropdown({
   const { getReferenceProps, getFloatingProps } = useInteractions([click, dismiss]);
 
   return (
-    <div className={twMerge('relative overflow-visible', className)}>
+    <div className={twMerge('relative overflow-visible flex flex-col gap-1', className)}>
       {label && (
         <label
           id={`${id}-label`}
-          className="flex items-center justify-between text-sm font-semibold text-gray-500 leading-5"
+          className="flex items-center justify-between text-sm font-semibold text-gray-500 leading-4.5"
         >
           <span>{t(label)}</span>
           {optional && <span className="text-xs font-normal text-gray-500">{t('Optional')}</span>}

--- a/frontend/src/pages/Administration/Modules/components/ConfigureModuleModal.tsx
+++ b/frontend/src/pages/Administration/Modules/components/ConfigureModuleModal.tsx
@@ -193,6 +193,7 @@ export default function ConfigureModuleModal({
           label={t('Default Duration')}
           value={defaultDuration}
           type="number"
+          placeholder={t('Add number')}
           helpText={t(
             'The default duration for Widgets of this Module when the user has elected to not set a specific duration.',
           )}

--- a/frontend/src/pages/Design/Campaigns/CampaignEditor.tsx
+++ b/frontend/src/pages/Design/Campaigns/CampaignEditor.tsx
@@ -527,7 +527,7 @@ export default function CampaignEditor() {
               {(
                 [
                   { key: 'general', label: t('General') },
-                  { key: 'reference', label: t('References') },
+                  { key: 'reference', label: t('Reference') },
                 ] as const
               ).map(({ key, label }) => (
                 <button
@@ -552,7 +552,7 @@ export default function CampaignEditor() {
                 <TextInput
                   name="name"
                   label={t('Name')}
-                  placeholder=" "
+                  placeholder={t('Enter name')}
                   helpText={t('The Name for this Campaign')}
                   value={draft.name}
                   onChange={(val) => setDraft((prev) => prev && { ...prev, name: val })}
@@ -611,6 +611,7 @@ export default function CampaignEditor() {
                     name="target"
                     type="number"
                     label={t('Target')}
+                    placeholder={t('Add number')}
                     helpText={t(
                       'What is the target number for this Campaign over its entire playtime',
                     )}
@@ -645,7 +646,7 @@ export default function CampaignEditor() {
                     key={ref}
                     name={ref}
                     label={t('Reference {{n}}', { n: i + 1 })}
-                    placeholder={t('Enter here')}
+                    placeholder={t('Enter reference {{n}}', { n: i + 1 })}
                     value={draft[ref]}
                     onChange={(val) => setDraft((prev) => prev && { ...prev, [ref]: val })}
                   />

--- a/frontend/src/pages/Design/Campaigns/components/AddCampaignModal.tsx
+++ b/frontend/src/pages/Design/Campaigns/components/AddCampaignModal.tsx
@@ -222,6 +222,7 @@ export default function AddCampaignModal({
           <TextInput
             name="name"
             label={t('Name')}
+            placeholder={t('Enter name')}
             value={draft.name}
             onChange={(val) => setDraft((prev) => ({ ...prev, name: val }))}
             error={formErrors.name}
@@ -265,6 +266,7 @@ export default function AddCampaignModal({
                 name="target"
                 label={t('Target')}
                 type="number"
+                placeholder={t('Add number')}
                 helpText={t('What is the target number for this Campaign over its entire playtime')}
                 value={draft.target === '' ? '' : String(draft.target)}
                 onChange={(val) =>


### PR DESCRIPTION
 ### Frontend Changes
- Added an explicit numeric placeholder ("Add number") to the Ad Campaign Target field and the Module "Default Duration" field, which previously fell back to the generic "Add text" placeholder meant for free-text inputs.
- Aligned Name/Reference-field placeholder wording and the Reference tab label in the Campaign editor with the existing convention used elsewhere in the app (and with the legacy Twig form).

-------
Relates to https://github.com/xibosignage/xibo/issues/3918