### PR TITLE
Folders: fix permissions not updating for direct child items on move

### DIFF
--- a/lib/Entity/Folder.php
+++ b/lib/Entity/Folder.php
@@ -508,6 +508,7 @@ class Folder implements \JsonSerializable
         // if we had permissions set on this folder, then permissionsFolderId stays as it was
         if ($this->getPermissionFolderId() !== null) {
             $this->permissionsFolderId = $newParentFolder->getPermissionFolderIdOrThis();
+            $this->updateChildObjects($this->permissionsFolderId, $this->id);
             $this->manageChildPermissions($this->permissionsFolderId);
         }
 


### PR DESCRIPTION
relates to: https://github.com/xibosignage/xibo/issues/3939

`updateFoldersAfterMove()` cascaded the new `permissionsFolderId` to sub-folders and their items via `manageChildPermissions()`, but never called` updateChildObjects()` for items sitting directly in the moved folder. This left those items with stale permissions after a move. 